### PR TITLE
feat: Add Deno runtime adapter with cross-runtime CI and JSR publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 # Cancel in-progress runs for the same branch/PR
 concurrency:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -49,14 +49,14 @@ jobs:
           - runtime: node
             node-version: lts/*
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Always install Bun for dependency management (bun install)
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: matrix.runtime == 'node'
         with:
           node-version: ${{ matrix.node-version }}
@@ -84,8 +84,9 @@ jobs:
     name: Test (deno)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: [lint]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -105,9 +106,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [lint, test]
+    needs: [lint, test, test-deno]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,115 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs for the same branch/PR
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────
+  # Lint + type check + format — runs once on Bun (fastest)
+  # ─────────────────────────────────────────────────────────────────
+  lint:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run check
+      - run: bun run lint
+      - run: bun run format:check
+
+  # ─────────────────────────────────────────────────────────────────
+  # Tests — matrix across Node LTS and Bun stable
+  #
+  # vitest runs natively on both Node and Bun. The test suite
+  # exercises all three adapters (Node, Bun, Deno) via mock
+  # injection — no actual Deno runtime needed for these tests.
+  # ─────────────────────────────────────────────────────────────────
+  test:
+    name: Test (${{ matrix.runtime }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runtime: bun
+            bun-version: latest
+          - runtime: node
+            node-version: lts/*
+    steps:
+      - uses: actions/checkout@v4
+
+      # Always install Bun for dependency management (bun install)
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        if: matrix.runtime == 'node'
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: bun install --frozen-lockfile
+
+      # Bun: run vitest via bun
+      - name: Test (Bun)
+        if: matrix.runtime == 'bun'
+        run: bun run test
+
+      # Node: run vitest via npx (uses Node, not Bun, as the runtime)
+      - name: Test (Node)
+        if: matrix.runtime == 'node'
+        run: npx vitest run
+
+  # ─────────────────────────────────────────────────────────────────
+  # Deno smoke test — verifies the adapter works on real Deno
+  #
+  # vitest doesn't run under Deno, so we build the package first
+  # then run a Deno-native smoke test that imports the built output
+  # and exercises createDenoAdapter() on a real Deno runtime.
+  # ─────────────────────────────────────────────────────────────────
+  test-deno:
+    name: Test (deno)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - name: Deno adapter smoke test
+        run: deno run --allow-read --allow-env scripts/deno-smoke-test.ts
+
+  # ─────────────────────────────────────────────────────────────────
+  # Build — verifies the package builds, types are correct, and
+  # package.json exports are valid (publint + attw)
+  # ─────────────────────────────────────────────────────────────────
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run build

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -1,0 +1,26 @@
+name: Publish to JSR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write # OIDC provenance for JSR
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: Publish to JSR
+        run: deno publish --no-check

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       id-token: write # OIDC provenance for JSR
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
@@ -22,5 +22,8 @@ jobs:
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
+      - run: bun run build
+      - name: Deno adapter smoke test
+        run: deno run --allow-read --allow-env scripts/deno-smoke-test.ts
       - name: Publish to JSR
         run: deno publish --no-check

--- a/.opencode/state/v0.9/prd.json
+++ b/.opencode/state/v0.9/prd.json
@@ -14,7 +14,7 @@
 			"title": "Add cross-runtime CI test matrix",
 			"description": "GitHub Actions running tests on Node LTS, Bun stable, Deno stable. Adapter parity tests verifying identical behavior across runtimes.",
 			"priority": "integration",
-			"passes": false
+			"passes": true
 		},
 		{
 			"id": "jsr-publishing",

--- a/.opencode/state/v0.9/prd.json
+++ b/.opencode/state/v0.9/prd.json
@@ -21,7 +21,7 @@
 			"title": "Set up JSR publishing",
 			"description": "Configure package for JSR (Deno-first registry). Dual publish: npm + JSR. Ensure type exports work on both registries.",
 			"priority": "integration",
-			"passes": false
+			"passes": true
 		}
 	]
 }

--- a/.opencode/state/v0.9/prd.json
+++ b/.opencode/state/v0.9/prd.json
@@ -1,0 +1,27 @@
+{
+	"prdName": "v0.9-deno-adapter",
+	"description": "Deno adapter + cross-runtime CI + JSR publishing",
+	"tasks": [
+		{
+			"id": "deno-adapter",
+			"title": "Implement Deno runtime adapter",
+			"description": "Implement RuntimeAdapter for Deno in src/runtime/deno.ts. Use Deno.args, Deno.env, Deno.cwd(), Deno.stdout/stderr. Handle permissions gracefully. Update createAdapter() to use it. Wire into barrel exports.",
+			"priority": "architecture",
+			"passes": true
+		},
+		{
+			"id": "cross-runtime-ci",
+			"title": "Add cross-runtime CI test matrix",
+			"description": "GitHub Actions running tests on Node LTS, Bun stable, Deno stable. Adapter parity tests verifying identical behavior across runtimes.",
+			"priority": "integration",
+			"passes": false
+		},
+		{
+			"id": "jsr-publishing",
+			"title": "Set up JSR publishing",
+			"description": "Configure package for JSR (Deno-first registry). Dual publish: npm + JSR. Ensure type exports work on both registries.",
+			"priority": "integration",
+			"passes": false
+		}
+	]
+}

--- a/.opencode/state/v0.9/progress.txt
+++ b/.opencode/state/v0.9/progress.txt
@@ -47,7 +47,7 @@ Started: 2026-02-11
 - **Learnings:** vitest doesn't run under Deno — Deno testing requires separate smoke test against built output. Concurrency group with `cancel-in-progress` prevents wasted CI minutes on force-pushes. Node test runs use `npx vitest run` (not `bun run test`) to ensure Node is the actual runtime.
 
 ## Task - jsr-publishing
-- Created `deno.json` with JSR config: `@dreamcli/dreamcli@0.9.0`, three subpath exports, sloppy-imports for `.js` extension compat
+- Created `deno.json` with JSR config: `@kjanat/dreamcli@0.9.0`, three subpath exports, sloppy-imports for `.js` extension compat
 - Fixed 2 "slow type" errors for JSR fast-check: added explicit type annotations to `SHELLS` (completion/index.ts) and `RUNTIMES` (runtime/detect.ts)
 - `--no-check` flag needed: project's minimal `NodeProcess` interface conflicts with real `@types/node` under Deno's type checker
 - `nodeModulesDir: "auto"` needed for `@types/node` resolution during `deno publish`

--- a/.opencode/state/v0.9/progress.txt
+++ b/.opencode/state/v0.9/progress.txt
@@ -45,3 +45,15 @@ Started: 2026-02-11
 - Verified locally: Deno smoke test passes on Deno 2.6.6, all 1695 vitest tests still pass
 - Files added: `.github/workflows/ci.yml`, `scripts/deno-smoke-test.ts`
 - **Learnings:** vitest doesn't run under Deno — Deno testing requires separate smoke test against built output. Concurrency group with `cancel-in-progress` prevents wasted CI minutes on force-pushes. Node test runs use `npx vitest run` (not `bun run test`) to ensure Node is the actual runtime.
+
+## Task - jsr-publishing
+- Created `deno.json` with JSR config: `@dreamcli/dreamcli@0.9.0`, three subpath exports, sloppy-imports for `.js` extension compat
+- Fixed 2 "slow type" errors for JSR fast-check: added explicit type annotations to `SHELLS` (completion/index.ts) and `RUNTIMES` (runtime/detect.ts)
+- `--no-check` flag needed: project's minimal `NodeProcess` interface conflicts with real `@types/node` under Deno's type checker
+- `nodeModulesDir: "auto"` needed for `@types/node` resolution during `deno publish`
+- Excluded `AGENTS.md` and test files from JSR publish
+- Created `.github/workflows/publish-jsr.yml` — triggered on release or manual dispatch, OIDC provenance via `id-token: write`
+- `deno publish --dry-run --no-check --allow-dirty` passes cleanly (zero errors)
+- Files added: `deno.json`, `.github/workflows/publish-jsr.yml`
+- Files modified: `src/core/completion/index.ts` (SHELLS annotation), `src/runtime/detect.ts` (RUNTIMES annotation)
+- **Learnings:** JSR "slow types" require explicit type annotations on exported `as const` values — the type inference shortcut doesn't work for JSR's fast-check. `unstable: ["sloppy-imports"]` is the pragmatic fix for `.js` extension imports in a NodeNext project. `--no-check` is safe when combined with a separate tsgo/tsc check in CI.

--- a/.opencode/state/v0.9/progress.txt
+++ b/.opencode/state/v0.9/progress.txt
@@ -1,0 +1,36 @@
+# Progress Log
+PRD: v0.9-deno-adapter
+Started: 2026-02-11
+
+## Codebase Patterns
+<!-- Consolidate reusable patterns here -->
+- Runtime adapters follow factory pattern: `create{Platform}Adapter()` returning `RuntimeAdapter`
+- Node adapter reads process state once at creation, exposes through immutable interface
+- Bun adapter delegates entirely to Node adapter (Node-compat process global)
+- `detect.ts` uses globalThis feature detection with injectable `globals` param for testing
+- `auto.ts` switches on `detectRuntime()` result, exhaustive via `never` default
+- Test files use `mockNodeProcess()` helper, `vi.fn()` for spies, no module mocking
+- Platform env/homedir/configDir resolution is pure functions on env+platform args
+- `@internal` JSDoc for non-public symbols
+- `.js` extensions in all relative imports (NodeNext resolution)
+
+- Deno adapter needs `deno-builtins.d.ts` for TextEncoder/TextDecoder/ReadableStream (lib:ES2022 excludes web APIs)
+- `createDenoAdapter(ns?)` injectable namespace mirrors `createNodeAdapter(proc?)` pattern
+- Deno.args pre-strips binary/script; adapter prepends synthetic `['deno', 'run']` for argv parity
+- Permission-safe helpers: `safeEnvToObject()` catches PermissionDenied, falls back to `{}`
+- `readFile` returns null for both NotFound AND PermissionDenied (graceful degradation for config probing)
+- Testing Deno adapter path through `createAdapter()` requires `withMockDenoGlobal()` helper (installs mock on globalThis)
+- Error detection: `isDenoErrorNamed(err, 'NotFound')` — checks `err.name` string (no Deno.errors import needed)
+
+---
+<!-- Task logs below - APPEND ONLY -->
+
+## Task - deno-adapter
+- Implemented `createDenoAdapter()` in `src/runtime/deno.ts` (~300 lines)
+- Added `deno-builtins.d.ts` for ambient web API types (TextEncoder, TextDecoder, ReadableStream)
+- Wired into `auto.ts` (removed CLIError throw, now creates Deno adapter), barrel `index.ts`, subpath `runtime.ts`
+- 38 tests in `deno.test.ts` covering: argv synthesis, env (incl. PermissionDenied), cwd, stdout/stderr, TTY, exit, stdin line reading, readFile (NotFound/PermissionDenied/propagation), homedir/configDir resolution, public exports
+- Updated `auto.test.ts` (3 tests changed: Deno now creates adapter, not throws; added `withMockDenoGlobal` helper)
+- Updated `cli-completion-e2e.test.ts` (1 test changed: Deno creates adapter instead of throwing CLIError)
+- Files changed: `deno.ts`, `deno-builtins.d.ts`, `deno.test.ts`, `auto.ts`, `auto.test.ts`, `cli-completion-e2e.test.ts`, `index.ts`, `runtime.ts`
+- **Learnings:** Deno's stdin uses ReadableStream (not readline), needs manual line buffering. globalThis mock cleanup pattern essential for cross-runtime adapter tests in vitest.

--- a/.opencode/state/v0.9/progress.txt
+++ b/.opencode/state/v0.9/progress.txt
@@ -34,3 +34,14 @@ Started: 2026-02-11
 - Updated `cli-completion-e2e.test.ts` (1 test changed: Deno creates adapter instead of throwing CLIError)
 - Files changed: `deno.ts`, `deno-builtins.d.ts`, `deno.test.ts`, `auto.ts`, `auto.test.ts`, `cli-completion-e2e.test.ts`, `index.ts`, `runtime.ts`
 - **Learnings:** Deno's stdin uses ReadableStream (not readline), needs manual line buffering. globalThis mock cleanup pattern essential for cross-runtime adapter tests in vitest.
+
+## Task - cross-runtime-ci
+- Created `.github/workflows/ci.yml` with 4 jobs: lint, test (matrix), test-deno, build
+- **lint**: Bun-only — type check (tsgo), biome lint, dprint format check
+- **test**: Matrix with Bun stable + Node LTS — vitest runs natively on both
+- **test-deno**: Builds package, then runs `scripts/deno-smoke-test.ts` under real Deno with `--allow-read --allow-env`
+- **build**: After lint+test pass — tsdown build + publint + attw
+- Created `scripts/deno-smoke-test.ts` — 21 assertions exercising createDenoAdapter() against real Deno APIs (argv, env, cwd, I/O, TTY, readFile, homedir, configDir)
+- Verified locally: Deno smoke test passes on Deno 2.6.6, all 1695 vitest tests still pass
+- Files added: `.github/workflows/ci.yml`, `scripts/deno-smoke-test.ts`
+- **Learnings:** vitest doesn't run under Deno — Deno testing requires separate smoke test against built output. Concurrency group with `cancel-in-progress` prevents wasted CI minutes on force-pushes. Node test runs use `npx vitest run` (not `bun run test`) to ensure Node is the actual runtime.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-02-11 **Commit:** 1c8e6ba **Branch:** v0.8-spinner-progress
+**Generated:** 2026-02-11 **Commit:** b08fc87 **Branch:** v0.9-deno-adapter
 
 ## OVERVIEW
 
@@ -36,7 +36,7 @@ src/
     ├── auto.ts             # Auto-detecting adapter factory
     ├── node.ts             # Node.js adapter implementation
     ├── bun.ts              # Bun adapter (delegates to Node adapter)
-    ├── deno.ts             # STUB
+    ├── deno.ts             # Deno adapter (permission-safe Deno namespace)
     └── detect.ts           # Runtime auto-detection (Bun/Deno/Node feature detection)
 ```
 
@@ -88,7 +88,7 @@ guarantees erasure).
 
 - **Tabs**, width 2, line width 100, single quotes, semicolons always, LF
 - **`verbatimModuleSyntax`** — use `import type` for type-only imports
-- **`.js` extensions** in all relative imports (NodeNext resolution)
+- **`.ts` extensions** in all relative imports (`allowImportingTsExtensions` + `noEmit`)
 - **Maximum TS strictness** — `strict`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`
 - **No `any`** (biome warns), **no `!` non-null assertion** (biome info)
 - **Barrel-per-module** — each module has `index.ts` re-exporting public symbols
@@ -145,8 +145,9 @@ bun run ci           # check → lint → test → build (sequential)
 
 - **CI**: GitHub Actions — lint+typecheck (Bun), test matrix (Node LTS + Bun), Deno smoke test,
   build
-- **No publish automation** — manual `bun publish`, quality gates in build step
-- **~31 source files, 46 test files, ~9.9k source lines** — 1658 tests
+- **JSR publishing** — `deno.json` (`@dreamcli/dreamcli`), GitHub Actions publish workflow with OIDC
+- **npm publishing** — manual `bun publish`, quality gates in build step
+- **~32 source files, 47 test files, ~10.1k source lines** — 1695 tests
 - **5 files >500 lines** — `resolve/index.ts` (940), `cli/index.ts` (793), `schema/command.ts`
   (784), `completion/index.ts` (786), `output/activity.ts` (581)
 - `cli/index.ts` partially split: `dispatch.ts` + `propagate.ts` extracted as `@internal`
@@ -155,7 +156,6 @@ bun run ci           # check → lint → test → build (sequential)
 - `stdinIsTTY` gates interactive prompt auto-creation in `cli/index.ts` — prompts only activate when
   stdin is a TTY
 - Three subpath exports: `"."`, `"./testkit"`, `"./runtime"`
-- `deno.ts` is an empty stub (planned, not yet implemented)
 - `src/` included in `files` (published source)
 - `node-builtins.d.ts` — handwritten ambient module declarations for `node:readline` and
   `node:fs/promises` to avoid `@types/node` dependency

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ bun run ci           # check → lint → test → build (sequential)
 
 - **CI**: GitHub Actions — lint+typecheck (Bun), test matrix (Node LTS + Bun), Deno smoke test,
   build
-- **JSR publishing** — `deno.json` (`@dreamcli/dreamcli`), GitHub Actions publish workflow with OIDC
+- **JSR publishing** — `deno.json` (`@kjanat/dreamcli`), GitHub Actions publish workflow with OIDC
 - **npm publishing** — manual `bun publish`, quality gates in build step
 - **~32 source files, 47 test files, ~10.1k source lines** — 1695 tests
 - **5 files >500 lines** — `resolve/index.ts` (940), `cli/index.ts` (793), `schema/command.ts`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,8 @@ bun run ci           # check → lint → test → build (sequential)
 
 ## NOTES
 
-- **No CI automation** — `bun run ci` is local-only, no GitHub Actions
+- **CI**: GitHub Actions — lint+typecheck (Bun), test matrix (Node LTS + Bun), Deno smoke test,
+  build
 - **No publish automation** — manual `bun publish`, quality gates in build step
 - **~31 source files, 46 test files, ~9.9k source lines** — 1658 tests
 - **5 files >500 lines** — `resolve/index.ts` (940), `cli/index.ts` (793), `schema/command.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### JSR Publishing
 
-- **`deno.json`** with JSR package config (`@dreamcli/dreamcli`), three subpath exports, publish
+- **`deno.json`** with JSR package config (`@kjanat/dreamcli`), three subpath exports, publish
   include/exclude rules.
 - **GitHub Actions publish workflow** (`.github/workflows/publish-jsr.yml`) — publishes to JSR on
   GitHub release with OIDC provenance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-02-11
+
+### Added
+
+#### Deno Adapter
+
+- **`createDenoAdapter(ns?)`** — full `RuntimeAdapter` implementation for Deno. Reads argv from
+  `Deno.args` (prepends synthetic `['deno', 'run']` for parity), env from `Deno.env.toObject()`, cwd
+  from `Deno.cwd()`, stdout/stderr via `TextEncoder` → `Deno.stdout.write`/`Deno.stderr.write`,
+  stdin via `Deno.stdin.readable` stream with line-buffered reader, TTY detection via
+  `isTerminal()`, `readFile` via `Deno.readTextFile`, and homedir/configDir from env vars.
+- **Permission-safe** — `PermissionDenied` errors gracefully degrade: env falls back to `{}`, cwd to
+  `/`, readFile to `null`. Non-permission errors propagate.
+- **`deno-builtins.d.ts`** — ambient type declarations for `TextEncoder`, `TextDecoder`, and
+  `ReadableStream` (needed because `lib: ["ES2022"]` excludes web platform APIs).
+- **`createAdapter()` auto-detection** now handles Deno runtime via `globalThis.Deno` feature
+  probing.
+- Re-exported `createDenoAdapter` and `DenoNamespace` from `dreamcli/runtime` subpath.
+
+#### Cross-Runtime CI
+
+- **GitHub Actions CI workflow** (`.github/workflows/ci.yml`) — lint+typecheck (Bun), test matrix
+  (Node LTS + Bun stable), Deno smoke test, build with publint+attw.
+- **Deno smoke test** (`scripts/deno-smoke-test.ts`) — runs on real Deno runtime after build,
+  exercising `createDenoAdapter()` against actual Deno APIs.
+
+#### JSR Publishing
+
+- **`deno.json`** with JSR package config (`@dreamcli/dreamcli`), three subpath exports, publish
+  include/exclude rules.
+- **GitHub Actions publish workflow** (`.github/workflows/publish-jsr.yml`) — publishes to JSR on
+  GitHub release with OIDC provenance.
+
+### Changed
+
+- **`.ts` import extensions** — all import specifiers switched from `.js` to `.ts` via
+  `allowImportingTsExtensions`. tsconfig updated: `noEmit: true` +
+  `allowImportingTsExtensions: true` replace `declaration`/`declarationMap`/`sourceMap`/`outDir`
+  (all handled by tsdown). Removes the need for Deno's `unstable: ["sloppy-imports"]`.
+- `detectRuntime()` updated with Deno detection via `globalThis.Deno?.version?.deno`.
+- `createAdapter()` switch now covers `'deno'` case alongside `'node'` and `'bun'`.
+- Completion generator: `typeof` check on `globalThis` narrowed to avoid Deno type errors.
+- `runtime/deno.ts` expanded from empty stub (~5 lines) to full implementation (~318 lines).
+- Test count: 1695 tests across 47 test files (up from 1658 in v0.8.0).
+
 ## [0.8.0] - 2026-02-11
 
 ### Breaking
@@ -430,7 +475,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MIT License.
 - Markdownlint configuration.
 
-[Unreleased]: https://github.com/kjanat/dreamcli/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/kjanat/dreamcli/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/kjanat/dreamcli/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/kjanat/dreamcli/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/kjanat/dreamcli/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/kjanat/dreamcli/compare/v0.5.0...v0.6.0

--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,7 @@
 	},
 	"publish": {
 		"include": ["src", "LICENSE"],
-		"exclude": ["src/**/*.test.ts", "src/**/AGENTS.md"]
+		"exclude": ["src/**/*.test.ts", "src/**/test-helpers.ts", "src/**/AGENTS.md"]
 	},
 	"nodeModulesDir": "manual",
 	"exclude": ["dist/", "node_modules/", "coverage/"]

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,6 @@
 {
-	"name": "@dreamcli/dreamcli",
+	"$schema": "https://github.com/denoland/deno/blob/main/cli/schemas/config-file.v1.json",
+	"name": "@kjanat/dreamcli",
 	"version": "0.9.0",
 	"exports": {
 		".": "./src/index.ts",

--- a/deno.json
+++ b/deno.json
@@ -11,7 +11,6 @@
 		"exclude": ["src/**/*.test.ts", "src/**/AGENTS.md"]
 	},
 	"nodeModulesDir": "auto",
-	"unstable": ["sloppy-imports"],
 	"compilerOptions": {
 		"strict": true,
 		"noUncheckedIndexedAccess": true,

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://github.com/denoland/deno/blob/main/cli/schemas/config-file.v1.json",
+	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
 	"version": "0.9.0",
 	"exports": {
@@ -8,14 +8,9 @@
 		"./testkit": "./src/testkit.ts"
 	},
 	"publish": {
-		"include": ["src", "LICENSE", "README.md"],
+		"include": ["src", "LICENSE"],
 		"exclude": ["src/**/*.test.ts", "src/**/AGENTS.md"]
 	},
-	"nodeModulesDir": "auto",
-	"compilerOptions": {
-		"strict": true,
-		"noUncheckedIndexedAccess": true,
-		"exactOptionalPropertyTypes": true,
-		"verbatimModuleSyntax": true
-	}
+	"nodeModulesDir": "manual",
+	"exclude": ["dist/", "node_modules/", "coverage/"]
 }

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,21 @@
+{
+	"name": "@dreamcli/dreamcli",
+	"version": "0.9.0",
+	"exports": {
+		".": "./src/index.ts",
+		"./runtime": "./src/runtime.ts",
+		"./testkit": "./src/testkit.ts"
+	},
+	"publish": {
+		"include": ["src", "LICENSE", "README.md"],
+		"exclude": ["src/**/*.test.ts", "src/**/AGENTS.md"]
+	},
+	"nodeModulesDir": "auto",
+	"unstable": ["sloppy-imports"],
+	"compilerOptions": {
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
+		"verbatimModuleSyntax": true
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dreamcli",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"license": "MIT",
 	"type": "module",

--- a/scripts/deno-smoke-test.ts
+++ b/scripts/deno-smoke-test.ts
@@ -12,8 +12,8 @@
  *   1 — a check failed
  */
 
-import type { RuntimeAdapter } from '../dist/runtime.mjs';
 // Import from built output (not source) to verify the published shape
+import type { RuntimeAdapter } from '../dist/runtime.mjs';
 import { createDenoAdapter } from '../dist/runtime.mjs';
 
 let failures = 0;
@@ -125,8 +125,8 @@ assert(typeof adapter.exit === 'function', 'exit is a function');
 console.log('');
 if (failures > 0) {
 	console.error(`\n${failures} check(s) failed`);
-	Deno.exit(1);
+	adapter.exit(1);
 } else {
 	console.log('All checks passed');
-	Deno.exit(0);
+	adapter.exit(0);
 }

--- a/scripts/deno-smoke-test.ts
+++ b/scripts/deno-smoke-test.ts
@@ -1,0 +1,131 @@
+/**
+ * Deno adapter smoke test.
+ *
+ * Runs under Deno to verify the built package works on a real Deno runtime.
+ * This complements the vitest-based unit tests (which run under Node/Bun
+ * with mock injection) by exercising the adapter against actual Deno APIs.
+ *
+ * Usage: deno run --allow-read --allow-env scripts/deno-smoke-test.ts
+ *
+ * Exit codes:
+ *   0 — all checks passed
+ *   1 — a check failed
+ */
+
+import type { RuntimeAdapter } from '../dist/runtime.mjs';
+// Import from built output (not source) to verify the published shape
+import { createDenoAdapter } from '../dist/runtime.mjs';
+
+let failures = 0;
+
+function assert(condition: boolean, message: string): void {
+	if (condition) {
+		console.log(`  ✓ ${message}`);
+	} else {
+		console.error(`  ✗ ${message}`);
+		failures += 1;
+	}
+}
+
+// ───────────────────────────────────────────────────────────────────
+// 1. Adapter creation
+// ───────────────────────────────────────────────────────────────────
+
+console.log('createDenoAdapter()');
+
+const adapter: RuntimeAdapter = createDenoAdapter();
+
+assert(adapter !== null && adapter !== undefined, 'adapter is defined');
+
+// ───────────────────────────────────────────────────────────────────
+// 2. argv — should have synthetic prefix + Deno.args
+// ───────────────────────────────────────────────────────────────────
+
+console.log('\nargv');
+
+assert(Array.isArray(adapter.argv), 'argv is an array');
+assert(adapter.argv.length >= 2, 'argv has at least 2 entries (synthetic prefix)');
+assert(adapter.argv[0] === 'deno', 'argv[0] is "deno"');
+assert(adapter.argv[1] === 'run', 'argv[1] is "run"');
+
+// ───────────────────────────────────────────────────────────────────
+// 3. Environment
+// ───────────────────────────────────────────────────────────────────
+
+console.log('\nenv');
+
+assert(typeof adapter.env === 'object', 'env is an object');
+// PATH should be available (--allow-env granted)
+const hasPath = adapter.env.PATH !== undefined || adapter.env.Path !== undefined;
+assert(hasPath, 'env contains PATH');
+
+// ───────────────────────────────────────────────────────────────────
+// 4. cwd
+// ───────────────────────────────────────────────────────────────────
+
+console.log('\ncwd');
+
+assert(typeof adapter.cwd === 'string', 'cwd is a string');
+assert(adapter.cwd.length > 0, 'cwd is non-empty');
+
+// ───────────────────────────────────────────────────────────────────
+// 5. I/O functions
+// ───────────────────────────────────────────────────────────────────
+
+console.log('\nI/O');
+
+assert(typeof adapter.stdout === 'function', 'stdout is a function');
+assert(typeof adapter.stderr === 'function', 'stderr is a function');
+assert(typeof adapter.stdin === 'function', 'stdin is a function');
+
+// Exercise stdout/stderr — should not throw
+adapter.stdout('');
+adapter.stderr('');
+
+// ───────────────────────────────────────────────────────────────────
+// 6. TTY detection
+// ───────────────────────────────────────────────────────────────────
+
+console.log('\nTTY');
+
+assert(typeof adapter.isTTY === 'boolean', 'isTTY is a boolean');
+assert(typeof adapter.stdinIsTTY === 'boolean', 'stdinIsTTY is a boolean');
+
+// ───────────────────────────────────────────────────────────────────
+// 7. Filesystem
+// ───────────────────────────────────────────────────────────────────
+
+console.log('\nfilesystem');
+
+assert(typeof adapter.readFile === 'function', 'readFile is a function');
+assert(typeof adapter.homedir === 'string', 'homedir is a string');
+assert(typeof adapter.configDir === 'string', 'configDir is a string');
+
+// readFile should return contents for existing file
+const pkg = await adapter.readFile('./package.json');
+assert(pkg !== null, 'readFile returns content for existing file');
+assert(typeof pkg === 'string' && pkg.includes('dreamcli'), 'readFile content contains "dreamcli"');
+
+// readFile should return null for nonexistent file
+const missing = await adapter.readFile('./nonexistent-file-12345.json');
+assert(missing === null, 'readFile returns null for nonexistent file');
+
+// ───────────────────────────────────────────────────────────────────
+// 8. exit function
+// ───────────────────────────────────────────────────────────────────
+
+console.log('\nexit');
+
+assert(typeof adapter.exit === 'function', 'exit is a function');
+
+// ───────────────────────────────────────────────────────────────────
+// Summary
+// ───────────────────────────────────────────────────────────────────
+
+console.log('');
+if (failures > 0) {
+	console.error(`\n${failures} check(s) failed`);
+	Deno.exit(1);
+} else {
+	console.log('All checks passed');
+}

--- a/scripts/deno-smoke-test.ts
+++ b/scripts/deno-smoke-test.ts
@@ -128,4 +128,5 @@ if (failures > 0) {
 	Deno.exit(1);
 } else {
 	console.log('All checks passed');
+	Deno.exit(0);
 }

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -53,8 +53,8 @@ command map building, 3-way dispatch result (`unknown` / `needs-subcommand` / `m
 - `levenshtein()` in `dispatch.ts` uses `Uint16Array` rolling buffer — different impl from `parse/`
 - `uniqueCommands()` deduplicates via `Set` on command name — `@internal`
 - `extractConfigFlag()` handles both `--config path` and `--config=path` forms
-- Direct imports: `schema/command.js`, `schema/flag.js`, `schema/arg.js` (not through barrel)
-- Cross-layer imports: `runtime/adapter.js`, `runtime/auto.js` (not through runtime barrel)
+- Direct imports: `schema/command.ts`, `schema/flag.ts`, `schema/arg.ts` (not through barrel)
+- Cross-layer imports: `runtime/adapter.ts`, `runtime/auto.ts` (not through runtime barrel)
 
 ## TEST FILES (10)
 

--- a/src/core/cli/cli-completion-e2e.test.ts
+++ b/src/core/cli/cli-completion-e2e.test.ts
@@ -6,10 +6,9 @@
  * CLIBuilder × completion generators × runtime detection × adapter factory.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createTestAdapter, ExitError } from '../../runtime/adapter.js';
 import type { GlobalForDetect } from '../../runtime/detect.js';
-import { CLIError } from '../errors/index.js';
 import { arg } from '../schema/arg.js';
 import { command } from '../schema/command.js';
 import { flag } from '../schema/flag.js';
@@ -572,13 +571,49 @@ describe('E2E — detectRuntime in CLIBuilder.run() path', () => {
 		expect(typeof adapter.stderr).toBe('function');
 	});
 
-	it('auto-adapter throws CLIError for simulated Deno runtime', async () => {
+	it('auto-adapter creates valid adapter for simulated Deno runtime', async () => {
 		const { createAdapter } = await import('../../runtime/auto.js');
-		const globals: GlobalForDetect = {
-			Deno: { version: { deno: '2.1.0' } },
+
+		// Install a mock Deno namespace on globalThis — createDenoAdapter() reads
+		// from globalThis.Deno when no explicit namespace is provided.
+		const g = globalThis as Record<string, unknown>;
+		const prev = g['Deno'];
+		g['Deno'] = {
+			args: [],
+			env: { get: () => undefined, toObject: () => ({}) },
+			cwd: () => '/deno/mock',
+			stdout: { write: vi.fn(() => Promise.resolve(0)), isTerminal: () => false },
+			stderr: { write: vi.fn(() => Promise.resolve(0)) },
+			stdin: {
+				isTerminal: () => false,
+				readable: {
+					getReader: () => ({
+						read: () => Promise.resolve({ done: true, value: undefined }),
+						releaseLock: () => {},
+					}),
+				},
+			},
+			exit: vi.fn() as unknown as (code: number) => never,
+			readTextFile: () =>
+				Promise.reject(Object.assign(new Error('not found'), { name: 'NotFound' })),
+			version: { deno: '2.1.0' },
 		};
-		// Deno is detected but not yet supported — throws UNSUPPORTED_RUNTIME
-		expect(() => createAdapter(globals)).toThrow(CLIError);
+
+		try {
+			const globals: GlobalForDetect = {
+				Deno: { version: { deno: '2.1.0' } },
+			};
+			const adapter = createAdapter(globals);
+			expect(adapter).toBeDefined();
+			expect(typeof adapter.stdout).toBe('function');
+			expect(typeof adapter.stderr).toBe('function');
+		} finally {
+			if (prev === undefined) {
+				delete g['Deno'];
+			} else {
+				g['Deno'] = prev;
+			}
+		}
 	});
 });
 

--- a/src/core/cli/cli-completion-e2e.test.ts
+++ b/src/core/cli/cli-completion-e2e.test.ts
@@ -7,13 +7,13 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { createTestAdapter, ExitError } from '../../runtime/adapter.js';
-import type { GlobalForDetect } from '../../runtime/detect.js';
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { middleware } from '../schema/middleware.js';
-import { cli } from './index.js';
+import { createTestAdapter, ExitError } from '../../runtime/adapter.ts';
+import type { GlobalForDetect } from '../../runtime/detect.ts';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { middleware } from '../schema/middleware.ts';
+import { cli } from './index.ts';
 
 // ===================================================================
 // Shared test commands
@@ -560,7 +560,7 @@ describe('E2E — detectRuntime in CLIBuilder.run() path', () => {
 		// Verify the createAdapter path works with Bun globals.
 		// We test this via the adapter factory directly since run() would
 		// need a real Bun runtime for process.argv etc.
-		const { createAdapter } = await import('../../runtime/auto.js');
+		const { createAdapter } = await import('../../runtime/auto.ts');
 		const globals: GlobalForDetect = {
 			Bun: { version: '1.2.0' },
 			process: { versions: { node: '22.0.0' } },
@@ -572,7 +572,7 @@ describe('E2E — detectRuntime in CLIBuilder.run() path', () => {
 	});
 
 	it('auto-adapter creates valid adapter for simulated Deno runtime', async () => {
-		const { createAdapter } = await import('../../runtime/auto.js');
+		const { createAdapter } = await import('../../runtime/auto.ts');
 
 		// Install a mock Deno namespace on globalThis — createDenoAdapter() reads
 		// from globalThis.Deno when no explicit namespace is provided.

--- a/src/core/cli/cli-completion-e2e.test.ts
+++ b/src/core/cli/cli-completion-e2e.test.ts
@@ -573,33 +573,9 @@ describe('E2E — detectRuntime in CLIBuilder.run() path', () => {
 
 	it('auto-adapter creates valid adapter for simulated Deno runtime', async () => {
 		const { createAdapter } = await import('../../runtime/auto.ts');
+		const { withMockDenoGlobal } = await import('../../runtime/test-helpers.ts');
 
-		// Install a mock Deno namespace on globalThis — createDenoAdapter() reads
-		// from globalThis.Deno when no explicit namespace is provided.
-		const g = globalThis as Record<string, unknown>;
-		const prev = g['Deno'];
-		g['Deno'] = {
-			args: [],
-			env: { get: () => undefined, toObject: () => ({}) },
-			cwd: () => '/deno/mock',
-			stdout: { write: vi.fn(() => Promise.resolve(0)), isTerminal: () => false },
-			stderr: { write: vi.fn(() => Promise.resolve(0)) },
-			stdin: {
-				isTerminal: () => false,
-				readable: {
-					getReader: () => ({
-						read: () => Promise.resolve({ done: true, value: undefined }),
-						releaseLock: () => {},
-					}),
-				},
-			},
-			exit: vi.fn() as unknown as (code: number) => never,
-			readTextFile: () =>
-				Promise.reject(Object.assign(new Error('not found'), { name: 'NotFound' })),
-			version: { deno: '2.1.0' },
-		};
-
-		try {
+		withMockDenoGlobal(() => {
 			const globals: GlobalForDetect = {
 				Deno: { version: { deno: '2.1.0' } },
 			};
@@ -607,13 +583,7 @@ describe('E2E — detectRuntime in CLIBuilder.run() path', () => {
 			expect(adapter).toBeDefined();
 			expect(typeof adapter.stdout).toBe('function');
 			expect(typeof adapter.stderr).toBe('function');
-		} finally {
-			if (prev === undefined) {
-				delete g['Deno'];
-			} else {
-				g['Deno'] = prev;
-			}
-		}
+		});
 	});
 });
 

--- a/src/core/cli/cli-completions.test.ts
+++ b/src/core/cli/cli-completions.test.ts
@@ -3,11 +3,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { CLIError } from '../errors/index.js';
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { cli } from './index.js';
+import { CLIError } from '../errors/index.ts';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { cli } from './index.ts';
 
 // ===================================================================
 // Test helpers

--- a/src/core/cli/cli-config.test.ts
+++ b/src/core/cli/cli-config.test.ts
@@ -5,13 +5,13 @@
  * and precedence between explicit options.config and loaded config.
  */
 import { describe, expect, it } from 'vitest';
-import { createTestAdapter, ExitError } from '../../runtime/index.js';
-import type { FormatLoader } from '../config/index.js';
-import { configFormat } from '../config/index.js';
-import { CLIError } from '../errors/index.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { cli } from './index.js';
+import { createTestAdapter, ExitError } from '../../runtime/index.ts';
+import type { FormatLoader } from '../config/index.ts';
+import { configFormat } from '../config/index.ts';
+import { CLIError } from '../errors/index.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { cli } from './index.ts';
 
 // ===================================================================
 // Test helpers

--- a/src/core/cli/cli-dispatch.test.ts
+++ b/src/core/cli/cli-dispatch.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { CommandSchema, ErasedCommand } from '../schema/command.js';
-import { dispatch, findClosestCommand, levenshtein, uniqueCommands } from './dispatch.js';
+import type { CommandSchema, ErasedCommand } from '../schema/command.ts';
+import { dispatch, findClosestCommand, levenshtein, uniqueCommands } from './dispatch.ts';
 
 // ===================================================================
 // Helpers

--- a/src/core/cli/cli-json.test.ts
+++ b/src/core/cli/cli-json.test.ts
@@ -3,10 +3,10 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { CLIError } from '../errors/index.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { cli } from './index.js';
+import { CLIError } from '../errors/index.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { cli } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Test commands

--- a/src/core/cli/cli-middleware.test.ts
+++ b/src/core/cli/cli-middleware.test.ts
@@ -6,12 +6,12 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { CLIError } from '../errors/index.js';
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { middleware } from '../schema/middleware.js';
-import { cli } from './index.js';
+import { CLIError } from '../errors/index.ts';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { middleware } from '../schema/middleware.ts';
+import { cli } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Middleware flows through CLI dispatch

--- a/src/core/cli/cli-nesting.test.ts
+++ b/src/core/cli/cli-nesting.test.ts
@@ -6,10 +6,10 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { arg } from '../schema/arg.js';
-import { command, group } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { cli } from './index.js';
+import { arg } from '../schema/arg.ts';
+import { command, group } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { cli } from './index.ts';
 
 // ===================================================================
 // Helpers

--- a/src/core/cli/cli-propagate.test.ts
+++ b/src/core/cli/cli-propagate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import type { CommandSchema } from '../schema/command.js';
-import { createSchema } from '../schema/flag.js';
-import { collectPropagatedFlags } from './propagate.js';
+import type { CommandSchema } from '../schema/command.ts';
+import { createSchema } from '../schema/flag.ts';
+import { collectPropagatedFlags } from './propagate.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers — build minimal CommandSchema for testing

--- a/src/core/cli/cli-tty.test.ts
+++ b/src/core/cli/cli-tty.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { createTestAdapter, ExitError } from '../../runtime/adapter.js';
-import { command } from '../schema/command.js';
-import { cli } from './index.js';
+import { createTestAdapter, ExitError } from '../../runtime/adapter.ts';
+import { command } from '../schema/command.ts';
+import { cli } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/cli/cli.test.ts
+++ b/src/core/cli/cli.test.ts
@@ -3,11 +3,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ParseError } from '../errors/index.js';
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { CLIBuilder, cli, formatRootHelp } from './index.js';
+import { ParseError } from '../errors/index.ts';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { CLIBuilder, cli, formatRootHelp } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Test commands
@@ -667,12 +667,12 @@ describe('edge cases', () => {
 
 describe('public exports', () => {
 	it('exports cli factory', async () => {
-		const { cli: cliExport } = await import('../../index.js');
+		const { cli: cliExport } = await import('../../index.ts');
 		expect(typeof cliExport).toBe('function');
 	});
 
 	it('exports CLIBuilder class', async () => {
-		const { CLIBuilder: CLIBuilderExport } = await import('../../index.js');
+		const { CLIBuilder: CLIBuilderExport } = await import('../../index.ts');
 		expect(typeof CLIBuilderExport).toBe('function');
 	});
 });

--- a/src/core/cli/dispatch.ts
+++ b/src/core/cli/dispatch.ts
@@ -10,7 +10,7 @@
  * @internal
  */
 
-import type { CommandSchema, ErasedCommand } from '../schema/command.js';
+import type { CommandSchema, ErasedCommand } from '../schema/command.ts';
 
 // ---------------------------------------------------------------------------
 // Dispatch result types (discriminated union)

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -9,28 +9,28 @@
  * @module dreamcli/core/cli
  */
 
-import type { RuntimeAdapter } from '../../runtime/adapter.js';
-import { createAdapter } from '../../runtime/auto.js';
-import { generateCompletion, SHELLS } from '../completion/index.js';
-import type { FormatLoader } from '../config/index.js';
-import { discoverConfig } from '../config/index.js';
-import { CLIError, ParseError } from '../errors/index.js';
-import type { HelpOptions } from '../help/index.js';
-import { formatHelp } from '../help/index.js';
-import type { CapturedOutput, Verbosity } from '../output/index.js';
-import { createCaptureOutput } from '../output/index.js';
-import type { PromptEngine, TestAnswer } from '../prompt/index.js';
-import { createTerminalPrompter } from '../prompt/index.js';
-import type { ArgBuilder, ArgConfig } from '../schema/arg.js';
-import type { CommandBuilder, CommandSchema, ErasedCommand } from '../schema/command.js';
-import { command } from '../schema/command.js';
-import type { FlagBuilder, FlagConfig } from '../schema/flag.js';
-import { flag } from '../schema/flag.js';
-import type { RunOptions, RunResult } from '../testkit/index.js';
-import { runCommand } from '../testkit/index.js';
-import { dispatch, findClosestCommand } from './dispatch.js';
-import { collectPropagatedFlags } from './propagate.js';
-import { formatRootHelp } from './root-help.js';
+import type { RuntimeAdapter } from '../../runtime/adapter.ts';
+import { createAdapter } from '../../runtime/auto.ts';
+import { generateCompletion, SHELLS } from '../completion/index.ts';
+import type { FormatLoader } from '../config/index.ts';
+import { discoverConfig } from '../config/index.ts';
+import { CLIError, ParseError } from '../errors/index.ts';
+import type { HelpOptions } from '../help/index.ts';
+import { formatHelp } from '../help/index.ts';
+import type { CapturedOutput, Verbosity } from '../output/index.ts';
+import { createCaptureOutput } from '../output/index.ts';
+import type { PromptEngine, TestAnswer } from '../prompt/index.ts';
+import { createTerminalPrompter } from '../prompt/index.ts';
+import type { ArgBuilder, ArgConfig } from '../schema/arg.ts';
+import type { CommandBuilder, CommandSchema, ErasedCommand } from '../schema/command.ts';
+import { command } from '../schema/command.ts';
+import type { FlagBuilder, FlagConfig } from '../schema/flag.ts';
+import { flag } from '../schema/flag.ts';
+import type { RunOptions, RunResult } from '../testkit/index.ts';
+import { runCommand } from '../testkit/index.ts';
+import { dispatch, findClosestCommand } from './dispatch.ts';
+import { collectPropagatedFlags } from './propagate.ts';
+import { formatRootHelp } from './root-help.ts';
 
 // ---------------------------------------------------------------------------
 // Type-erased command — erasure function (interface now in schema/command.ts)

--- a/src/core/cli/propagate.ts
+++ b/src/core/cli/propagate.ts
@@ -9,7 +9,7 @@
  * @module dreamcli/core/cli/propagate
  */
 
-import type { CommandSchema, FlagSchema } from '../schema/index.js';
+import type { CommandSchema, FlagSchema } from '../schema/index.ts';
 
 // ---------------------------------------------------------------------------
 // Propagated flag collection

--- a/src/core/cli/root-help.ts
+++ b/src/core/cli/root-help.ts
@@ -8,7 +8,7 @@
  * @internal
  */
 
-import type { HelpOptions } from '../help/index.js';
+import type { HelpOptions } from '../help/index.ts';
 
 // Re-use CLISchema inline to avoid circular import through the barrel.
 // Only the shape matters — we read `.name`, `.version`, `.description`, `.commands`.

--- a/src/core/completion/completion.test.ts
+++ b/src/core/completion/completion.test.ts
@@ -3,16 +3,16 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { CLISchema } from '../cli/index.js';
-import { isCLIError } from '../errors/index.js';
-import type { CommandSchema, FlagSchema } from '../schema/index.js';
-import type { CompletionOptions } from './index.js';
+import type { CLISchema } from '../cli/index.ts';
+import { isCLIError } from '../errors/index.ts';
+import type { CommandSchema, FlagSchema } from '../schema/index.ts';
+import type { CompletionOptions } from './index.ts';
 import {
 	generateBashCompletion,
 	generateCompletion,
 	generateZshCompletion,
 	SHELLS,
-} from './index.js';
+} from './index.ts';
 
 // ===================================================================
 // Test helpers

--- a/src/core/completion/index.ts
+++ b/src/core/completion/index.ts
@@ -9,10 +9,10 @@
  * @module dreamcli/core/completion
  */
 
-import type { CLISchema } from '../cli/index.js';
-import { collectPropagatedFlags } from '../cli/propagate.js';
-import { CLIError } from '../errors/index.js';
-import type { CommandSchema, FlagSchema } from '../schema/index.js';
+import type { CLISchema } from '../cli/index.ts';
+import { collectPropagatedFlags } from '../cli/propagate.ts';
+import { CLIError } from '../errors/index.ts';
+import type { CommandSchema, FlagSchema } from '../schema/index.ts';
 
 // ---------------------------------------------------------------------------
 // Shell type — supported completion targets

--- a/src/core/completion/index.ts
+++ b/src/core/completion/index.ts
@@ -36,10 +36,12 @@ type Shell = 'bash' | 'zsh' | 'fish' | 'powershell';
  *
  * @see {@link Shell} for the union type matching these entries.
  */
-const SHELLS = Object.freeze(['bash', 'zsh', 'fish', 'powershell'] as const satisfies readonly [
-	Shell,
-	...Shell[],
-]);
+const SHELLS: Readonly<readonly ['bash', 'zsh', 'fish', 'powershell']> = Object.freeze([
+	'bash',
+	'zsh',
+	'fish',
+	'powershell',
+] as const satisfies readonly [Shell, ...Shell[]]);
 
 // ---------------------------------------------------------------------------
 // CompletionOptions — generator configuration

--- a/src/core/config/config.test.ts
+++ b/src/core/config/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { CLIError } from '../errors/index.js';
-import type { ConfigAdapter, ConfigDiscoveryResult, FormatLoader } from './index.js';
-import { buildConfigSearchPaths, configFormat, discoverConfig } from './index.js';
+import { CLIError } from '../errors/index.ts';
+import type { ConfigAdapter, ConfigDiscoveryResult, FormatLoader } from './index.ts';
+import { buildConfigSearchPaths, configFormat, discoverConfig } from './index.ts';
 
 // ===================================================================
 // Test helpers

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -11,8 +11,8 @@
  * @module dreamcli/core/config
  */
 
-import type { RuntimeAdapter } from '../../runtime/adapter.js';
-import { CLIError } from '../errors/index.js';
+import type { RuntimeAdapter } from '../../runtime/adapter.ts';
+import { CLIError } from '../errors/index.ts';
 
 // ---------------------------------------------------------------------------
 // Types — format loaders

--- a/src/core/errors/errors.test.ts
+++ b/src/core/errors/errors.test.ts
@@ -6,7 +6,7 @@ import {
 	isValidationError,
 	ParseError,
 	ValidationError,
-} from './index.js';
+} from './index.ts';
 
 // ---------------------------------------------------------------------------
 // CLIError

--- a/src/core/help/help.test.ts
+++ b/src/core/help/help.test.ts
@@ -6,11 +6,11 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
 
-import { formatHelp } from './index.js';
+import { formatHelp } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/help/index.ts
+++ b/src/core/help/index.ts
@@ -14,7 +14,7 @@ import type {
 	CommandExample,
 	CommandSchema,
 	FlagSchema,
-} from '../schema/index.js';
+} from '../schema/index.ts';
 
 // ---------------------------------------------------------------------------
 // Configuration

--- a/src/core/output/AGENTS.md
+++ b/src/core/output/AGENTS.md
@@ -60,8 +60,8 @@ All activity handle output (static and TTY) routes to **stderr** — stdout rese
 
 ## GOTCHAS
 
-- Imports `schema/activity.ts` directly for activity types, `schema/command.ts` for `Out` — avoids
-  circular dep through barrel
+- Imports `schema/activity.ts` directly for activity types, `schema/command.ts` for `Out` — bypasses
+  barrel to avoid circular dep
 - `writer.ts` is a leaf: `WriteFn` type + `writeLine` helper. Shared by `index.ts` and `activity.ts`
 - Terminal escape sequences (`HIDE_CURSOR`, `ERASE_LINE`, etc.) are `@internal` constants in
   `activity.ts`

--- a/src/core/output/activity.ts
+++ b/src/core/output/activity.ts
@@ -20,9 +20,9 @@ import type {
 	ProgressHandle,
 	ProgressOptions,
 	SpinnerHandle,
-} from '../schema/activity.js';
-import type { WriteFn } from './writer.js';
-import { writeLine } from './writer.js';
+} from '../schema/activity.ts';
+import type { WriteFn } from './writer.ts';
+import { writeLine } from './writer.ts';
 
 // ---------------------------------------------------------------------------
 // Timer globals — minimal declarations for setInterval/clearInterval.

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -18,8 +18,8 @@ import type {
 	SpinnerHandle,
 	SpinnerOptions,
 	TableColumn,
-} from '../schema/activity.js';
-import type { Out } from '../schema/command.js';
+} from '../schema/activity.ts';
+import type { Out } from '../schema/command.ts';
 import {
 	CaptureProgressHandle,
 	CaptureSpinnerHandle,
@@ -29,9 +29,9 @@ import {
 	StaticSpinnerHandle,
 	TTYProgressHandle,
 	TTYSpinnerHandle,
-} from './activity.js';
-import type { WriteFn } from './writer.js';
-import { writeLine } from './writer.js';
+} from './activity.ts';
+import type { WriteFn } from './writer.ts';
+import { writeLine } from './writer.ts';
 
 // ---------------------------------------------------------------------------
 // Verbosity

--- a/src/core/output/output-activity-dispatch.test.ts
+++ b/src/core/output/output-activity-dispatch.test.ts
@@ -14,9 +14,9 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { command } from '../schema/command.js';
-import { runCommand } from '../testkit/index.js';
-import { createCaptureOutput, OutputChannel } from './index.js';
+import { command } from '../schema/command.ts';
+import { runCommand } from '../testkit/index.ts';
+import { createCaptureOutput, OutputChannel } from './index.ts';
 
 // --- Test helpers ---
 

--- a/src/core/output/output-progress.test.ts
+++ b/src/core/output/output-progress.test.ts
@@ -14,14 +14,14 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import type { ActivityEvent } from '../schema/activity.js';
-import type { WriteFn } from './index.js';
+import type { ActivityEvent } from '../schema/activity.ts';
+import type { WriteFn } from './index.ts';
 import {
 	CaptureProgressHandle,
 	noopProgressHandle,
 	StaticProgressHandle,
 	TTYProgressHandle,
-} from './index.js';
+} from './index.ts';
 
 // --- Test helpers ---
 

--- a/src/core/output/output-spinner.test.ts
+++ b/src/core/output/output-spinner.test.ts
@@ -14,14 +14,14 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import type { ActivityEvent } from '../schema/activity.js';
-import type { WriteFn } from './index.js';
+import type { ActivityEvent } from '../schema/activity.ts';
+import type { WriteFn } from './index.ts';
 import {
 	CaptureSpinnerHandle,
 	noopSpinnerHandle,
 	StaticSpinnerHandle,
 	TTYSpinnerHandle,
-} from './index.js';
+} from './index.ts';
 
 // --- Test helpers ---
 

--- a/src/core/output/output-table.test.ts
+++ b/src/core/output/output-table.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createCaptureOutput } from './index.js';
+import { createCaptureOutput } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // table() — TTY (non-JSON) mode

--- a/src/core/output/output-tty.test.ts
+++ b/src/core/output/output-tty.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { Out } from '../schema/command.js';
-import { createCaptureOutput, createOutput, OutputChannel } from './index.js';
+import type { Out } from '../schema/command.ts';
+import { createCaptureOutput, createOutput, OutputChannel } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // isTTY on Out interface

--- a/src/core/output/output.test.ts
+++ b/src/core/output/output.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import type { Out } from '../schema/command.js';
-import type { CapturedOutput, OutputOptions, Verbosity, WriteFn } from './index.js';
-import { createCaptureOutput, createOutput, OutputChannel } from './index.js';
+import type { Out } from '../schema/command.ts';
+import type { CapturedOutput, OutputOptions, Verbosity, WriteFn } from './index.ts';
+import { createCaptureOutput, createOutput, OutputChannel } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // createOutput — factory

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -13,8 +13,8 @@
  * @module dreamcli/core/parse
  */
 
-import { ParseError } from '../errors/index.js';
-import type { ArgSchema, CommandArgEntry, CommandSchema, FlagSchema } from '../schema/index.js';
+import { ParseError } from '../errors/index.ts';
+import type { ArgSchema, CommandArgEntry, CommandSchema, FlagSchema } from '../schema/index.ts';
 
 // ---------------------------------------------------------------------------
 // Tokenizer — schema-agnostic argv splitting

--- a/src/core/parse/parse.test.ts
+++ b/src/core/parse/parse.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { ParseError } from '../errors/index.js';
-import { createArgSchema } from '../schema/arg.js';
-import type { CommandSchema } from '../schema/command.js';
-import { createSchema } from '../schema/flag.js';
-import { parse, tokenize } from './index.js';
+import { ParseError } from '../errors/index.ts';
+import { createArgSchema } from '../schema/arg.ts';
+import type { CommandSchema } from '../schema/command.ts';
+import { createSchema } from '../schema/flag.ts';
+import { parse, tokenize } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers — build minimal CommandSchema for testing

--- a/src/core/prompt/index.ts
+++ b/src/core/prompt/index.ts
@@ -18,14 +18,14 @@
  * @module dreamcli/core/prompt
  */
 
-import type { WriteFn } from '../output/index.js';
+import type { WriteFn } from '../output/index.ts';
 import type {
 	ConfirmPromptConfig,
 	InputPromptConfig,
 	PromptConfig,
 	PromptResult,
 	SelectChoice,
-} from '../schema/prompt.js';
+} from '../schema/prompt.ts';
 
 // ---------------------------------------------------------------------------
 // Resolved prompt config — choices guaranteed present for select kinds

--- a/src/core/prompt/prompt.test.ts
+++ b/src/core/prompt/prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import type { PromptResult, SelectChoice } from '../schema/prompt.js';
+import type { PromptResult, SelectChoice } from '../schema/prompt.ts';
 import type {
 	PromptEngine,
 	ReadFn,
@@ -8,13 +8,13 @@ import type {
 	ResolvedSelectPromptConfig,
 	TestAnswer,
 	TestPrompterOptions,
-} from './index.js';
+} from './index.ts';
 import {
 	createTerminalPrompter,
 	createTestPrompter,
 	PROMPT_CANCEL,
 	resolvePromptConfig,
-} from './index.js';
+} from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/resolve/index.ts
+++ b/src/core/resolve/index.ts
@@ -15,18 +15,18 @@
  * @module dreamcli/core/resolve
  */
 
-import type { ValidationErrorCode } from '../errors/index.js';
-import { ValidationError } from '../errors/index.js';
-import type { ParseResult } from '../parse/index.js';
-import type { PromptEngine } from '../prompt/index.js';
-import { resolvePromptConfig } from '../prompt/index.js';
+import type { ValidationErrorCode } from '../errors/index.ts';
+import { ValidationError } from '../errors/index.ts';
+import type { ParseResult } from '../parse/index.ts';
+import type { PromptEngine } from '../prompt/index.ts';
+import { resolvePromptConfig } from '../prompt/index.ts';
 import type {
 	CommandArgEntry,
 	CommandSchema,
 	ErasedInteractiveResolver,
 	FlagSchema,
-} from '../schema/index.js';
-import type { PromptConfig } from '../schema/prompt.js';
+} from '../schema/index.ts';
+import type { PromptConfig } from '../schema/prompt.ts';
 
 // ---------------------------------------------------------------------------
 // Resolve options — injectable external state for the resolution chain

--- a/src/core/resolve/resolve-config.test.ts
+++ b/src/core/resolve/resolve-config.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isValidationError, ValidationError } from '../errors/index.js';
-import type { ParseResult } from '../parse/index.js';
-import type { CommandSchema } from '../schema/command.js';
-import { createSchema } from '../schema/flag.js';
-import type { ResolveOptions } from './index.js';
-import { resolve } from './index.js';
+import { isValidationError, ValidationError } from '../errors/index.ts';
+import type { ParseResult } from '../parse/index.ts';
+import type { CommandSchema } from '../schema/command.ts';
+import { createSchema } from '../schema/flag.ts';
+import type { ResolveOptions } from './index.ts';
+import { resolve } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/resolve/resolve-env.test.ts
+++ b/src/core/resolve/resolve-env.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isValidationError, ValidationError } from '../errors/index.js';
-import type { ParseResult } from '../parse/index.js';
-import type { CommandSchema } from '../schema/command.js';
-import { createSchema } from '../schema/flag.js';
-import type { ResolveOptions } from './index.js';
-import { resolve } from './index.js';
+import { isValidationError, ValidationError } from '../errors/index.ts';
+import type { ParseResult } from '../parse/index.ts';
+import type { CommandSchema } from '../schema/command.ts';
+import { createSchema } from '../schema/flag.ts';
+import type { ResolveOptions } from './index.ts';
+import { resolve } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/resolve/resolve-errors.test.ts
+++ b/src/core/resolve/resolve-errors.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { isValidationError, type ValidationError } from '../errors/index.js';
-import type { ParseResult } from '../parse/index.js';
-import type { CommandSchema } from '../schema/command.js';
-import { createSchema } from '../schema/flag.js';
-import { resolve } from './index.js';
+import { isValidationError, type ValidationError } from '../errors/index.ts';
+import type { ParseResult } from '../parse/index.ts';
+import type { CommandSchema } from '../schema/command.ts';
+import { createSchema } from '../schema/flag.ts';
+import { resolve } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/resolve/resolve-integration.test.ts
+++ b/src/core/resolve/resolve-integration.test.ts
@@ -6,11 +6,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { cli } from '../cli/index.js';
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { runCommand } from '../testkit/index.js';
+import { cli } from '../cli/index.ts';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { runCommand } from '../testkit/index.ts';
 
 // ---------------------------------------------------------------------------
 // Test commands

--- a/src/core/resolve/resolve-interactive.test.ts
+++ b/src/core/resolve/resolve-interactive.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
-import { ValidationError } from '../errors/index.js';
-import type { ParseResult } from '../parse/index.js';
-import { createTestPrompter, PROMPT_CANCEL } from '../prompt/index.js';
-import type { CommandSchema, InteractiveParams } from '../schema/command.js';
-import { command } from '../schema/command.js';
-import type { FlagBuilder, FlagConfig } from '../schema/flag.js';
-import { createSchema, flag } from '../schema/flag.js';
-import { resolve } from './index.js';
+import { ValidationError } from '../errors/index.ts';
+import type { ParseResult } from '../parse/index.ts';
+import { createTestPrompter, PROMPT_CANCEL } from '../prompt/index.ts';
+import type { CommandSchema, InteractiveParams } from '../schema/command.ts';
+import { command } from '../schema/command.ts';
+import type { FlagBuilder, FlagConfig } from '../schema/flag.ts';
+import { createSchema, flag } from '../schema/flag.ts';
+import { resolve } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -7,13 +7,13 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ValidationError } from '../errors/index.js';
-import type { ParseResult } from '../parse/index.js';
-import { createTestPrompter, PROMPT_CANCEL } from '../prompt/index.js';
-import type { CommandSchema } from '../schema/index.js';
-import { createSchema } from '../schema/index.js';
-import type { ResolveOptions } from './index.js';
-import { resolve } from './index.js';
+import { ValidationError } from '../errors/index.ts';
+import type { ParseResult } from '../parse/index.ts';
+import { createTestPrompter, PROMPT_CANCEL } from '../prompt/index.ts';
+import type { CommandSchema } from '../schema/index.ts';
+import { createSchema } from '../schema/index.ts';
+import type { ResolveOptions } from './index.ts';
+import { resolve } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/resolve/resolve.test.ts
+++ b/src/core/resolve/resolve.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isValidationError, ValidationError } from '../errors/index.js';
-import type { ParseResult } from '../parse/index.js';
-import { createArgSchema } from '../schema/arg.js';
-import type { CommandSchema } from '../schema/command.js';
-import { createSchema } from '../schema/flag.js';
-import { resolve } from './index.js';
+import { isValidationError, ValidationError } from '../errors/index.ts';
+import type { ParseResult } from '../parse/index.ts';
+import { createArgSchema } from '../schema/arg.ts';
+import type { CommandSchema } from '../schema/command.ts';
+import { createSchema } from '../schema/flag.ts';
+import { resolve } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers — build minimal schemas and parse results

--- a/src/core/schema/AGENTS.md
+++ b/src/core/schema/AGENTS.md
@@ -34,12 +34,12 @@ Only multi-file module in `core/`. All others use single `index.ts`.
 - **Activity types** (`activity.ts`): `ActivityEvent` (10-variant DU), `SpinnerHandle`,
   `ProgressHandle`, `SpinnerOptions`, `ProgressOptions`, `Fallback`, `TableColumn`
 - **Output interface** (`command.ts`): `Out` (~110 lines JSDoc + signatures) — imports activity
-  types from `./activity.js`
+  types from `./activity.ts`
 - **Command schema** (`command.ts`): `CommandSchema`, `ErasedCommand`, `ActionHandler`,
   `ActionParams`, `InteractiveResolver`, `CommandExample`, etc.
 
 Activity types live in `activity.ts` (still in schema/, not in output/) because `Out` needs them in
-`CommandBuilder.action()` signature. `command.ts` imports them from `./activity.js`.
+`CommandBuilder.action()` signature. `command.ts` imports them from `./activity.ts`.
 
 ## ADDING A FLAG TYPE
 

--- a/src/core/schema/arg.test.ts
+++ b/src/core/schema/arg.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import type { ArgSchema, InferArg, InferArgs } from './arg.js';
-import { ArgBuilder, arg } from './arg.js';
+import type { ArgSchema, InferArg, InferArgs } from './arg.ts';
+import { ArgBuilder, arg } from './arg.ts';
 
 /** Test-only wrapper for custom parse validation. */
 interface ParsedPath {

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
-import { arg } from './arg.js';
-import type { ActionParams, CommandArgEntry, CommandSchema, Out } from './command.js';
-import { CommandBuilder, command, group } from './command.js';
-import { flag } from './flag.js';
-import { middleware } from './middleware.js';
+import { arg } from './arg.ts';
+import type { ActionParams, CommandArgEntry, CommandSchema, Out } from './command.ts';
+import { CommandBuilder, command, group } from './command.ts';
+import { flag } from './flag.ts';
+import { middleware } from './middleware.ts';
 
 // ---------------------------------------------------------------------------
 // Factory function

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -9,18 +9,18 @@
  * @module dreamcli/core/schema/command
  */
 
-import type { RunOptions, RunResult } from '../testkit/index.js';
+import type { RunOptions, RunResult } from '../testkit/index.ts';
 import type {
 	ProgressHandle,
 	ProgressOptions,
 	SpinnerHandle,
 	SpinnerOptions,
 	TableColumn,
-} from './activity.js';
-import type { ArgBuilder, ArgConfig, ArgSchema, InferArgs } from './arg.js';
-import type { FlagBuilder, FlagConfig, FlagSchema, InferFlags } from './flag.js';
-import type { ErasedMiddlewareHandler, Middleware } from './middleware.js';
-import type { PromptConfig } from './prompt.js';
+} from './activity.ts';
+import type { ArgBuilder, ArgConfig, ArgSchema, InferArgs } from './arg.ts';
+import type { FlagBuilder, FlagConfig, FlagSchema, InferFlags } from './flag.ts';
+import type { ErasedMiddlewareHandler, Middleware } from './middleware.ts';
+import type { PromptConfig } from './prompt.ts';
 
 // ---------------------------------------------------------------------------
 // Context type utilities

--- a/src/core/schema/flag.test.ts
+++ b/src/core/schema/flag.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import type { FlagSchema, InferFlag, InferFlags } from './flag.js';
-import { FlagBuilder, flag } from './flag.js';
+import type { FlagSchema, InferFlag, InferFlags } from './flag.ts';
+import { FlagBuilder, flag } from './flag.ts';
 
 // ---------------------------------------------------------------------------
 // Factory functions — runtime schema

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -9,7 +9,7 @@
  * @module dreamcli/core/schema/flag
  */
 
-import type { PromptConfig } from './prompt.js';
+import type { PromptConfig } from './prompt.ts';
 
 // ---------------------------------------------------------------------------
 // Type-level configuration (phantom state tracked through the chain)
@@ -452,4 +452,4 @@ export type {
 	PromptResult,
 	SelectChoice,
 	SelectPromptConfig,
-} from './prompt.js';
+} from './prompt.ts';

--- a/src/core/schema/index.ts
+++ b/src/core/schema/index.ts
@@ -12,7 +12,7 @@ export type {
 	SpinnerHandle,
 	SpinnerOptions,
 	TableColumn,
-} from './activity.js';
+} from './activity.ts';
 export type {
 	ArgConfig,
 	ArgFactory,
@@ -25,8 +25,8 @@ export type {
 	ResolvedArgValue,
 	WithArgPresence,
 	WithVariadic,
-} from './arg.js';
-export { ArgBuilder, arg, createArgSchema } from './arg.js';
+} from './arg.ts';
+export { ArgBuilder, arg, createArgSchema } from './arg.ts';
 export type {
 	ActionHandler,
 	ActionParams,
@@ -41,8 +41,8 @@ export type {
 	InteractiveResolver,
 	InteractiveResult,
 	Out,
-} from './command.js';
-export { CommandBuilder, command, group } from './command.js';
+} from './command.ts';
+export { CommandBuilder, command, group } from './command.ts';
 export type {
 	ConfirmPromptConfig,
 	FlagConfig,
@@ -63,12 +63,12 @@ export type {
 	SelectChoice,
 	SelectPromptConfig,
 	WithPresence,
-} from './flag.js';
-export { createSchema, FlagBuilder, flag } from './flag.js';
+} from './flag.ts';
+export { createSchema, FlagBuilder, flag } from './flag.ts';
 export type {
 	ErasedMiddlewareHandler,
 	Middleware,
 	MiddlewareHandler,
 	MiddlewareParams,
-} from './middleware.js';
-export { middleware } from './middleware.js';
+} from './middleware.ts';
+export { middleware } from './middleware.ts';

--- a/src/core/schema/middleware.test.ts
+++ b/src/core/schema/middleware.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
-import { CLIError } from '../errors/index.js';
-import { runCommand } from '../testkit/index.js';
-import { arg } from './arg.js';
-import { command } from './command.js';
-import { flag } from './flag.js';
-import { middleware } from './middleware.js';
+import { CLIError } from '../errors/index.ts';
+import { runCommand } from '../testkit/index.ts';
+import { arg } from './arg.ts';
+import { command } from './command.ts';
+import { flag } from './flag.ts';
+import { middleware } from './middleware.ts';
 
 // ---------------------------------------------------------------------------
 // Factory function

--- a/src/core/schema/middleware.ts
+++ b/src/core/schema/middleware.ts
@@ -14,7 +14,7 @@
  * @module dreamcli/core/schema/middleware
  */
 
-import type { Out } from './command.js';
+import type { Out } from './command.ts';
 
 // ---------------------------------------------------------------------------
 // Middleware parameter types

--- a/src/core/schema/prompt.test.ts
+++ b/src/core/schema/prompt.test.ts
@@ -10,8 +10,8 @@ import type {
 	PromptResult,
 	SelectChoice,
 	SelectPromptConfig,
-} from './flag.js';
-import { flag } from './flag.js';
+} from './flag.ts';
+import { flag } from './flag.ts';
 
 // ---------------------------------------------------------------------------
 // PromptConfig discriminated union — type-level tests
@@ -390,7 +390,7 @@ describe('command builder with prompted flags', () => {
 	// Importing here to avoid circular — these tests validate integration
 	// but the command module doesn't need to know about prompts
 	it('command with prompted flags compiles and builds schema', async () => {
-		const { command } = await import('./command.js');
+		const { command } = await import('./command.ts');
 
 		const deploy = command('deploy')
 			.flag(
@@ -424,14 +424,14 @@ describe('command builder with prompted flags', () => {
 
 describe('public surface exports', () => {
 	it('prompt types are re-exported from schema barrel', async () => {
-		const schema = await import('./index.js');
+		const schema = await import('./index.ts');
 		// Type-only exports can't be checked at runtime, but we can verify
 		// the module loads without errors and the re-exports compile
 		expect(schema).toBeDefined();
 	});
 
 	it('prompt types are re-exported from public surface', async () => {
-		const dreamcli = await import('../../index.js');
+		const dreamcli = await import('../../index.ts');
 		expect(dreamcli).toBeDefined();
 	});
 });

--- a/src/core/testkit/AGENTS.md
+++ b/src/core/testkit/AGENTS.md
@@ -52,4 +52,4 @@ captured output. Calls `out.stopActive()` in `finally` to clean up leaked spinne
 - `mergedSchema` field on `RunOptions` is `@internal` — used by CLI dispatch layer only
 - `CaptureOutputChannel` (from output/) wired here for output + activity capture
 - `formatRootHelp()` (in `cli/root-help.ts`) re-exported as `@internal` for CLI-level help rendering
-- Direct imports: `schema/command.js`, `schema/flag.js`, `schema/arg.js` (not through barrel)
+- Direct imports: `schema/command.ts`, `schema/flag.ts`, `schema/arg.ts` (not through barrel)

--- a/src/core/testkit/index.ts
+++ b/src/core/testkit/index.ts
@@ -12,20 +12,20 @@
  * @module dreamcli/core/testkit
  */
 
-import { CLIError } from '../errors/index.js';
-import type { HelpOptions } from '../help/index.js';
-import { formatHelp } from '../help/index.js';
-import type { CapturedOutput, Verbosity } from '../output/index.js';
-import { createCaptureOutput } from '../output/index.js';
-import { parse } from '../parse/index.js';
-import type { PromptEngine, TestAnswer } from '../prompt/index.js';
-import { createTestPrompter } from '../prompt/index.js';
-import type { DeprecationWarning, ResolveOptions } from '../resolve/index.js';
-import { resolve } from '../resolve/index.js';
-import type { ActivityEvent } from '../schema/activity.js';
-import type { ArgBuilder, ArgConfig } from '../schema/arg.js';
-import type { ActionHandler, CommandBuilder, CommandSchema, Out } from '../schema/command.js';
-import type { FlagBuilder, FlagConfig } from '../schema/flag.js';
+import { CLIError } from '../errors/index.ts';
+import type { HelpOptions } from '../help/index.ts';
+import { formatHelp } from '../help/index.ts';
+import type { CapturedOutput, Verbosity } from '../output/index.ts';
+import { createCaptureOutput } from '../output/index.ts';
+import { parse } from '../parse/index.ts';
+import type { PromptEngine, TestAnswer } from '../prompt/index.ts';
+import { createTestPrompter } from '../prompt/index.ts';
+import type { DeprecationWarning, ResolveOptions } from '../resolve/index.ts';
+import { resolve } from '../resolve/index.ts';
+import type { ActivityEvent } from '../schema/activity.ts';
+import type { ArgBuilder, ArgConfig } from '../schema/arg.ts';
+import type { ActionHandler, CommandBuilder, CommandSchema, Out } from '../schema/command.ts';
+import type { FlagBuilder, FlagConfig } from '../schema/flag.ts';
 
 // ---------------------------------------------------------------------------
 // Internal types

--- a/src/core/testkit/middleware-context-e2e.test.ts
+++ b/src/core/testkit/middleware-context-e2e.test.ts
@@ -15,13 +15,13 @@
  */
 
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
-import { cli } from '../cli/index.js';
-import { CLIError } from '../errors/index.js';
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { middleware } from '../schema/middleware.js';
-import { runCommand } from './index.js';
+import { cli } from '../cli/index.ts';
+import { CLIError } from '../errors/index.ts';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { middleware } from '../schema/middleware.ts';
+import { runCommand } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Shared middleware definitions — realistic patterns

--- a/src/core/testkit/output-e2e.test.ts
+++ b/src/core/testkit/output-e2e.test.ts
@@ -15,13 +15,13 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { cli } from '../cli/index.js';
-import { CLIError } from '../errors/index.js';
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { middleware } from '../schema/middleware.js';
-import { runCommand } from './index.js';
+import { cli } from '../cli/index.ts';
+import { CLIError } from '../errors/index.ts';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { middleware } from '../schema/middleware.ts';
+import { runCommand } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Reusable test commands

--- a/src/core/testkit/testkit-json.test.ts
+++ b/src/core/testkit/testkit-json.test.ts
@@ -3,10 +3,10 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { CLIError } from '../errors/index.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { runCommand } from './index.js';
+import { CLIError } from '../errors/index.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { runCommand } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/testkit/testkit-nesting.test.ts
+++ b/src/core/testkit/testkit-nesting.test.ts
@@ -7,12 +7,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { cli } from '../cli/index.js';
-import { arg } from '../schema/arg.js';
-import { command, group } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { middleware } from '../schema/middleware.js';
-import { runCommand } from './index.js';
+import { cli } from '../cli/index.ts';
+import { arg } from '../schema/arg.ts';
+import { command, group } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { middleware } from '../schema/middleware.ts';
+import { runCommand } from './index.ts';
 
 // ===================================================================
 // Helpers

--- a/src/core/testkit/testkit-prompt.test.ts
+++ b/src/core/testkit/testkit-prompt.test.ts
@@ -7,12 +7,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { cli } from '../cli/index.js';
-import { createTestPrompter, PROMPT_CANCEL } from '../prompt/index.js';
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { runCommand } from './index.js';
+import { cli } from '../cli/index.ts';
+import { createTestPrompter, PROMPT_CANCEL } from '../prompt/index.ts';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { runCommand } from './index.ts';
 
 // ========================================================================
 // runCommand — answers convenience field

--- a/src/core/testkit/testkit-tty.test.ts
+++ b/src/core/testkit/testkit-tty.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { command } from '../schema/command.js';
-import { runCommand } from './index.js';
+import { command } from '../schema/command.ts';
+import { runCommand } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/testkit/testkit.test.ts
+++ b/src/core/testkit/testkit.test.ts
@@ -3,11 +3,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { CLIError, ValidationError } from '../errors/index.js';
-import { arg } from '../schema/arg.js';
-import { command } from '../schema/command.js';
-import { flag } from '../schema/flag.js';
-import { runCommand } from './index.js';
+import { CLIError, ValidationError } from '../errors/index.ts';
+import { arg } from '../schema/arg.ts';
+import { command } from '../schema/command.ts';
+import { flag } from '../schema/flag.ts';
+import { runCommand } from './index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 describe('dreamcli', () => {
 	it('module loads without error', async () => {
-		const mod = await import('./index.js');
+		const mod = await import('./index.ts');
 		expect(mod).toBeDefined();
 	});
 });
@@ -11,7 +11,7 @@ describe('dreamcli', () => {
 
 describe('dreamcli/testkit — module loads', () => {
 	it('module loads without error', async () => {
-		const mod = await import('./testkit.js');
+		const mod = await import('./testkit.ts');
 		expect(mod).toBeDefined();
 	});
 });
@@ -20,29 +20,29 @@ describe('dreamcli/testkit — module loads', () => {
 
 describe('dreamcli/runtime — module loads', () => {
 	it('module loads without error', async () => {
-		const mod = await import('./runtime.js');
+		const mod = await import('./runtime.ts');
 		expect(mod).toBeDefined();
 	});
 });
 
 describe('project structure', () => {
 	const coreModules = [
-		'./core/errors/index.js',
-		'./core/schema/index.js',
-		'./core/parse/index.js',
-		'./core/resolve/index.js',
-		'./core/help/index.js',
-		'./core/completion/index.js',
-		'./core/output/index.js',
-		'./core/testkit/index.js',
+		'./core/errors/index.ts',
+		'./core/schema/index.ts',
+		'./core/parse/index.ts',
+		'./core/resolve/index.ts',
+		'./core/help/index.ts',
+		'./core/completion/index.ts',
+		'./core/output/index.ts',
+		'./core/testkit/index.ts',
 	] as const;
 
 	const runtimeModules = [
-		'./runtime/adapter.js',
-		'./runtime/detect.js',
-		'./runtime/node.js',
-		'./runtime/bun.js',
-		'./runtime/deno.js',
+		'./runtime/adapter.ts',
+		'./runtime/detect.ts',
+		'./runtime/node.ts',
+		'./runtime/bun.ts',
+		'./runtime/deno.ts',
 	] as const;
 
 	for (const path of coreModules) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,15 @@
  * @module dreamcli
  */
 
-export type { CLIRunOptions, CLISchema, ConfigSettings } from './core/cli/index.js';
-export { CLIBuilder, cli } from './core/cli/index.js';
-export type { CompletionOptions, Shell } from './core/completion/index.js';
+export type { CLIRunOptions, CLISchema, ConfigSettings } from './core/cli/index.ts';
+export { CLIBuilder, cli } from './core/cli/index.ts';
+export type { CompletionOptions, Shell } from './core/completion/index.ts';
 export {
 	generateBashCompletion,
 	generateCompletion,
 	generateZshCompletion,
 	SHELLS,
-} from './core/completion/index.js';
+} from './core/completion/index.ts';
 export type {
 	ConfigAdapter,
 	ConfigDiscoveryOptions,
@@ -24,8 +24,8 @@ export type {
 	ConfigFound,
 	ConfigNotFound,
 	FormatLoader,
-} from './core/config/index.js';
-export { buildConfigSearchPaths, configFormat, discoverConfig } from './core/config/index.js';
+} from './core/config/index.ts';
+export { buildConfigSearchPaths, configFormat, discoverConfig } from './core/config/index.ts';
 export type {
 	CLIErrorJSON,
 	CLIErrorOptions,
@@ -34,7 +34,7 @@ export type {
 	ParseErrorOptions,
 	ValidationErrorCode,
 	ValidationErrorOptions,
-} from './core/errors/index.js';
+} from './core/errors/index.ts';
 export {
 	CLIError,
 	isCLIError,
@@ -42,23 +42,23 @@ export {
 	isValidationError,
 	ParseError,
 	ValidationError,
-} from './core/errors/index.js';
-export type { HelpOptions } from './core/help/index.js';
-export { formatHelp } from './core/help/index.js';
-export type { OutputOptions, Verbosity, WriteFn } from './core/output/index.js';
-export { createOutput } from './core/output/index.js';
-export type { ParseResult, Token } from './core/parse/index.js';
-export { parse, tokenize } from './core/parse/index.js';
+} from './core/errors/index.ts';
+export type { HelpOptions } from './core/help/index.ts';
+export { formatHelp } from './core/help/index.ts';
+export type { OutputOptions, Verbosity, WriteFn } from './core/output/index.ts';
+export { createOutput } from './core/output/index.ts';
+export type { ParseResult, Token } from './core/parse/index.ts';
+export { parse, tokenize } from './core/parse/index.ts';
 export type {
 	PromptEngine,
 	ReadFn,
 	ResolvedMultiselectPromptConfig,
 	ResolvedPromptConfig,
 	ResolvedSelectPromptConfig,
-} from './core/prompt/index.js';
-export { createTerminalPrompter, resolvePromptConfig } from './core/prompt/index.js';
-export type { DeprecationWarning, ResolveOptions, ResolveResult } from './core/resolve/index.js';
-export { resolve } from './core/resolve/index.js';
+} from './core/prompt/index.ts';
+export { createTerminalPrompter, resolvePromptConfig } from './core/prompt/index.ts';
+export type { DeprecationWarning, ResolveOptions, ResolveResult } from './core/resolve/index.ts';
+export { resolve } from './core/resolve/index.ts';
 export type {
 	ActionHandler,
 	ActionParams,
@@ -114,7 +114,7 @@ export type {
 	WithArgPresence,
 	WithPresence,
 	WithVariadic,
-} from './core/schema/index.js';
+} from './core/schema/index.ts';
 export {
 	ArgBuilder,
 	arg,
@@ -126,4 +126,4 @@ export {
 	flag,
 	group,
 	middleware,
-} from './core/schema/index.js';
+} from './core/schema/index.ts';

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,7 +13,7 @@ export type {
 	NodeProcess,
 	Runtime,
 	RuntimeAdapter,
-} from './runtime/index.js';
+} from './runtime/index.ts';
 export {
 	createAdapter,
 	createBunAdapter,
@@ -22,4 +22,4 @@ export {
 	detectRuntime,
 	ExitError,
 	RUNTIMES,
-} from './runtime/index.js';
+} from './runtime/index.ts';

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7,10 +7,17 @@
  * @module dreamcli/runtime
  */
 
-export type { GlobalForDetect, NodeProcess, Runtime, RuntimeAdapter } from './runtime/index.js';
+export type {
+	DenoNamespace,
+	GlobalForDetect,
+	NodeProcess,
+	Runtime,
+	RuntimeAdapter,
+} from './runtime/index.js';
 export {
 	createAdapter,
 	createBunAdapter,
+	createDenoAdapter,
 	createNodeAdapter,
 	detectRuntime,
 	ExitError,

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -12,10 +12,10 @@ adapter factories, `ExitError`, detection. `createTestAdapter`/`TestAdapterOptio
 | File                 | Status     | Lines | Purpose                                                                |
 | -------------------- | ---------- | ----: | ---------------------------------------------------------------------- |
 | `adapter.ts`         | **Active** |   120 | `RuntimeAdapter` interface — process/env/IO abstraction                |
-| `auto.ts`            | **Active** |    35 | `createAdapter()` — auto-detecting adapter factory                     |
+| `auto.ts`            | **Active** |    64 | `createAdapter()` — auto-detecting adapter factory                     |
 | `node.ts`            | **Active** |   230 | `createNodeAdapter()` — Node.js implementation                         |
 | `bun.ts`             | **Active** |    20 | `createBunAdapter()` — delegates to Node adapter                       |
-| `deno.ts`            | **Active** |   300 | `createDenoAdapter()` — Deno namespace implementation                  |
+| `deno.ts`            | **Active** |   318 | `createDenoAdapter()` — Deno namespace implementation                  |
 | `detect.ts`          | **Active** |    90 | `detectRuntime()` — Bun/Deno/Node feature detection                    |
 | `node-builtins.d.ts` | Types      |    45 | `@internal` — ambient decls for `node:readline`, `node:fs/promises`    |
 | `deno-builtins.d.ts` | Types      |    30 | `@internal` — ambient decls for TextEncoder/TextDecoder/ReadableStream |

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -9,16 +9,17 @@ adapter factories, `ExitError`, detection. `createTestAdapter`/`TestAdapterOptio
 
 ## FILES
 
-| File                 | Status     | Lines | Purpose                                                             |
-| -------------------- | ---------- | ----: | ------------------------------------------------------------------- |
-| `adapter.ts`         | **Active** |   120 | `RuntimeAdapter` interface — process/env/IO abstraction             |
-| `auto.ts`            | **Active** |    35 | `createAdapter()` — auto-detecting adapter factory                  |
-| `node.ts`            | **Active** |   230 | `createNodeAdapter()` — Node.js implementation                      |
-| `bun.ts`             | **Active** |    20 | `createBunAdapter()` — delegates to Node adapter                    |
-| `deno.ts`            | STUB       |     4 | `export {}` — planned Deno adapter                                  |
-| `detect.ts`          | **Active** |    90 | `detectRuntime()` — Bun/Deno/Node feature detection                 |
-| `node-builtins.d.ts` | Types      |    45 | `@internal` — ambient decls for `node:readline`, `node:fs/promises` |
-| `index.ts`           | Barrel     |    30 | Re-exports `RuntimeAdapter`, adapters, `ExitError`                  |
+| File                 | Status     | Lines | Purpose                                                                |
+| -------------------- | ---------- | ----: | ---------------------------------------------------------------------- |
+| `adapter.ts`         | **Active** |   120 | `RuntimeAdapter` interface — process/env/IO abstraction                |
+| `auto.ts`            | **Active** |    35 | `createAdapter()` — auto-detecting adapter factory                     |
+| `node.ts`            | **Active** |   230 | `createNodeAdapter()` — Node.js implementation                         |
+| `bun.ts`             | **Active** |    20 | `createBunAdapter()` — delegates to Node adapter                       |
+| `deno.ts`            | **Active** |   300 | `createDenoAdapter()` — Deno namespace implementation                  |
+| `detect.ts`          | **Active** |    90 | `detectRuntime()` — Bun/Deno/Node feature detection                    |
+| `node-builtins.d.ts` | Types      |    45 | `@internal` — ambient decls for `node:readline`, `node:fs/promises`    |
+| `deno-builtins.d.ts` | Types      |    30 | `@internal` — ambient decls for TextEncoder/TextDecoder/ReadableStream |
+| `index.ts`           | Barrel     |    30 | Re-exports `RuntimeAdapter`, adapters, `ExitError`                     |
 
 ## `RuntimeAdapter` INTERFACE
 
@@ -46,13 +47,14 @@ joinPath(...segments: string[]): string
 4. Wire auto-detection in `auto.ts`
 5. Re-export from `src/runtime.ts`
 
-## TEST FILES (4)
+## TEST FILES (5)
 
 | File              | Tests                                                     |
 | ----------------- | --------------------------------------------------------- |
 | `runtime.test.ts` | Node adapter, test adapter, `ExitError`, adapter contract |
 | `detect.test.ts`  | Runtime detection logic (globalThis feature probing)      |
 | `bun.test.ts`     | Bun adapter delegation                                    |
+| `deno.test.ts`    | Deno adapter (mock namespace, permission handling, stdin) |
 | `auto.test.ts`    | Auto-detecting adapter factory                            |
 
 ## GOTCHAS
@@ -65,3 +67,9 @@ joinPath(...segments: string[]): string
 - Empty-string env var fallbacks treated as unset in `node.ts`
 - Win32 paths: `resolveConfigDir` strips trailing separator, `resolveHomedir` has
   `HOMEDRIVE`+`HOMEPATH` fallback
+- `deno.ts` has 7 `@internal` symbols: `DenoNamespace`, `isDenoErrorNamed`, `safeEnvToObject`,
+  `safeCwd`, `getDenoNamespace`, `readDenoStdinLine`, `resolveDenoHomedir`, `resolveDenoConfigDir`
+- Deno.args pre-strips binary/script — adapter prepends synthetic `['deno', 'run']` for argv parity
+- Permission-safe: env/cwd catch `PermissionDenied`, readFile returns null for both `NotFound` and
+  `PermissionDenied`
+- `deno-builtins.d.ts` needed because `lib: ["ES2022"]` excludes web platform APIs

--- a/src/runtime/adapter.ts
+++ b/src/runtime/adapter.ts
@@ -9,8 +9,8 @@
  * @module dreamcli/runtime/adapter
  */
 
-import type { WriteFn } from '../core/output/index.js';
-import type { ReadFn } from '../core/prompt/index.js';
+import type { WriteFn } from '../core/output/index.ts';
+import type { ReadFn } from '../core/prompt/index.ts';
 
 // ---------------------------------------------------------------------------
 // Runtime adapter interface — the single platform abstraction boundary

--- a/src/runtime/auto.test.ts
+++ b/src/runtime/auto.test.ts
@@ -7,8 +7,7 @@
  * not internal implementation details.
  */
 
-import { describe, expect, it } from 'vitest';
-import { CLIError, isCLIError } from '../core/errors/index.js';
+import { describe, expect, it, vi } from 'vitest';
 import type { RuntimeAdapter } from './adapter.js';
 import { createAdapter } from './auto.js';
 import type { GlobalForDetect } from './detect.js';
@@ -17,6 +16,46 @@ import { RUNTIMES } from './detect.js';
 // ===================================================================
 // Helpers
 // ===================================================================
+
+/**
+ * Install a minimal mock Deno namespace on globalThis for the duration of `fn`.
+ *
+ * `createDenoAdapter()` reads from `globalThis.Deno` when no explicit
+ * namespace is provided. In vitest (Node), there is no real Deno global,
+ * so Deno-path tests in `createAdapter` must install a mock temporarily.
+ */
+function withMockDenoGlobal<T>(fn: () => T): T {
+	const g = globalThis as Record<string, unknown>;
+	const prev = g['Deno'];
+	g['Deno'] = {
+		args: [],
+		env: { get: () => undefined, toObject: () => ({}) },
+		cwd: () => '/deno/mock',
+		stdout: { write: vi.fn(() => Promise.resolve(0)), isTerminal: () => false },
+		stderr: { write: vi.fn(() => Promise.resolve(0)) },
+		stdin: {
+			isTerminal: () => false,
+			readable: {
+				getReader: () => ({
+					read: () => Promise.resolve({ done: true, value: undefined }),
+					releaseLock: () => {},
+				}),
+			},
+		},
+		exit: vi.fn() as unknown as (code: number) => never,
+		readTextFile: () => Promise.reject(Object.assign(new Error('not found'), { name: 'NotFound' })),
+		version: { deno: '2.0.0' },
+	};
+	try {
+		return fn();
+	} finally {
+		if (prev === undefined) {
+			delete g['Deno'];
+		} else {
+			g['Deno'] = prev;
+		}
+	}
+}
 
 /**
  * Assert that a value satisfies the RuntimeAdapter interface shape.
@@ -66,39 +105,17 @@ describe('createAdapter — runtime dispatch', () => {
 	});
 
 	// -------------------------------------------------------------------
-	// Deno (throws CLIError — not yet supported)
+	// Deno
 	// -------------------------------------------------------------------
 
-	it('throws CLIError for Deno runtime', () => {
-		const globals: GlobalForDetect = {
-			Deno: { version: { deno: '2.0.0' } },
-		};
-		expect(() => createAdapter(globals)).toThrow(CLIError);
-	});
-
-	it('Deno CLIError has UNSUPPORTED_RUNTIME code', () => {
-		const globals: GlobalForDetect = {
-			Deno: { version: { deno: '2.0.0' } },
-		};
-		try {
-			createAdapter(globals);
-			expect.unreachable('should have thrown');
-		} catch (e) {
-			expect(isCLIError(e)).toBe(true);
-			expect((e as CLIError).code).toBe('UNSUPPORTED_RUNTIME');
-		}
-	});
-
-	it('Deno CLIError includes suggest field', () => {
-		const globals: GlobalForDetect = {
-			Deno: { version: { deno: '2.0.0' } },
-		};
-		try {
-			createAdapter(globals);
-			expect.unreachable('should have thrown');
-		} catch (e) {
-			expect((e as CLIError).suggest).toContain('createNodeAdapter');
-		}
+	it('creates adapter for Deno runtime', () => {
+		withMockDenoGlobal(() => {
+			const globals: GlobalForDetect = {
+				Deno: { version: { deno: '2.0.0' } },
+			};
+			const adapter = createAdapter(globals);
+			assertAdapterShape(adapter);
+		});
 	});
 
 	// -------------------------------------------------------------------
@@ -128,8 +145,7 @@ describe('createAdapter — exhaustiveness', () => {
 	it('handles every Runtime variant without returning undefined', () => {
 		// Exhaustiveness is enforced at compile-time via `default: never`.
 		// This test verifies runtime behavior: every known Runtime value
-		// either produces a valid RuntimeAdapter or throws a CLIError
-		// (Deno is not yet supported).
+		// produces a valid RuntimeAdapter.
 		const globalsForRuntime: Record<string, GlobalForDetect> = {
 			node: { process: { versions: { node: '22.0.0' } } },
 			bun: { Bun: { version: '1.1.0' }, process: { versions: { node: '22.0.0' } } },
@@ -137,20 +153,13 @@ describe('createAdapter — exhaustiveness', () => {
 			unknown: {},
 		};
 
-		const unsupported = new Set(['deno']);
-
-		for (const runtime of RUNTIMES) {
-			if (unsupported.has(runtime)) {
-				expect(
-					() => createAdapter(globalsForRuntime[runtime]),
-					`createAdapter should throw for unsupported runtime '${runtime}'`,
-				).toThrow(CLIError);
-			} else {
+		withMockDenoGlobal(() => {
+			for (const runtime of RUNTIMES) {
 				const adapter = createAdapter(globalsForRuntime[runtime]);
 				expect(adapter, `createAdapter returned undefined for runtime '${runtime}'`).toBeDefined();
 				assertAdapterShape(adapter);
 			}
-		}
+		});
 	});
 });
 

--- a/src/runtime/auto.test.ts
+++ b/src/runtime/auto.test.ts
@@ -7,55 +7,16 @@
  * not internal implementation details.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { RuntimeAdapter } from './adapter.ts';
 import { createAdapter } from './auto.ts';
 import type { GlobalForDetect } from './detect.ts';
 import { RUNTIMES } from './detect.ts';
+import { withMockDenoGlobal } from './test-helpers.ts';
 
 // ===================================================================
 // Helpers
 // ===================================================================
-
-/**
- * Install a minimal mock Deno namespace on globalThis for the duration of `fn`.
- *
- * `createDenoAdapter()` reads from `globalThis.Deno` when no explicit
- * namespace is provided. In vitest (Node), there is no real Deno global,
- * so Deno-path tests in `createAdapter` must install a mock temporarily.
- */
-function withMockDenoGlobal<T>(fn: () => T): T {
-	const g = globalThis as Record<string, unknown>;
-	const prev = g['Deno'];
-	g['Deno'] = {
-		args: [],
-		env: { get: () => undefined, toObject: () => ({}) },
-		cwd: () => '/deno/mock',
-		stdout: { write: vi.fn(() => Promise.resolve(0)), isTerminal: () => false },
-		stderr: { write: vi.fn(() => Promise.resolve(0)) },
-		stdin: {
-			isTerminal: () => false,
-			readable: {
-				getReader: () => ({
-					read: () => Promise.resolve({ done: true, value: undefined }),
-					releaseLock: () => {},
-				}),
-			},
-		},
-		exit: vi.fn() as unknown as (code: number) => never,
-		readTextFile: () => Promise.reject(Object.assign(new Error('not found'), { name: 'NotFound' })),
-		version: { deno: '2.0.0' },
-	};
-	try {
-		return fn();
-	} finally {
-		if (prev === undefined) {
-			delete g['Deno'];
-		} else {
-			g['Deno'] = prev;
-		}
-	}
-}
 
 /**
  * Assert that a value satisfies the RuntimeAdapter interface shape.

--- a/src/runtime/auto.test.ts
+++ b/src/runtime/auto.test.ts
@@ -8,10 +8,10 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import type { RuntimeAdapter } from './adapter.js';
-import { createAdapter } from './auto.js';
-import type { GlobalForDetect } from './detect.js';
-import { RUNTIMES } from './detect.js';
+import type { RuntimeAdapter } from './adapter.ts';
+import { createAdapter } from './auto.ts';
+import type { GlobalForDetect } from './detect.ts';
+import { RUNTIMES } from './detect.ts';
 
 // ===================================================================
 // Helpers

--- a/src/runtime/auto.ts
+++ b/src/runtime/auto.ts
@@ -9,9 +9,9 @@
  * @module dreamcli/runtime/auto
  */
 
-import { CLIError } from '../core/errors/index.js';
 import type { RuntimeAdapter } from './adapter.js';
 import { createBunAdapter } from './bun.js';
+import { createDenoAdapter } from './deno.js';
 import type { GlobalForDetect } from './detect.js';
 import { detectRuntime } from './detect.js';
 import { createNodeAdapter } from './node.js';
@@ -27,10 +27,6 @@ import { createNodeAdapter } from './node.js';
  * Unknown runtimes fall back to the Node adapter because most JS runtimes
  * expose a Node-compatible `process` global.
  *
- * Deno is detected but not yet supported — throws a `CLIError` with code
- * `UNSUPPORTED_RUNTIME` until a dedicated Deno adapter is implemented.
- * Use `createNodeAdapter()` directly if you need to bypass detection.
- *
  * @param globals - Override `globalThis` for testing. Production callers
  *   should omit this parameter.
  * @returns A `RuntimeAdapter` for the detected runtime.
@@ -39,7 +35,7 @@ import { createNodeAdapter } from './node.js';
  * ```ts
  * import { cli } from 'dreamcli';
  *
- * // Auto-detects Node/Bun and creates the right adapter
+ * // Auto-detects Node/Bun/Deno and creates the right adapter
  * cli('mycli').run(); // uses createAdapter() internally
  * ```
  */
@@ -50,10 +46,7 @@ function createAdapter(globals?: GlobalForDetect): RuntimeAdapter {
 		case 'bun':
 			return createBunAdapter();
 		case 'deno':
-			throw new CLIError('Deno runtime detected but not yet supported', {
-				code: 'UNSUPPORTED_RUNTIME',
-				suggest: 'Use createNodeAdapter() directly to bypass auto-detection',
-			});
+			return createDenoAdapter();
 		case 'node':
 		case 'unknown':
 			return createNodeAdapter();

--- a/src/runtime/auto.ts
+++ b/src/runtime/auto.ts
@@ -9,12 +9,12 @@
  * @module dreamcli/runtime/auto
  */
 
-import type { RuntimeAdapter } from './adapter.js';
-import { createBunAdapter } from './bun.js';
-import { createDenoAdapter } from './deno.js';
-import type { GlobalForDetect } from './detect.js';
-import { detectRuntime } from './detect.js';
-import { createNodeAdapter } from './node.js';
+import type { RuntimeAdapter } from './adapter.ts';
+import { createBunAdapter } from './bun.ts';
+import { createDenoAdapter } from './deno.ts';
+import type { GlobalForDetect } from './detect.ts';
+import { detectRuntime } from './detect.ts';
+import { createNodeAdapter } from './node.ts';
 
 // ---------------------------------------------------------------------------
 // Auto-adapter factory

--- a/src/runtime/bun.test.ts
+++ b/src/runtime/bun.test.ts
@@ -7,9 +7,9 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import type { RuntimeAdapter } from './adapter.js';
-import { createBunAdapter } from './bun.js';
-import type { NodeProcess } from './node.js';
+import type { RuntimeAdapter } from './adapter.ts';
+import { createBunAdapter } from './bun.ts';
+import type { NodeProcess } from './node.ts';
 
 // ---------------------------------------------------------------------------
 // Test helpers

--- a/src/runtime/bun.ts
+++ b/src/runtime/bun.ts
@@ -12,9 +12,9 @@
  * @module dreamcli/runtime/bun
  */
 
-import type { RuntimeAdapter } from './adapter.js';
-import type { NodeProcess } from './node.js';
-import { createNodeAdapter } from './node.js';
+import type { RuntimeAdapter } from './adapter.ts';
+import type { NodeProcess } from './node.ts';
+import { createNodeAdapter } from './node.ts';
 
 // ---------------------------------------------------------------------------
 // Bun adapter factory

--- a/src/runtime/deno-builtins.d.ts
+++ b/src/runtime/deno-builtins.d.ts
@@ -17,10 +17,19 @@ declare class TextDecoder {
 	decode(input?: Uint8Array, options?: { stream?: boolean }): string;
 }
 
-interface ReadableStreamReadResult<T> {
-	readonly done: boolean;
+interface ReadableStreamReadValueResult<T> {
+	readonly done: false;
 	readonly value: T;
 }
+
+interface ReadableStreamReadDoneResult<T> {
+	readonly done: true;
+	readonly value?: T;
+}
+
+type ReadableStreamReadResult<T> =
+	| ReadableStreamReadValueResult<T>
+	| ReadableStreamReadDoneResult<T>;
 
 interface ReadableStreamDefaultReader<R> {
 	read(): Promise<ReadableStreamReadResult<R>>;

--- a/src/runtime/deno-builtins.d.ts
+++ b/src/runtime/deno-builtins.d.ts
@@ -7,6 +7,7 @@
  * on the full DOM lib or `@types/deno`.
  *
  * @internal
+ * @module dreamcli/runtime/deno-builtins
  */
 
 declare class TextEncoder {

--- a/src/runtime/deno-builtins.d.ts
+++ b/src/runtime/deno-builtins.d.ts
@@ -1,0 +1,32 @@
+/**
+ * Minimal type declarations for web platform APIs used by the Deno adapter.
+ *
+ * The project's tsconfig uses `lib: ["ES2022"]` which excludes DOM/web APIs.
+ * This file provides just enough type information for the Deno adapter to
+ * use `TextEncoder`, `TextDecoder`, and `ReadableStream` without depending
+ * on the full DOM lib or `@types/deno`.
+ *
+ * @internal
+ */
+
+declare class TextEncoder {
+	encode(input?: string): Uint8Array;
+}
+
+declare class TextDecoder {
+	decode(input?: Uint8Array, options?: { stream?: boolean }): string;
+}
+
+interface ReadableStreamReadResult<T> {
+	readonly done: boolean;
+	readonly value: T;
+}
+
+interface ReadableStreamDefaultReader<R> {
+	read(): Promise<ReadableStreamReadResult<R>>;
+	releaseLock(): void;
+}
+
+declare class ReadableStream<R = Uint8Array> {
+	getReader(): ReadableStreamDefaultReader<R>;
+}

--- a/src/runtime/deno.test.ts
+++ b/src/runtime/deno.test.ts
@@ -7,9 +7,9 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import type { RuntimeAdapter } from './adapter.js';
-import type { DenoNamespace } from './deno.js';
-import { createDenoAdapter } from './deno.js';
+import type { RuntimeAdapter } from './adapter.ts';
+import type { DenoNamespace } from './deno.ts';
+import { createDenoAdapter } from './deno.ts';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -494,12 +494,12 @@ describe('createDenoAdapter — configDir', () => {
 
 describe('public surface — Deno adapter', () => {
 	it('exports createDenoAdapter from runtime barrel', async () => {
-		const mod = await import('./index.js');
+		const mod = await import('./index.ts');
 		expect(mod.createDenoAdapter).toBeDefined();
 	});
 
 	it('exports createDenoAdapter from runtime subpath', async () => {
-		const mod = await import('../runtime.js');
+		const mod = await import('../runtime.ts');
 		expect(mod.createDenoAdapter).toBeDefined();
 	});
 });

--- a/src/runtime/deno.test.ts
+++ b/src/runtime/deno.test.ts
@@ -11,9 +11,9 @@ import type { RuntimeAdapter } from './adapter.ts';
 import type { DenoNamespace } from './deno.ts';
 import { createDenoAdapter } from './deno.ts';
 
-// ---------------------------------------------------------------------------
+// ---
 // Test helpers
-// ---------------------------------------------------------------------------
+// ---
 
 /** Minimal readable stream that yields chunks then signals done. */
 function mockReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
@@ -73,9 +73,9 @@ function makeDenoError(name: string, message?: string): Error {
 	return err;
 }
 
-// ===================================================================
+// ===
 // createDenoAdapter — basic contract
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — basic contract', () => {
 	it('returns a RuntimeAdapter with all required fields', () => {
@@ -101,9 +101,9 @@ describe('createDenoAdapter — basic contract', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — argv synthesis
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — argv synthesis', () => {
 	it('prepends synthetic binary+script to Deno.args', () => {
@@ -125,9 +125,9 @@ describe('createDenoAdapter — argv synthesis', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — environment
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — environment', () => {
 	it('reads env from Deno.env.toObject()', () => {
@@ -167,9 +167,9 @@ describe('createDenoAdapter — environment', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — cwd
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — cwd', () => {
 	it('reads cwd from Deno.cwd()', () => {
@@ -198,9 +198,9 @@ describe('createDenoAdapter — cwd', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — I/O
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — stdout/stderr', () => {
 	it('routes stdout writes through TextEncoder to Deno.stdout.write', () => {
@@ -239,9 +239,9 @@ describe('createDenoAdapter — stdout/stderr', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — TTY detection
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — TTY detection', () => {
 	it('isTTY is true when stdout.isTerminal() returns true', () => {
@@ -273,9 +273,9 @@ describe('createDenoAdapter — TTY detection', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — exit
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — exit', () => {
 	it('delegates exit to Deno.exit', () => {
@@ -288,9 +288,9 @@ describe('createDenoAdapter — exit', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — stdin line reading
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — stdin', () => {
 	it('stdin is a ReadFn (function)', () => {
@@ -344,9 +344,9 @@ describe('createDenoAdapter — stdin', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — readFile
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — readFile', () => {
 	it('returns file contents on success', async () => {
@@ -385,9 +385,9 @@ describe('createDenoAdapter — readFile', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — homedir
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — homedir', () => {
 	it('uses HOME env on Unix', () => {
@@ -431,9 +431,9 @@ describe('createDenoAdapter — homedir', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // createDenoAdapter — configDir
-// ===================================================================
+// ===
 
 describe('createDenoAdapter — configDir', () => {
 	it('uses XDG_CONFIG_HOME on Unix', () => {
@@ -488,9 +488,9 @@ describe('createDenoAdapter — configDir', () => {
 	});
 });
 
-// ===================================================================
+// ===
 // Public surface exports
-// ===================================================================
+// ===
 
 describe('public surface — Deno adapter', () => {
 	it('exports createDenoAdapter from runtime barrel', async () => {

--- a/src/runtime/deno.test.ts
+++ b/src/runtime/deno.test.ts
@@ -1,0 +1,505 @@
+/**
+ * Tests for the Deno runtime adapter.
+ *
+ * Since tests run under Node/Bun (vitest), the Deno namespace isn't
+ * available. All tests inject a mock `DenoNamespace` via the `ns`
+ * parameter, verifying the adapter's behavior without requiring Deno.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { RuntimeAdapter } from './adapter.js';
+import type { DenoNamespace } from './deno.js';
+import { createDenoAdapter } from './deno.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal readable stream that yields chunks then signals done. */
+function mockReadableStream(chunks: string[]): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	const encoded = chunks.map((c) => encoder.encode(c));
+	let index = 0;
+
+	return {
+		getReader() {
+			return {
+				read() {
+					const value = encoded[index];
+					if (value !== undefined) {
+						index += 1;
+						return Promise.resolve({ done: false as const, value });
+					}
+					return Promise.resolve({
+						done: true as const,
+						value: new Uint8Array(0),
+					});
+				},
+				releaseLock() {},
+			};
+		},
+	} as ReadableStream<Uint8Array>;
+}
+
+/** Create a minimal mock DenoNamespace with optional overrides. */
+function mockDeno(overrides?: Partial<DenoNamespace>): DenoNamespace {
+	return {
+		args: overrides?.args ?? [],
+		env: overrides?.env ?? {
+			get: () => undefined,
+			toObject: () => ({}),
+		},
+		cwd: overrides?.cwd ?? (() => '/deno/project'),
+		stdout: overrides?.stdout ?? {
+			write: vi.fn(() => Promise.resolve(0)),
+			isTerminal: () => false,
+		},
+		stderr: overrides?.stderr ?? {
+			write: vi.fn(() => Promise.resolve(0)),
+		},
+		stdin: overrides?.stdin ?? {
+			isTerminal: () => false,
+			readable: mockReadableStream([]),
+		},
+		exit: overrides?.exit ?? (vi.fn() as unknown as (code: number) => never),
+		readTextFile: overrides?.readTextFile ?? (() => Promise.reject(makeDenoError('NotFound'))),
+	};
+}
+
+/** Create a Deno-style error with a `name` property. */
+function makeDenoError(name: string, message?: string): Error {
+	const err = new Error(message ?? name);
+	err.name = name;
+	return err;
+}
+
+// ===================================================================
+// createDenoAdapter — basic contract
+// ===================================================================
+
+describe('createDenoAdapter', () => {
+	it('returns a RuntimeAdapter with all required fields', () => {
+		const adapter: RuntimeAdapter = createDenoAdapter(mockDeno());
+
+		expect(adapter.argv).toBeDefined();
+		expect(adapter.env).toBeDefined();
+		expect(adapter.cwd).toBeDefined();
+		expect(typeof adapter.stdout).toBe('function');
+		expect(typeof adapter.stderr).toBe('function');
+		expect(typeof adapter.stdin).toBe('function');
+		expect(typeof adapter.isTTY).toBe('boolean');
+		expect(typeof adapter.stdinIsTTY).toBe('boolean');
+		expect(typeof adapter.exit).toBe('function');
+		expect(typeof adapter.readFile).toBe('function');
+		expect(typeof adapter.homedir).toBe('string');
+		expect(typeof adapter.configDir).toBe('string');
+	});
+
+	it('satisfies RuntimeAdapter type', () => {
+		const adapter: RuntimeAdapter = createDenoAdapter(mockDeno());
+		expect(adapter).toBeDefined();
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — argv synthesis
+// ===================================================================
+
+describe('createDenoAdapter — argv synthesis', () => {
+	it('prepends synthetic binary+script to Deno.args', () => {
+		const ns = mockDeno({ args: ['deploy', '--force'] });
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.argv).toEqual(['deno', 'run', 'deploy', '--force']);
+	});
+
+	it('has 2 entries when Deno.args is empty', () => {
+		const ns = mockDeno({ args: [] });
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.argv).toEqual(['deno', 'run']);
+	});
+
+	it('preserves all user args in order', () => {
+		const ns = mockDeno({ args: ['build', '--target', 'production', '--verbose'] });
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.argv).toEqual(['deno', 'run', 'build', '--target', 'production', '--verbose']);
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — environment
+// ===================================================================
+
+describe('createDenoAdapter — environment', () => {
+	it('reads env from Deno.env.toObject()', () => {
+		const ns = mockDeno({
+			env: {
+				get: (key: string) => ({ DENO_ENV: 'production' })[key],
+				toObject: () => ({ DENO_ENV: 'production', API_KEY: 'secret' }),
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.env).toEqual({ DENO_ENV: 'production', API_KEY: 'secret' });
+	});
+
+	it('falls back to empty env on PermissionDenied', () => {
+		const ns = mockDeno({
+			env: {
+				get: () => undefined,
+				toObject: () => {
+					throw makeDenoError('PermissionDenied');
+				},
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.env).toEqual({});
+	});
+
+	it('propagates non-permission errors from env', () => {
+		const ns = mockDeno({
+			env: {
+				get: () => undefined,
+				toObject: () => {
+					throw new TypeError('unexpected');
+				},
+			},
+		});
+		expect(() => createDenoAdapter(ns)).toThrow(TypeError);
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — cwd
+// ===================================================================
+
+describe('createDenoAdapter — cwd', () => {
+	it('reads cwd from Deno.cwd()', () => {
+		const ns = mockDeno({ cwd: () => '/home/user/deno-project' });
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.cwd).toBe('/home/user/deno-project');
+	});
+
+	it('falls back to / on PermissionDenied', () => {
+		const ns = mockDeno({
+			cwd: () => {
+				throw makeDenoError('PermissionDenied');
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.cwd).toBe('/');
+	});
+
+	it('propagates non-permission cwd errors', () => {
+		const ns = mockDeno({
+			cwd: () => {
+				throw new Error('disk error');
+			},
+		});
+		expect(() => createDenoAdapter(ns)).toThrow('disk error');
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — I/O
+// ===================================================================
+
+describe('createDenoAdapter — stdout/stderr', () => {
+	it('routes stdout writes through TextEncoder to Deno.stdout.write', () => {
+		let captured: Uint8Array | undefined;
+		const ns = mockDeno({
+			stdout: {
+				write: (p: Uint8Array) => {
+					captured = p;
+					return Promise.resolve(p.length);
+				},
+				isTerminal: () => false,
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+
+		adapter.stdout('hello deno');
+		expect(captured).toBeDefined();
+		expect(new TextDecoder().decode(captured)).toBe('hello deno');
+	});
+
+	it('routes stderr writes through TextEncoder to Deno.stderr.write', () => {
+		let captured: Uint8Array | undefined;
+		const ns = mockDeno({
+			stderr: {
+				write: (p: Uint8Array) => {
+					captured = p;
+					return Promise.resolve(p.length);
+				},
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+
+		adapter.stderr('deno error');
+		expect(captured).toBeDefined();
+		expect(new TextDecoder().decode(captured)).toBe('deno error');
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — TTY detection
+// ===================================================================
+
+describe('createDenoAdapter — TTY detection', () => {
+	it('isTTY is true when stdout.isTerminal() returns true', () => {
+		const ns = mockDeno({
+			stdout: { write: vi.fn(() => Promise.resolve(0)), isTerminal: () => true },
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.isTTY).toBe(true);
+	});
+
+	it('isTTY is false when stdout.isTerminal() returns false', () => {
+		const ns = mockDeno();
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.isTTY).toBe(false);
+	});
+
+	it('stdinIsTTY is true when stdin.isTerminal() returns true', () => {
+		const ns = mockDeno({
+			stdin: { isTerminal: () => true, readable: mockReadableStream([]) },
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.stdinIsTTY).toBe(true);
+	});
+
+	it('stdinIsTTY is false when stdin.isTerminal() returns false', () => {
+		const ns = mockDeno();
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.stdinIsTTY).toBe(false);
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — exit
+// ===================================================================
+
+describe('createDenoAdapter — exit', () => {
+	it('delegates exit to Deno.exit', () => {
+		const exitFn = vi.fn() as unknown as (code: number) => never;
+		const ns = mockDeno({ exit: exitFn });
+		const adapter = createDenoAdapter(ns);
+
+		adapter.exit(42);
+		expect(exitFn).toHaveBeenCalledWith(42);
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — stdin line reading
+// ===================================================================
+
+describe('createDenoAdapter — stdin', () => {
+	it('stdin is a ReadFn (function)', () => {
+		const adapter = createDenoAdapter(mockDeno());
+		expect(typeof adapter.stdin).toBe('function');
+	});
+
+	it('reads a line from stdin stream', async () => {
+		const ns = mockDeno({
+			stdin: { isTerminal: () => false, readable: mockReadableStream(['hello\n']) },
+		});
+		const adapter = createDenoAdapter(ns);
+		const line = await adapter.stdin();
+		expect(line).toBe('hello');
+	});
+
+	it('strips carriage return from line endings', async () => {
+		const ns = mockDeno({
+			stdin: { isTerminal: () => false, readable: mockReadableStream(['hello\r\n']) },
+		});
+		const adapter = createDenoAdapter(ns);
+		const line = await adapter.stdin();
+		expect(line).toBe('hello');
+	});
+
+	it('returns null on empty EOF', async () => {
+		const ns = mockDeno({
+			stdin: { isTerminal: () => false, readable: mockReadableStream([]) },
+		});
+		const adapter = createDenoAdapter(ns);
+		const line = await adapter.stdin();
+		expect(line).toBeNull();
+	});
+
+	it('returns buffered content on EOF without newline', async () => {
+		const ns = mockDeno({
+			stdin: { isTerminal: () => false, readable: mockReadableStream(['partial']) },
+		});
+		const adapter = createDenoAdapter(ns);
+		const line = await adapter.stdin();
+		expect(line).toBe('partial');
+	});
+
+	it('handles multi-chunk line assembly', async () => {
+		const ns = mockDeno({
+			stdin: { isTerminal: () => false, readable: mockReadableStream(['hel', 'lo\n']) },
+		});
+		const adapter = createDenoAdapter(ns);
+		const line = await adapter.stdin();
+		expect(line).toBe('hello');
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — readFile
+// ===================================================================
+
+describe('createDenoAdapter — readFile', () => {
+	it('returns file contents on success', async () => {
+		const ns = mockDeno({
+			readTextFile: (path: string) =>
+				path === '/etc/config.json'
+					? Promise.resolve('{"key":"val"}')
+					: Promise.reject(makeDenoError('NotFound')),
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(await adapter.readFile('/etc/config.json')).toBe('{"key":"val"}');
+	});
+
+	it('returns null on NotFound', async () => {
+		const ns = mockDeno({
+			readTextFile: () => Promise.reject(makeDenoError('NotFound')),
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(await adapter.readFile('/nonexistent')).toBeNull();
+	});
+
+	it('returns null on PermissionDenied', async () => {
+		const ns = mockDeno({
+			readTextFile: () => Promise.reject(makeDenoError('PermissionDenied')),
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(await adapter.readFile('/secret')).toBeNull();
+	});
+
+	it('propagates other errors', async () => {
+		const ns = mockDeno({
+			readTextFile: () => Promise.reject(new Error('disk failure')),
+		});
+		const adapter = createDenoAdapter(ns);
+		await expect(adapter.readFile('/broken')).rejects.toThrow('disk failure');
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — homedir
+// ===================================================================
+
+describe('createDenoAdapter — homedir', () => {
+	it('uses HOME env on Unix', () => {
+		const ns = mockDeno({
+			env: {
+				get: (k: string) => ({ HOME: '/home/alice' })[k],
+				toObject: () => ({ HOME: '/home/alice' }),
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.homedir).toBe('/home/alice');
+	});
+
+	it('uses USERPROFILE on Windows', () => {
+		const ns = mockDeno({
+			env: {
+				get: (k: string) => ({ USERPROFILE: 'C:\\Users\\alice' })[k],
+				toObject: () => ({ USERPROFILE: 'C:\\Users\\alice' }),
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.homedir).toBe('C:\\Users\\alice');
+	});
+
+	it('uses HOMEDRIVE+HOMEPATH when USERPROFILE unset', () => {
+		const env: Record<string, string> = { HOMEDRIVE: 'D:', HOMEPATH: '\\Users\\bob' };
+		const ns = mockDeno({
+			env: {
+				get: (k: string) => env[k],
+				toObject: () => env,
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.homedir).toBe('D:\\Users\\bob');
+	});
+
+	it('falls back to / when no home env set', () => {
+		const ns = mockDeno();
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.homedir).toBe('/');
+	});
+});
+
+// ===================================================================
+// createDenoAdapter — configDir
+// ===================================================================
+
+describe('createDenoAdapter — configDir', () => {
+	it('uses XDG_CONFIG_HOME on Unix', () => {
+		const env: Record<string, string> = { HOME: '/home/alice', XDG_CONFIG_HOME: '/custom/config' };
+		const ns = mockDeno({
+			env: {
+				get: (k: string) => env[k],
+				toObject: () => env,
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.configDir).toBe('/custom/config');
+	});
+
+	it('defaults to ~/.config on Unix', () => {
+		const env: Record<string, string> = { HOME: '/home/alice' };
+		const ns = mockDeno({
+			env: {
+				get: (k: string) => env[k],
+				toObject: () => env,
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.configDir).toBe('/home/alice/.config');
+	});
+
+	it('uses APPDATA on Windows', () => {
+		const env: Record<string, string> = {
+			USERPROFILE: 'C:\\Users\\alice',
+			APPDATA: 'C:\\Users\\alice\\AppData\\Roaming',
+		};
+		const ns = mockDeno({
+			env: {
+				get: (k: string) => env[k],
+				toObject: () => env,
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.configDir).toBe('C:\\Users\\alice\\AppData\\Roaming');
+	});
+
+	it('treats empty APPDATA as unset', () => {
+		const env: Record<string, string> = { HOME: '/home/alice', APPDATA: '' };
+		const ns = mockDeno({
+			env: {
+				get: (k: string) => env[k],
+				toObject: () => env,
+			},
+		});
+		const adapter = createDenoAdapter(ns);
+		expect(adapter.configDir).toBe('/home/alice/.config');
+	});
+});
+
+// ===================================================================
+// Public surface exports
+// ===================================================================
+
+describe('public surface — Deno adapter', () => {
+	it('exports createDenoAdapter from runtime barrel', async () => {
+		const mod = await import('./index.js');
+		expect(mod.createDenoAdapter).toBeDefined();
+	});
+
+	it('exports createDenoAdapter from runtime subpath', async () => {
+		const mod = await import('../runtime.js');
+		expect(mod.createDenoAdapter).toBeDefined();
+	});
+});

--- a/src/runtime/deno.test.ts
+++ b/src/runtime/deno.test.ts
@@ -77,7 +77,7 @@ function makeDenoError(name: string, message?: string): Error {
 // createDenoAdapter — basic contract
 // ===================================================================
 
-describe('createDenoAdapter', () => {
+describe('createDenoAdapter — basic contract', () => {
 	it('returns a RuntimeAdapter with all required fields', () => {
 		const adapter: RuntimeAdapter = createDenoAdapter(mockDeno());
 

--- a/src/runtime/deno.ts
+++ b/src/runtime/deno.ts
@@ -1,7 +1,318 @@
 /**
  * Deno runtime adapter implementation.
  *
+ * Bridges the platform-agnostic `RuntimeAdapter` interface to Deno's
+ * namespace APIs (`Deno.args`, `Deno.env`, `Deno.cwd()`, etc.).
+ *
+ * Deno requires explicit permissions for some operations. The adapter
+ * handles missing permissions gracefully:
+ *
+ * - **`--allow-env`**: needed for `Deno.env.toObject()`. Without it,
+ *   the adapter falls back to an empty env (flags using env sources
+ *   simply won't resolve from env).
+ * - **`--allow-read`**: needed for `Deno.readTextFile()`. Without it,
+ *   `readFile` returns `null` (same as file-not-found).
+ *
+ * No permissions are needed for `Deno.args`, `Deno.stdout`, `Deno.stderr`,
+ * `Deno.stdin`, `Deno.exit()`, or TTY detection.
+ *
  * @module dreamcli/runtime/deno
  */
 
-export {};
+import type { WriteFn } from '../core/output/index.js';
+import type { ReadFn } from '../core/prompt/index.js';
+import type { RuntimeAdapter } from './adapter.js';
+
+// ---------------------------------------------------------------------------
+// Minimal Deno namespace shape — avoids @types/deno dependency
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal subset of the Deno namespace needed by the adapter.
+ *
+ * We avoid `@types/deno` to keep the core runtime-agnostic at the type level.
+ * This interface declares only what `createDenoAdapter` actually reads.
+ *
+ * The `env` property is optional because it requires `--allow-env` permission.
+ * When permission is denied, the adapter catches the error and falls back to
+ * an empty env object.
+ *
+ * @internal
+ */
+interface DenoNamespace {
+	/** Raw command-line args (excludes the binary/script — Deno pre-strips them). */
+	readonly args: readonly string[];
+
+	/** Environment variable access (requires `--allow-env`). */
+	readonly env: {
+		/** Get a single env var. Returns `undefined` if unset or permission denied. */
+		get(key: string): string | undefined;
+		/** Get all env vars as a plain object. Throws on permission denied. */
+		toObject(): Record<string, string>;
+	};
+
+	/** Current working directory (may throw if `--allow-read` is denied for cwd). */
+	cwd(): string;
+
+	readonly stdout: {
+		/** Write raw bytes to stdout. */
+		write(p: Uint8Array): Promise<number>;
+		/** Whether stdout is connected to a TTY. */
+		isTerminal(): boolean;
+	};
+
+	readonly stderr: {
+		/** Write raw bytes to stderr. */
+		write(p: Uint8Array): Promise<number>;
+	};
+
+	readonly stdin: {
+		/** Whether stdin is connected to a TTY. */
+		isTerminal(): boolean;
+		/** Readable stream for stdin bytes. */
+		readonly readable: ReadableStream<Uint8Array>;
+	};
+
+	/** Exit the process with the given code. */
+	exit(code: number): never;
+
+	/** Read a file as UTF-8 text (requires `--allow-read`). */
+	readTextFile(path: string): Promise<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Permission-safe helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether an unknown thrown value is a Deno error by name.
+ *
+ * @internal
+ */
+function isDenoErrorNamed(err: unknown, name: string): boolean {
+	if (typeof err !== 'object' || err === null || !('name' in err)) return false;
+	// After the `in` check, TS narrows err to `object & Record<'name', unknown>`.
+	const candidate: { name: unknown } = err;
+	return typeof candidate.name === 'string' && candidate.name === name;
+}
+
+/**
+ * Safely read all environment variables. Returns empty object if
+ * `--allow-env` permission is not granted.
+ *
+ * @internal
+ */
+function safeEnvToObject(deno: DenoNamespace): Readonly<Record<string, string | undefined>> {
+	try {
+		return deno.env.toObject();
+	} catch (err: unknown) {
+		if (isDenoErrorNamed(err, 'PermissionDenied')) return {};
+		throw err;
+	}
+}
+
+/**
+ * Safely get the current working directory. Returns `/` if the cwd is
+ * inaccessible due to missing permissions.
+ *
+ * @internal
+ */
+function safeCwd(deno: DenoNamespace): string {
+	try {
+		return deno.cwd();
+	} catch (err: unknown) {
+		if (isDenoErrorNamed(err, 'PermissionDenied')) return '/';
+		throw err;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Deno adapter factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a runtime adapter backed by the Deno namespace.
+ *
+ * Reads `Deno.args`, `Deno.env`, `Deno.cwd()`, and wraps Deno's stream-based
+ * I/O into the `WriteFn`/`ReadFn` functions expected by the framework.
+ *
+ * Unlike Node/Bun, Deno strips the binary and script path from `Deno.args`.
+ * The adapter prepends synthetic entries (`['deno', 'run']`) so the argv
+ * shape matches the `RuntimeAdapter` contract (binary + script + user args).
+ *
+ * @param ns - Override the Deno namespace (useful for testing the adapter itself).
+ * @returns A `RuntimeAdapter` backed by Deno's namespace APIs.
+ *
+ * @example
+ * ```ts
+ * import { cli } from 'dreamcli';
+ * import { createDenoAdapter } from 'dreamcli/runtime';
+ *
+ * cli('mycli')
+ *   .command(deploy)
+ *   .run({ adapter: createDenoAdapter() });
+ * ```
+ */
+function createDenoAdapter(ns?: DenoNamespace): RuntimeAdapter {
+	const d = ns ?? getDenoNamespace();
+	const encoder = new TextEncoder();
+
+	// --- Synthetic argv: Deno.args has user args only (no binary/script) ---
+	const argv: readonly string[] = ['deno', 'run', ...d.args];
+
+	// --- Environment (permission-safe) ---
+	const env = safeEnvToObject(d);
+
+	// --- CWD (permission-safe) ---
+	const cwd = safeCwd(d);
+
+	// --- I/O writers ---
+	const stdoutWrite: WriteFn = (data) => {
+		void d.stdout.write(encoder.encode(data));
+	};
+	const stderrWrite: WriteFn = (data) => {
+		void d.stderr.write(encoder.encode(data));
+	};
+
+	// --- Stdin line reading ---
+	const stdinRead: ReadFn = () => readDenoStdinLine(d);
+
+	// --- Filesystem ---
+	const readFile = async (path: string): Promise<string | null> => {
+		try {
+			return await d.readTextFile(path);
+		} catch (err: unknown) {
+			// NotFound = file doesn't exist → null (expected for config probing)
+			if (isDenoErrorNamed(err, 'NotFound')) return null;
+			// PermissionDenied = --allow-read not granted → treat as not found
+			// (config discovery is opt-in; failing silently is the graceful path)
+			if (isDenoErrorNamed(err, 'PermissionDenied')) return null;
+			throw err; // Other I/O errors propagate
+		}
+	};
+
+	// --- Home directory ---
+	const homedir = resolveDenoHomedir(env);
+
+	// --- Config directory ---
+	const configDir = resolveDenoConfigDir(env, homedir);
+
+	return {
+		argv,
+		env,
+		cwd,
+		stdout: stdoutWrite,
+		stderr: stderrWrite,
+		stdin: stdinRead,
+		isTTY: d.stdout.isTerminal(),
+		stdinIsTTY: d.stdin.isTerminal(),
+		exit: (code) => d.exit(code),
+		readFile,
+		homedir,
+		configDir,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Deno namespace access — isolated for testability
+// ---------------------------------------------------------------------------
+
+/**
+ * Access the global `Deno` namespace.
+ *
+ * Cast through `unknown` to avoid TypeScript errors when Deno types
+ * aren't installed. Safe because this adapter is only used on Deno
+ * where `globalThis.Deno` is always defined.
+ *
+ * @internal
+ */
+function getDenoNamespace(): DenoNamespace {
+	return (globalThis as unknown as { Deno: DenoNamespace }).Deno;
+}
+
+// ---------------------------------------------------------------------------
+// Stdin line reading
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a single line from Deno's stdin.
+ *
+ * Uses the `ReadableStream` API with a manual buffer to read until
+ * a newline character is found. Returns `null` on EOF.
+ *
+ * This is intentionally simple — the terminal prompter handles retries
+ * and validation.
+ *
+ * @internal
+ */
+async function readDenoStdinLine(deno: DenoNamespace): Promise<string | null> {
+	const reader = deno.stdin.readable.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+
+	try {
+		for (;;) {
+			const { value, done } = await reader.read();
+			if (done) {
+				// EOF — return buffered content or null
+				return buffer.length > 0 ? buffer : null;
+			}
+			buffer += decoder.decode(value, { stream: true });
+			const newlineIndex = buffer.indexOf('\n');
+			if (newlineIndex !== -1) {
+				// Return the line without the newline character.
+				// Remaining data after the newline is lost — this is acceptable
+				// because each prompt reads one line at a time.
+				return buffer.slice(0, newlineIndex).replace(/\r$/, '');
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Home / config directory resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the user's home directory from environment variables.
+ *
+ * Deno doesn't expose `os.homedir()` without `--allow-sys`, so we derive
+ * it from env vars — same approach as the Node adapter.
+ *
+ * @internal
+ */
+function resolveDenoHomedir(env: Readonly<Record<string, string | undefined>>): string {
+	// Deno runs on all platforms — check Windows-style vars first
+	if (env.USERPROFILE) return env.USERPROFILE;
+	if (env.HOMEDRIVE && env.HOMEPATH) return env.HOMEDRIVE + env.HOMEPATH;
+	return env.HOME || '/';
+}
+
+/**
+ * Resolve the platform-specific user configuration directory.
+ *
+ * Without `--allow-sys` we can't call `Deno.build.os` reliably in all
+ * permission modes. Instead we use the same env-based heuristic as the
+ * Node adapter: presence of `APPDATA` implies Windows.
+ *
+ * @internal
+ */
+function resolveDenoConfigDir(
+	env: Readonly<Record<string, string | undefined>>,
+	homedir: string,
+): string {
+	// APPDATA present and non-empty → Windows
+	if (env.APPDATA !== undefined && env.APPDATA !== '') return env.APPDATA;
+	// XDG_CONFIG_HOME → Unix override
+	if (env.XDG_CONFIG_HOME) return env.XDG_CONFIG_HOME;
+	return `${homedir}/.config`;
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export { createDenoAdapter };
+export type { DenoNamespace };

--- a/src/runtime/deno.ts
+++ b/src/runtime/deno.ts
@@ -36,8 +36,6 @@ import type { RuntimeAdapter } from './adapter.ts';
  * The `env` property is optional because it requires `--allow-env` permission.
  * When permission is denied, the adapter catches the error and falls back to
  * an empty env object.
- *
- * @internal
  */
 interface DenoNamespace {
 	/** Raw command-line args (excludes the binary/script — Deno pre-strips them). */
@@ -254,7 +252,9 @@ async function readDenoStdinLine(deno: DenoNamespace): Promise<string | null> {
 		for (;;) {
 			const { value, done } = await reader.read();
 			if (done) {
-				// EOF — return buffered content or null
+				// Flush any trailing bytes held by the streaming decoder
+				// (partial multibyte UTF-8 sequences buffered internally).
+				buffer += decoder.decode();
 				return buffer.length > 0 ? buffer : null;
 			}
 			buffer += decoder.decode(value, { stream: true });

--- a/src/runtime/deno.ts
+++ b/src/runtime/deno.ts
@@ -19,9 +19,9 @@
  * @module dreamcli/runtime/deno
  */
 
-import type { WriteFn } from '../core/output/index.js';
-import type { ReadFn } from '../core/prompt/index.js';
-import type { RuntimeAdapter } from './adapter.js';
+import type { WriteFn } from '../core/output/index.ts';
+import type { ReadFn } from '../core/prompt/index.ts';
+import type { RuntimeAdapter } from './adapter.ts';
 
 // ---------------------------------------------------------------------------
 // Minimal Deno namespace shape — avoids @types/deno dependency

--- a/src/runtime/detect.test.ts
+++ b/src/runtime/detect.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { GlobalForDetect, Runtime } from './detect.js';
-import { detectRuntime, RUNTIMES } from './detect.js';
+import type { GlobalForDetect, Runtime } from './detect.ts';
+import { detectRuntime, RUNTIMES } from './detect.ts';
 
 // ===================================================================
 // RUNTIMES constant

--- a/src/runtime/detect.ts
+++ b/src/runtime/detect.ts
@@ -42,7 +42,12 @@ type Runtime = 'node' | 'bun' | 'deno' | 'unknown';
  * }
  * ```
  */
-const RUNTIMES = ['node', 'bun', 'deno', 'unknown'] as const satisfies readonly Runtime[];
+const RUNTIMES: readonly ['node', 'bun', 'deno', 'unknown'] = [
+	'node',
+	'bun',
+	'deno',
+	'unknown',
+] as const satisfies readonly Runtime[];
 
 // ---------------------------------------------------------------------------
 // Minimal global shapes — avoid importing @types/* for each runtime

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -9,13 +9,13 @@
  * @module dreamcli/runtime
  */
 
-export type { RuntimeAdapter, TestAdapterOptions } from './adapter.js';
-export { createTestAdapter, ExitError } from './adapter.js';
-export { createAdapter } from './auto.js';
-export { createBunAdapter } from './bun.js';
-export type { DenoNamespace } from './deno.js';
-export { createDenoAdapter } from './deno.js';
-export type { GlobalForDetect, Runtime } from './detect.js';
-export { detectRuntime, RUNTIMES } from './detect.js';
-export type { NodeProcess } from './node.js';
-export { createNodeAdapter } from './node.js';
+export type { RuntimeAdapter, TestAdapterOptions } from './adapter.ts';
+export { createTestAdapter, ExitError } from './adapter.ts';
+export { createAdapter } from './auto.ts';
+export { createBunAdapter } from './bun.ts';
+export type { DenoNamespace } from './deno.ts';
+export { createDenoAdapter } from './deno.ts';
+export type { GlobalForDetect, Runtime } from './detect.ts';
+export { detectRuntime, RUNTIMES } from './detect.ts';
+export type { NodeProcess } from './node.ts';
+export { createNodeAdapter } from './node.ts';

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -13,6 +13,8 @@ export type { RuntimeAdapter, TestAdapterOptions } from './adapter.js';
 export { createTestAdapter, ExitError } from './adapter.js';
 export { createAdapter } from './auto.js';
 export { createBunAdapter } from './bun.js';
+export type { DenoNamespace } from './deno.js';
+export { createDenoAdapter } from './deno.js';
 export type { GlobalForDetect, Runtime } from './detect.js';
 export { detectRuntime, RUNTIMES } from './detect.js';
 export type { NodeProcess } from './node.js';

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -12,9 +12,9 @@
  * @module dreamcli/runtime/node
  */
 
-import type { WriteFn } from '../core/output/index.js';
-import type { ReadFn } from '../core/prompt/index.js';
-import type { RuntimeAdapter } from './adapter.js';
+import type { WriteFn } from '../core/output/index.ts';
+import type { ReadFn } from '../core/prompt/index.ts';
+import type { RuntimeAdapter } from './adapter.ts';
 
 // ---------------------------------------------------------------------------
 // Node.js error shape — for ENOENT detection without @types/node

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -42,8 +42,6 @@ interface NodeSystemError {
  * We avoid importing `@types/node` to keep the core runtime-agnostic
  * at the type level. This interface declares only what `createNodeAdapter`
  * actually reads from the global.
- *
- * @internal
  */
 interface NodeProcess {
 	readonly argv: readonly string[];

--- a/src/runtime/runtime.test.ts
+++ b/src/runtime/runtime.test.ts
@@ -3,14 +3,14 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { cli } from '../core/cli/index.js';
-import { arg } from '../core/schema/arg.js';
-import { command } from '../core/schema/command.js';
-import { flag } from '../core/schema/flag.js';
-import type { RuntimeAdapter } from './adapter.js';
-import { createTestAdapter, ExitError } from './adapter.js';
-import type { NodeProcess } from './node.js';
-import { createNodeAdapter } from './node.js';
+import { cli } from '../core/cli/index.ts';
+import { arg } from '../core/schema/arg.ts';
+import { command } from '../core/schema/command.ts';
+import { flag } from '../core/schema/flag.ts';
+import type { RuntimeAdapter } from './adapter.ts';
+import { createTestAdapter, ExitError } from './adapter.ts';
+import type { NodeProcess } from './node.ts';
+import { createNodeAdapter } from './node.ts';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -568,7 +568,7 @@ describe('CLIBuilder.run() prompt gating', () => {
 		});
 
 		// Provide explicit prompter — should take precedence
-		const { createTestPrompter } = await import('../core/prompt/index.js');
+		const { createTestPrompter } = await import('../core/prompt/index.ts');
 		const explicitPrompter = createTestPrompter(['ExplicitAnswer']);
 
 		const app = cli('mycli').command(cmd);
@@ -860,20 +860,20 @@ describe('RuntimeAdapter interface — filesystem', () => {
 
 describe('public surface', () => {
 	it('exports RuntimeAdapter type and factories from runtime barrel', async () => {
-		const mod = await import('./index.js');
+		const mod = await import('./index.ts');
 		expect(mod.createTestAdapter).toBeDefined();
 		expect(mod.createNodeAdapter).toBeDefined();
 		expect(mod.ExitError).toBeDefined();
 	});
 
 	it('exports adapter factories from runtime barrel', async () => {
-		const mod = await import('../runtime.js');
+		const mod = await import('../runtime.ts');
 		expect(mod.createNodeAdapter).toBeDefined();
 		expect(mod.ExitError).toBeDefined();
 	});
 
 	it('exports test adapter from testkit barrel', async () => {
-		const mod = await import('../testkit.js');
+		const mod = await import('../testkit.ts');
 		expect(mod.createTestAdapter).toBeDefined();
 	});
 });

--- a/src/runtime/test-helpers.ts
+++ b/src/runtime/test-helpers.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared test helpers for runtime adapter tests.
+ *
+ * @internal — test-only, not exported from any public barrel.
+ * @module dreamcli/runtime/test-helpers
+ */
+
+import { vi } from 'vitest';
+
+/**
+ * Install a minimal mock Deno namespace on globalThis for the duration of `fn`.
+ *
+ * `createDenoAdapter()` reads from `globalThis.Deno` when no explicit
+ * namespace is provided. In vitest (Node), there is no real Deno global,
+ * so Deno-path tests in `createAdapter` must install a mock temporarily.
+ */
+export function withMockDenoGlobal<T>(fn: () => T): T {
+	const g = globalThis as Record<string, unknown>;
+	const prev = g['Deno'];
+	g['Deno'] = {
+		args: [],
+		env: { get: () => undefined, toObject: () => ({}) },
+		cwd: () => '/deno/mock',
+		stdout: { write: vi.fn(() => Promise.resolve(0)), isTerminal: () => false },
+		stderr: { write: vi.fn(() => Promise.resolve(0)) },
+		stdin: {
+			isTerminal: () => false,
+			readable: {
+				getReader: () => ({
+					read: () => Promise.resolve({ done: true, value: undefined }),
+					releaseLock: () => {},
+				}),
+			},
+		},
+		exit: vi.fn() as unknown as (code: number) => never,
+		readTextFile: () => Promise.reject(Object.assign(new Error('not found'), { name: 'NotFound' })),
+		version: { deno: '2.0.0' },
+	};
+	try {
+		return fn();
+	} finally {
+		if (prev === undefined) {
+			delete g['Deno'];
+		} else {
+			g['Deno'] = prev;
+		}
+	}
+}

--- a/src/testkit.ts
+++ b/src/testkit.ts
@@ -7,11 +7,11 @@
  * @module dreamcli/testkit
  */
 
-export type { CapturedOutput } from './core/output/index.js';
-export { createCaptureOutput } from './core/output/index.js';
-export type { TestAnswer, TestPrompterOptions } from './core/prompt/index.js';
-export { createTestPrompter, PROMPT_CANCEL } from './core/prompt/index.js';
-export type { RunOptions, RunResult } from './core/testkit/index.js';
-export { runCommand } from './core/testkit/index.js';
-export type { TestAdapterOptions } from './runtime/index.js';
-export { createTestAdapter } from './runtime/index.js';
+export type { CapturedOutput } from './core/output/index.ts';
+export { createCaptureOutput } from './core/output/index.ts';
+export type { TestAnswer, TestPrompterOptions } from './core/prompt/index.ts';
+export { createTestPrompter, PROMPT_CANCEL } from './core/prompt/index.ts';
+export type { RunOptions, RunResult } from './core/testkit/index.ts';
+export { runCommand } from './core/testkit/index.ts';
+export type { TestAdapterOptions } from './runtime/index.ts';
+export { createTestAdapter } from './runtime/index.ts';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,10 +14,8 @@
 		"forceConsistentCasingInFileNames": true,
 
 		// Emit
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"outDir": "dist",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
 
 		// Interop
 		"esModuleInterop": true,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds first-class Deno support, TypeScript-first module resolution, cross-runtime CI, and JSR publishing. Wires a full Deno runtime adapter into runtime discovery, updates imports/tests to use .ts sources, and adds workflows/scripts to validate and publish a Deno-first package alongside existing npm workflows.

## Key Changes

- Deno runtime adapter
  - New implementation: src/runtime/deno.ts (exports type DenoNamespace and factory createDenoAdapter(ns?))
  - Permission-safe helpers (safeEnvToObject, safeCwd), synthetic argv (['deno','run', ...]), readFile semantics (null for NotFound/PermissionDenied), exit delegation, stdin line-reading, stdout/stderr wrappers
  - Minimal ambient typings: src/runtime/deno-builtins.d.ts
  - Extensive unit tests: src/runtime/deno.test.ts (many edge cases: perms, I/O, homedir/configDir)
  - Test helper for mocking Deno global: src/runtime/test-helpers.ts (withMockDenoGlobal)
  - Auto-detect now returns a Deno adapter when appropriate: src/runtime/auto.ts
  - Runtime barrels re-export Deno symbols: src/runtime/index.ts, src/runtime.ts

- Cross-runtime CI & tests
  - CI workflow: .github/workflows/ci.yml — concurrency, Bun-based lint/typecheck/format, Node/Bun test matrix, Deno smoke test against built output, build step
  - Deno smoke test script: scripts/deno-smoke-test.ts (runs under Deno against dist/runtime.mjs)
  - Tests and imports updated to .ts module specifiers and adjusted for Deno mocking

- JSR publishing
  - Publish workflow: .github/workflows/publish-jsr.yml (release/manual, sets up Deno/Bun, builds, runs smoke test, deno publish with OIDC)
  - deno.json added with package metadata, subpath exports, publish include/exclude, and nodeModulesDir/manual guidance

- Project & type improvements
  - package.json version bumped to 0.9.0
  - tsconfig.json: noEmit and allowImportingTsExtensions enabled (emit-related options removed)
  - Explicit type annotations hardened public constants (RUNTIMES, SHELLS) to satisfy JSR/type-check constraints
  - Widespread module specifier changes from .js → .ts across source and tests to support TypeScript-first resolution

- Docs & project state
  - AGENTS.md / CHANGELOG.md updated
  - .opencode state files added documenting the v0.9 plan and tasks

## Public API Surface Changes

- New public exports:
  - createDenoAdapter(ns?: DenoNamespace)
  - type DenoNamespace
- Existing public exports preserved; some exported constant types made more explicit (RUNTIMES, SHELLS). No other breaking changes observed.

## Testing & Validation

- Deno adapter covered by unit tests (vitest with mock Deno namespace) and a Deno-native smoke test that runs against built output in CI/publish workflows.
- CI runs lint/typecheck/format under Bun, vitest across Node and Bun, and a Deno smoke test to ensure cross-runtime parity.

## Notable Added Files

- .github/workflows/ci.yml
- .github/workflows/publish-jsr.yml
- deno.json
- scripts/deno-smoke-test.ts
- src/runtime/deno.ts
- src/runtime/deno-builtins.d.ts
- src/runtime/deno.test.ts
- src/runtime/test-helpers.ts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->