### PR TITLE
add: prompt-flag compatibility validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Prompt — flag kind compatibility validation** — `FlagBuilder.prompt()` now rejects incompatible
+  prompt/flag combinations at compile time via `AllowedPromptConfig<C>` (e.g.,
+  `flag.enum([…]).prompt({ kind: 'multiselect' })` is a TypeScript error). A runtime validation gate
+  in `resolvePromptValueWithConfig()` catches mismatches before the prompter is invoked, throwing a
+  `CONSTRAINT_VIOLATED` `ValidationError` with an actionable `suggest` message.
+- **`flagKind` phantom discriminator** — `FlagConfig` now carries a `flagKind` field (phantom — never
+  read at runtime) so the type system can distinguish all six flag kinds. `AllowedPromptConfig` uses
+  an indexed-access map (`PromptConfigByFlagKind`) for union-safe resolution.
+
+### Changed
+
+- **Meta-descriptions build** — `scripts/build-meta-descriptions.ts` pipes generated source through
+  `dprint fmt --stdin ts` instead of writing/reading a temp file and formatting in-place.
+
 ### Fixed
 
 - **Docs deploy** — remove dead Workers runtime vars (`BUN_VERSION`, `NODE_OPTIONS`) that had no

--- a/scripts/build-meta-descriptions.ts
+++ b/scripts/build-meta-descriptions.ts
@@ -46,6 +46,7 @@ if (checkMode) {
 await writeFile(generatedMetaSchemaDescriptionsPath, rendered);
 console.log('✓ src/core/json-schema/meta-descriptions.generated.ts updated');
 
+/** Pipe generated source through dprint via stdin for consistent formatting. */
 async function formatGeneratedSource(source: string): Promise<string> {
 	return Bun.$`bunx --bun dprint fmt --stdin ts < ${Buffer.from(source)}`.text();
 }

--- a/scripts/build-meta-descriptions.ts
+++ b/scripts/build-meta-descriptions.ts
@@ -10,8 +10,7 @@
  * @module
  */
 
-import { readFile, rm, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
 
 import { collectPublicApiIndex } from '../docs/.vitepress/data/api-index.ts';
 import {
@@ -48,16 +47,5 @@ await writeFile(generatedMetaSchemaDescriptionsPath, rendered);
 console.log('✓ src/core/json-schema/meta-descriptions.generated.ts updated');
 
 async function formatGeneratedSource(source: string): Promise<string> {
-	const tempFilePath = join(
-		dirname(generatedMetaSchemaDescriptionsPath),
-		'.meta-descriptions.generated.tmp.ts',
-	);
-
-	try {
-		await writeFile(tempFilePath, source);
-		await Bun.$`bunx --bun dprint fmt ${tempFilePath}`.quiet();
-		return await readFile(tempFilePath, 'utf8');
-	} finally {
-		await rm(tempFilePath, { force: true });
-	}
+	return Bun.$`bunx --bun dprint fmt --stdin ts < ${Buffer.from(source)}`.text();
 }

--- a/src/core/json-schema/meta-descriptions.generated.ts
+++ b/src/core/json-schema/meta-descriptions.generated.ts
@@ -6,193 +6,176 @@
 
 const definitionMetaSchemaDescriptions = {
 	root: {
-		description:
-			'Runtime descriptor for the CLI program.\n\nStores the program name, version, description, and registered commands.\\\nBuilt incrementally by CLIBuilder.',
+		description: "Runtime descriptor for the CLI program.\n\nStores the program name, version, description, and registered commands.\\\nBuilt incrementally by CLIBuilder.",
 		properties: {
-			name: {
-				description: 'Program name (used in help text, usage lines, and completion scripts).',
+			"name": {
+				description: "Program name (used in help text, usage lines, and completion scripts).",
 			},
-			version: {
-				description: 'Program version (shown by `--version`).',
+			"version": {
+				description: "Program version (shown by `--version`).",
 			},
-			description: {
-				description: 'Program description (shown in root help).',
+			"description": {
+				description: "Program description (shown in root help).",
 			},
-			defaultCommand: {
-				description:
-					'Default command dispatched when no subcommand matches.\n\nWhen set, the CLI root behaves like a hybrid command group: subcommands\ndispatch by name as usual, but empty argv or flags-only argv falls\nthrough to this command instead of showing root help.\n\nSet via the .default() builder method.',
+			"defaultCommand": {
+				description: "Default command dispatched when no subcommand matches.\n\nWhen set, the CLI root behaves like a hybrid command group: subcommands\ndispatch by name as usual, but empty argv or flags-only argv falls\nthrough to this command instead of showing root help.\n\nSet via the .default() builder method.",
 			},
-			commands: {
-				description: 'Registered commands (type-erased for heterogeneous storage).',
+			"commands": {
+				description: "Registered commands (type-erased for heterogeneous storage).",
 			},
 		},
 	},
 	defs: {
-		command: {
-			description:
-				"Runtime descriptor produced by CommandBuilder.\n\nConsumers (parser, help generator, CLI dispatcher) read this to\nunderstand the command's shape — flags, args, aliases, subcommands,\nmiddleware, and interactive resolver.",
+		"command": {
+			description: "Runtime descriptor produced by CommandBuilder.\n\nConsumers (parser, help generator, CLI dispatcher) read this to\nunderstand the command's shape — flags, args, aliases, subcommands,\nmiddleware, and interactive resolver.",
 			properties: {
-				name: {
+				"name": {
 					description: "The command name (used for dispatch, e.g. `'deploy'`).",
 				},
-				description: {
-					description: 'Human-readable description for help text.',
+				"description": {
+					description: "Human-readable description for help text.",
 				},
-				aliases: {
-					description: 'Alternative names for this command.',
+				"aliases": {
+					description: "Alternative names for this command.",
 				},
-				hidden: {
-					description: 'Whether this command is hidden from help listings.',
+				"hidden": {
+					description: "Whether this command is hidden from help listings.",
 				},
-				examples: {
-					description: 'Usage examples for help text.',
+				"examples": {
+					description: "Usage examples for help text.",
 				},
-				flags: {
-					description: 'Named flag schemas, keyed by flag name.',
+				"flags": {
+					description: "Named flag schemas, keyed by flag name.",
 				},
-				args: {
-					description: 'Ordered positional arg entries (name + schema).',
+				"args": {
+					description: "Ordered positional arg entries (name + schema).",
 				},
-				commands: {
-					description:
-						'Nested subcommand schemas (for help rendering and completion).\n\nPure data — no execution closures. Populated by `.command()` on\n`CommandBuilder`. Empty for leaf commands.',
+				"commands": {
+					description: "Nested subcommand schemas (for help rendering and completion).\n\nPure data — no execution closures. Populated by `.command()` on\n`CommandBuilder`. Empty for leaf commands.",
 				},
 			},
 		},
-		flag: {
-			description:
-				"The runtime descriptor stored inside every FlagBuilder. Consumers (parser,\nhelp generator, resolution chain) read this to understand the flag's shape\nwithout touching generics.",
+		"flag": {
+			description: "The runtime descriptor stored inside every FlagBuilder. Consumers (parser,\nhelp generator, resolution chain) read this to understand the flag's shape\nwithout touching generics.",
 			properties: {
-				kind: {
-					description: 'What kind of value this flag accepts.',
+				"kind": {
+					description: "What kind of value this flag accepts.",
 				},
-				presence: {
-					description:
-						"Presence describes whether a flag value is guaranteed to exist when the\naction handler runs:\n\n- `'optional'`  — not required; unresolved value follows the kind-specific\n  optional fallback (`undefined` for most flags, `[]` for arrays)\n- `'required'`  — must be supplied; error if missing\n- `'defaulted'` — always present (falls back to default value)",
+				"presence": {
+					description: "Presence describes whether a flag value is guaranteed to exist when the\naction handler runs:\n\n- `'optional'`  — not required; unresolved value follows the kind-specific\n  optional fallback (`undefined` for most flags, `[]` for arrays)\n- `'required'`  — must be supplied; error if missing\n- `'defaulted'` — always present (falls back to default value)",
 				},
-				defaultValue: {
-					description: 'Runtime default value (if any).',
+				"defaultValue": {
+					description: "Runtime default value (if any).",
 				},
-				aliases: {
+				"aliases": {
 					description: "Short/long aliases (e.g. `[{ name: 'f', hidden: false }]` for `--force`).",
 				},
-				envVar: {
-					description: 'Environment variable name for v0.2+ resolution.',
+				"envVar": {
+					description: "Environment variable name for v0.2+ resolution.",
 				},
-				configPath: {
+				"configPath": {
 					description: "Dotted config path for v0.2+ resolution (e.g. `'deploy.region'`).",
 				},
-				description: {
-					description: 'Human-readable description for help text.',
+				"description": {
+					description: "Human-readable description for help text.",
 				},
-				enumValues: {
+				"enumValues": {
 					description: "Allowed literal values when `kind === 'enum'`.",
 				},
-				elementSchema: {
+				"elementSchema": {
 					description: "Element schema when `kind === 'array'`.",
 				},
-				prompt: {
-					description: 'Interactive prompt configuration for v0.3+ resolution.',
+				"prompt": {
+					description: "Interactive prompt configuration for v0.3+ resolution.",
 				},
-				deprecated: {
-					description:
-						'Deprecation marker.\n\n- `undefined` — not deprecated (default)\n- `true` — deprecated with no migration message\n- `string` — deprecated with a reason/migration message\n\nWhen a deprecated flag is used, a warning is emitted to stderr.\nHelp text shows `[deprecated]` or `[deprecated: <reason>]`.',
+				"deprecated": {
+					description: "Deprecation marker.\n\n- `undefined` — not deprecated (default)\n- `true` — deprecated with no migration message\n- `string` — deprecated with a reason/migration message\n\nWhen a deprecated flag is used, a warning is emitted to stderr.\nHelp text shows `[deprecated]` or `[deprecated: <reason>]`.",
 				},
-				propagate: {
-					description:
-						'Whether this flag propagates to subcommands in nested command trees.\n\nWhen `true`, the flag is automatically available to all descendant\ncommands. A child command that defines a flag with the same name\nshadows the propagated parent flag.',
+				"propagate": {
+					description: "Whether this flag propagates to subcommands in nested command trees.\n\nWhen `true`, the flag is automatically available to all descendant\ncommands. A child command that defines a flag with the same name\nshadows the propagated parent flag.",
 				},
 			},
 		},
-		arg: {
-			description:
-				"The runtime descriptor stored inside every ArgBuilder. Consumers (parser,\nhelp generator) read this to understand the arg's shape without touching\ngenerics.",
+		"arg": {
+			description: "The runtime descriptor stored inside every ArgBuilder. Consumers (parser,\nhelp generator) read this to understand the arg's shape without touching\ngenerics.",
 			properties: {
-				name: {
-					description:
-						'A named positional argument entry in the command schema.\n\nPairs a user-facing arg name with its ArgSchema descriptor.\nThe array ordering in CommandSchema.args determines CLI position.',
+				"name": {
+					description: "A named positional argument entry in the command schema.\n\nPairs a user-facing arg name with its ArgSchema descriptor.\nThe array ordering in CommandSchema.args determines CLI position.",
 				},
-				kind: {
-					description: 'What kind of value this arg accepts.',
+				"kind": {
+					description: "What kind of value this arg accepts.",
 				},
-				presence: {
-					description:
-						"Presence describes whether a positional arg is guaranteed to exist when the\naction handler runs:\n\n- `'required'`  — must be supplied; error if missing (default)\n- `'optional'`  — may be `undefined` if not supplied\n- `'defaulted'` — always present (falls back to default value)",
+				"presence": {
+					description: "Presence describes whether a positional arg is guaranteed to exist when the\naction handler runs:\n\n- `'required'`  — must be supplied; error if missing (default)\n- `'optional'`  — may be `undefined` if not supplied\n- `'defaulted'` — always present (falls back to default value)",
 				},
-				variadic: {
-					description: 'Whether this arg consumes all remaining positionals.',
+				"variadic": {
+					description: "Whether this arg consumes all remaining positionals.",
 				},
-				stdinMode: {
-					description: 'Whether this arg may read from stdin during resolution.',
+				"stdinMode": {
+					description: "Whether this arg may read from stdin during resolution.",
 				},
-				defaultValue: {
-					description: 'Runtime default value (if any).',
+				"defaultValue": {
+					description: "Runtime default value (if any).",
 				},
-				description: {
-					description: 'Human-readable description for help text.',
+				"description": {
+					description: "Human-readable description for help text.",
 				},
-				envVar: {
-					description:
-						"Environment variable name for env resolution.\n\nWhen set and the CLI value is absent, the resolver reads this env var\nand coerces the string to the arg's declared kind.",
+				"envVar": {
+					description: "Environment variable name for env resolution.\n\nWhen set and the CLI value is absent, the resolver reads this env var\nand coerces the string to the arg's declared kind.",
 				},
-				enumValues: {
+				"enumValues": {
 					description: "Allowed literal values when `kind === 'enum'`.",
 				},
-				deprecated: {
-					description:
-						'Deprecation marker.\n\n- `undefined` — not deprecated (default)\n- `true` — deprecated with no migration message\n- `string` — deprecated with a reason/migration message\n\nWhen a deprecated arg is used, a warning is emitted to stderr.\nHelp text shows `[deprecated]` or `[deprecated: <reason>]`.',
+				"deprecated": {
+					description: "Deprecation marker.\n\n- `undefined` — not deprecated (default)\n- `true` — deprecated with no migration message\n- `string` — deprecated with a reason/migration message\n\nWhen a deprecated arg is used, a warning is emitted to stderr.\nHelp text shows `[deprecated]` or `[deprecated: <reason>]`.",
 				},
 			},
 		},
-		prompt: {
-			description:
-				"Discriminated union of all prompt configurations.\n\nUse the `kind` field to narrow:\n```ts\nif (config.kind === 'select') {\n  config.choices // readonly SelectChoice[] | undefined\n}\n```",
+		"prompt": {
+			description: "Discriminated union of all prompt configurations.\n\nUse the `kind` field to narrow:\n```ts\nif (config.kind === 'select') {\n  config.choices // readonly SelectChoice[] | undefined\n}\n```",
 			properties: {
-				kind: {
-					description:
-						"The kind of interactive prompt to present.\n\n- `'confirm'`     — yes/no boolean question\n- `'input'`       — free-text string input\n- `'select'`      — single selection from a list\n- `'multiselect'` — multiple selections from a list",
+				"kind": {
+					description: "The kind of interactive prompt to present.\n\n- `'confirm'`     — yes/no boolean question\n- `'input'`       — free-text string input\n- `'select'`      — single selection from a list\n- `'multiselect'` — multiple selections from a list",
 				},
-				message: {
-					description: 'The question displayed to the user.',
+				"message": {
+					description: "The question displayed to the user.",
 				},
-				placeholder: {
-					description: 'Placeholder text shown before user types (informational only).',
+				"placeholder": {
+					description: "Placeholder text shown before user types (informational only).",
 				},
-				choices: {
-					description:
-						'Available choices. When omitted for `enum` flags, the enum values\nfrom the flag schema are used automatically.',
+				"choices": {
+					description: "Available choices. When omitted for `enum` flags, the enum values\nfrom the flag schema are used automatically.",
 				},
-				min: {
-					description: 'Minimum number of selections required.',
+				"min": {
+					description: "Minimum number of selections required.",
 				},
-				max: {
-					description: 'Maximum number of selections allowed.',
+				"max": {
+					description: "Maximum number of selections allowed.",
 				},
 			},
 		},
-		choice: {
-			description:
-				'A selectable option for SelectPromptConfig and MultiselectPromptConfig prompts.',
+		"choice": {
+			description: "A selectable option for SelectPromptConfig and MultiselectPromptConfig prompts.",
 			properties: {
-				value: {
-					description: 'The value returned when this choice is selected.',
+				"value": {
+					description: "The value returned when this choice is selected.",
 				},
-				label: {
-					description: 'Display label shown to the user.',
+				"label": {
+					description: "Display label shown to the user.",
 				},
-				description: {
-					description: 'Optional description shown alongside the choice.',
+				"description": {
+					description: "Optional description shown alongside the choice.",
 				},
 			},
 		},
-		example: {
-			description: 'A single usage example shown in help text.',
+		"example": {
+			description: "A single usage example shown in help text.",
 			properties: {
-				command: {
+				"command": {
 					description: "The command invocation (e.g. `'deploy production --force'`).",
 				},
-				description: {
-					description: 'Optional description of what this example does.',
+				"description": {
+					description: "Optional description of what this example does.",
 				},
 			},
 		},

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -28,7 +28,7 @@ Each source tried in order; first non-undefined wins. Missing required values wi
 
 | Function                            | File        | Role                                                          |
 | ----------------------------------- | ----------- | ------------------------------------------------------------- |
-| `resolve()`                         | `flags.ts`  | Main entry — orchestrates full resolution for a command       |
+| `resolve()`                         | `index.ts`  | Main entry — orchestrates full resolution for a command       |
 | `resolveFlags()`                    | `flags.ts`  | All flags: CLI -> env -> config -> prompt -> default          |
 | `resolveArgs()`                     | `args.ts`   | All args: parsed -> default -> required validation            |
 | `coerceValue()`                     | `coerce.ts` | Unified raw value -> flag's declared kind (env/config/prompt) |

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -26,13 +26,14 @@ Each source tried in order; first non-undefined wins. Missing required values wi
 
 ## KEY FUNCTIONS
 
-| Function              | File        | Role                                                          |
-| --------------------- | ----------- | ------------------------------------------------------------- |
-| `resolve()`           | `flags.ts`  | Main entry — orchestrates full resolution for a command       |
-| `resolveFlags()`      | `flags.ts`  | All flags: CLI -> env -> config -> prompt -> default          |
-| `resolveArgs()`       | `args.ts`   | All args: parsed -> default -> required validation            |
-| `coerceValue()`       | `coerce.ts` | Unified raw value -> flag's declared kind (env/config/prompt) |
-| `resolveConfigPath()` | `config.ts` | Dotted path lookup in config object                           |
+| Function                            | File        | Role                                                          |
+| ----------------------------------- | ----------- | ------------------------------------------------------------- |
+| `resolve()`                         | `flags.ts`  | Main entry — orchestrates full resolution for a command       |
+| `resolveFlags()`                    | `flags.ts`  | All flags: CLI -> env -> config -> prompt -> default          |
+| `resolveArgs()`                     | `args.ts`   | All args: parsed -> default -> required validation            |
+| `coerceValue()`                     | `coerce.ts` | Unified raw value -> flag's declared kind (env/config/prompt) |
+| `resolveConfigPath()`               | `config.ts` | Dotted path lookup in config object                           |
+| `validatePromptFlagCompatibility()` | `flags.ts`  | Prompt kind ↔ flag kind gate (before prompter invocation)     |
 
 ## TWO-PASS ARCHITECTURE
 
@@ -73,6 +74,23 @@ once.
 | `resolve-stdin.test.ts`       | Stdin-based resolution                     |
 | `contracts.test.ts`           | Contract verification                      |
 | `property.test.ts`            | Property path resolution                   |
+
+## PROMPT — FLAG KIND COMPATIBILITY
+
+`COMPATIBLE_PROMPT_KINDS` in `flags.ts` maps each `FlagKind` to allowed `PromptKind[]`:
+
+| Flag kind | Allowed prompt kinds                      |
+| --------- | ----------------------------------------- |
+| boolean   | confirm                                   |
+| string    | input, select                             |
+| number    | input                                     |
+| enum      | select, input                             |
+| array     | multiselect                               |
+| custom    | input, select, confirm, multiselect (all) |
+
+`validatePromptFlagCompatibility()` checks this map before `prompter.promptOne()` runs. Mismatches
+produce a `CONSTRAINT_VIOLATED` `ValidationError` with `details.flagKind`, `details.promptKind`, and
+an actionable `suggest`. This mirrors the compile-time `AllowedPromptConfig<C>` in `schema/flag.ts`.
 
 ## GOTCHAS
 

--- a/src/core/resolve/flags.ts
+++ b/src/core/resolve/flags.ts
@@ -8,8 +8,12 @@
 import { ValidationError } from '#internals/core/errors/index.ts';
 import type { PromptEngine } from '#internals/core/prompt/index.ts';
 import { resolvePromptConfig } from '#internals/core/prompt/index.ts';
-import type { ErasedInteractiveResolver, FlagSchema } from '#internals/core/schema/index.ts';
-import type { PromptConfig } from '#internals/core/schema/prompt.ts';
+import type {
+	ErasedInteractiveResolver,
+	FlagKind,
+	FlagSchema,
+} from '#internals/core/schema/index.ts';
+import type { PromptConfig, PromptKind } from '#internals/core/schema/prompt.ts';
 import { coerceValue } from './coerce.ts';
 import { resolveConfigPath } from './config.ts';
 import type { DeprecationWarning } from './contracts.ts';
@@ -165,12 +169,45 @@ async function resolveFlags(
 	return resolved;
 }
 
+/** Maps each flag kind to the prompt kinds that produce compatible values. */
+const COMPATIBLE_PROMPT_KINDS: Record<FlagKind, readonly PromptKind[]> = {
+	boolean: ['confirm'],
+	string: ['input', 'select'],
+	number: ['input'],
+	enum: ['select'],
+	array: ['multiselect'],
+	custom: ['input', 'select', 'confirm', 'multiselect'],
+};
+
+function validatePromptFlagCompatibility(
+	flagName: string,
+	flagKind: FlagKind,
+	promptKind: PromptKind,
+): ValidationError | undefined {
+	const allowed = COMPATIBLE_PROMPT_KINDS[flagKind];
+	if (allowed.includes(promptKind)) return undefined;
+
+	return new ValidationError(
+		`Prompt kind '${promptKind}' is not compatible with ${flagKind} flag --${flagName}. Use '${allowed[0]}' instead`,
+		{
+			code: 'CONSTRAINT_VIOLATED',
+			details: { flag: flagName, flagKind, promptKind, allowed },
+			suggest: `Change the prompt to { kind: '${allowed[0]}' } for --${flagName}`,
+		},
+	);
+}
+
 async function resolvePromptValueWithConfig(
 	flagName: string,
 	schema: FlagSchema,
 	promptConfig: PromptConfig,
 	prompter: PromptEngine,
 ): Promise<PromptResolveResult> {
+	const mismatch = validatePromptFlagCompatibility(flagName, schema.kind, promptConfig.kind);
+	if (mismatch !== undefined) {
+		return { ok: false, error: mismatch };
+	}
+
 	const resolvedConfig = resolvePromptConfig(promptConfig, schema.enumValues);
 	const result = await prompter.promptOne(resolvedConfig);
 

--- a/src/core/resolve/flags.ts
+++ b/src/core/resolve/flags.ts
@@ -179,6 +179,13 @@ const COMPATIBLE_PROMPT_KINDS: Record<FlagKind, readonly PromptKind[]> = {
 	custom: ['input', 'select', 'confirm', 'multiselect'],
 };
 
+/**
+ * Check whether a prompt kind is compatible with the flag's declared kind.
+ *
+ * @returns `undefined` when compatible, or a {@link ValidationError} with
+ * code `'CONSTRAINT_VIOLATED'` and an actionable `suggest` message when not.
+ * @internal
+ */
 function validatePromptFlagCompatibility(
 	flagName: string,
 	flagKind: FlagKind,
@@ -197,6 +204,14 @@ function validatePromptFlagCompatibility(
 	);
 }
 
+/**
+ * Validate prompt/flag compatibility, run the prompt engine, and coerce the result.
+ *
+ * Returns early with a {@link ValidationError} if the prompt kind is
+ * incompatible with the flag kind (checked via {@link COMPATIBLE_PROMPT_KINDS}
+ * before the prompter is invoked).
+ * @internal
+ */
 async function resolvePromptValueWithConfig(
 	flagName: string,
 	schema: FlagSchema,
@@ -218,6 +233,7 @@ async function resolvePromptValueWithConfig(
 	return coerceValue(flagName, { kind: 'prompt' }, result.value, schema);
 }
 
+/** Build a human-readable suggestion listing all available sources for a required flag. @internal */
 function buildRequiredFlagSuggest(name: string, schema: FlagSchema): string {
 	const sources: string[] = [];
 	sources.push(`Provide --${name}${schema.kind !== 'boolean' ? ' <value>' : ''}`);

--- a/src/core/resolve/flags.ts
+++ b/src/core/resolve/flags.ts
@@ -174,7 +174,7 @@ const COMPATIBLE_PROMPT_KINDS: Record<FlagKind, readonly PromptKind[]> = {
 	boolean: ['confirm'],
 	string: ['input', 'select'],
 	number: ['input'],
-	enum: ['select'],
+	enum: ['select', 'input'],
 	array: ['multiselect'],
 	custom: ['input', 'select', 'confirm', 'multiselect'],
 };

--- a/src/core/resolve/flags.ts
+++ b/src/core/resolve/flags.ts
@@ -252,4 +252,4 @@ function buildRequiredFlagSuggest(name: string, schema: FlagSchema): string {
 	return sources.length === 2 ? `${rest.join('')} or ${last}` : `${rest.join(', ')}, or ${last}`;
 }
 
-export { resolveFlags };
+export { COMPATIBLE_PROMPT_KINDS, resolveFlags };

--- a/src/core/resolve/flags.ts
+++ b/src/core/resolve/flags.ts
@@ -8,11 +8,8 @@
 import { ValidationError } from '#internals/core/errors/index.ts';
 import type { PromptEngine } from '#internals/core/prompt/index.ts';
 import { resolvePromptConfig } from '#internals/core/prompt/index.ts';
-import type {
-	ErasedInteractiveResolver,
-	FlagKind,
-	FlagSchema,
-} from '#internals/core/schema/index.ts';
+import type { ErasedInteractiveResolver } from '#internals/core/schema/command.ts';
+import type { FlagKind, FlagSchema } from '#internals/core/schema/flag.ts';
 import type { PromptConfig, PromptKind } from '#internals/core/schema/prompt.ts';
 import { coerceValue } from './coerce.ts';
 import { resolveConfigPath } from './config.ts';

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -10,9 +10,11 @@ import { describe, expect, it } from 'vitest';
 import { ValidationError } from '#internals/core/errors/index.ts';
 import type { ParseResult } from '#internals/core/parse/index.ts';
 import { createTestPrompter, PROMPT_CANCEL } from '#internals/core/prompt/index.ts';
+import { FLAG_KINDS } from '#internals/core/schema/flag.ts';
 import type { CommandSchema } from '#internals/core/schema/index.ts';
 import { createSchema } from '#internals/core/schema/index.ts';
 import type { ResolveOptions } from './index.ts';
+import { COMPATIBLE_PROMPT_KINDS } from './flags.ts';
 import { resolve } from './index.ts';
 
 // --- Helpers
@@ -702,6 +704,16 @@ describe('resolve', () => {
 
 			const result = await resolve(schema, parsed, { prompter });
 			expect(result.deprecations).toHaveLength(0);
+		});
+	});
+
+	// --- drift guard
+
+	describe('drift guard', () => {
+		it('COMPATIBLE_PROMPT_KINDS covers all FLAG_KINDS', () => {
+			for (const kind of FLAG_KINDS) {
+				expect(COMPATIBLE_PROMPT_KINDS).toHaveProperty(kind);
+			}
 		});
 	});
 });

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -409,10 +409,7 @@ describe('resolve', () => {
 			const parsed = makeParsed();
 			const prompter = createTestPrompter([]);
 
-			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
-			await expect(resolve(schema, parsed, { prompter: createTestPrompter([]) })).rejects.toThrow(
-				/not compatible/,
-			);
+			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(/not compatible/);
 		});
 
 		it('rejects input on boolean flag', async () => {
@@ -534,6 +531,47 @@ describe('resolve', () => {
 
 			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
 			expect(prompted).toBe(false);
+		});
+	});
+
+	// --- allowed prompt / flag combinations (positive tests)
+
+	describe('allowed prompt / flag combinations', () => {
+		it('accepts input on enum flag', async () => {
+			const schema = makeSchema({
+				flags: {
+					region: createSchema('enum', {
+						enumValues: ['us', 'eu'],
+						prompt: { kind: 'input', message: 'Region?' },
+						presence: 'required',
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter(['eu']);
+
+			const result = await resolve(schema, parsed, { prompter });
+			expect(result.flags).toEqual({ region: 'eu' });
+		});
+
+		it('accepts select on string flag', async () => {
+			const schema = makeSchema({
+				flags: {
+					format: createSchema('string', {
+						prompt: {
+							kind: 'select',
+							message: 'Format?',
+							choices: [{ value: 'json' }, { value: 'yaml' }],
+						},
+						presence: 'required',
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter(['json']);
+
+			const result = await resolve(schema, parsed, { prompter });
+			expect(result.flags).toEqual({ format: 'json' });
 		});
 	});
 

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -393,185 +393,193 @@ describe('resolve', () => {
 		});
 	});
 
-	// --- prompt kind / flag kind mismatch (issue #11)
+	// --- prompt — flag kind compatibility (issue #11)
 
-	describe('prompt kind / flag kind mismatch', () => {
-		it('rejects multiselect on enum flag', async () => {
-			const schema = makeSchema({
-				flags: {
-					mood: createSchema('enum', {
-						enumValues: ['calm', 'happy'],
-						prompt: { kind: 'multiselect', message: 'Pick moods' },
-						presence: 'required',
-					}),
-				},
+	describe('prompt — flag kind compatibility', () => {
+		// --- rejected combinations
+
+		describe('rejected combinations', () => {
+			it('rejects multiselect on enum flag', async () => {
+				const schema = makeSchema({
+					flags: {
+						mood: createSchema('enum', {
+							enumValues: ['calm', 'happy'],
+							prompt: { kind: 'multiselect', message: 'Pick moods' },
+							presence: 'required',
+						}),
+					},
+				});
+				const parsed = makeParsed();
+				const prompter = createTestPrompter([]);
+
+				await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(/not compatible/);
 			});
-			const parsed = makeParsed();
-			const prompter = createTestPrompter([]);
 
-			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(/not compatible/);
+			it('rejects input on boolean flag', async () => {
+				const schema = makeSchema({
+					flags: {
+						force: createSchema('boolean', {
+							prompt: { kind: 'input', message: 'Force?' },
+						}),
+					},
+				});
+				const parsed = makeParsed();
+				const prompter = createTestPrompter([]);
+
+				await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+			});
+
+			it('rejects multiselect on boolean flag', async () => {
+				const schema = makeSchema({
+					flags: {
+						force: createSchema('boolean', {
+							prompt: { kind: 'multiselect', message: 'Force?' },
+						}),
+					},
+				});
+				const parsed = makeParsed();
+				const prompter = createTestPrompter([]);
+
+				await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+			});
+
+			it('rejects confirm on string flag', async () => {
+				const schema = makeSchema({
+					flags: {
+						name: createSchema('string', {
+							prompt: { kind: 'confirm', message: 'Name?' },
+							presence: 'required',
+						}),
+					},
+				});
+				const parsed = makeParsed();
+				const prompter = createTestPrompter([]);
+
+				await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+			});
+
+			it('rejects multiselect on number flag', async () => {
+				const schema = makeSchema({
+					flags: {
+						port: createSchema('number', {
+							prompt: { kind: 'multiselect', message: 'Port?' },
+							presence: 'required',
+						}),
+					},
+				});
+				const parsed = makeParsed();
+				const prompter = createTestPrompter([]);
+
+				await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+			});
+
+			it('rejects confirm on number flag', async () => {
+				const schema = makeSchema({
+					flags: {
+						port: createSchema('number', {
+							prompt: { kind: 'confirm', message: 'Port?' },
+							presence: 'required',
+						}),
+					},
+				});
+				const parsed = makeParsed();
+				const prompter = createTestPrompter([]);
+
+				await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+			});
 		});
 
-		it('rejects input on boolean flag', async () => {
-			const schema = makeSchema({
-				flags: {
-					force: createSchema('boolean', {
-						prompt: { kind: 'input', message: 'Force?' },
-					}),
-				},
-			});
-			const parsed = makeParsed();
-			const prompter = createTestPrompter([]);
+		// --- error diagnostics
 
-			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+		describe('error diagnostics', () => {
+			it('includes flag name and suggested kind in error message', async () => {
+				const schema = makeSchema({
+					flags: {
+						mood: createSchema('enum', {
+							enumValues: ['calm', 'happy'],
+							prompt: { kind: 'multiselect', message: 'Pick moods' },
+							presence: 'required',
+						}),
+					},
+				});
+				const parsed = makeParsed();
+				const prompter = createTestPrompter([]);
+
+				try {
+					await resolve(schema, parsed, { prompter });
+					expect.unreachable('should have thrown');
+				} catch (error) {
+					expect(error).toBeInstanceOf(ValidationError);
+					const ve = error as InstanceType<typeof ValidationError>;
+					expect(ve.message).toContain('multiselect');
+					expect(ve.message).toContain('--mood');
+					expect(ve.code).toBe('CONSTRAINT_VIOLATED');
+				}
+			});
+
+			it('does not prompt the user before rejecting', async () => {
+				let prompted = false;
+				const prompter: import('#internals/core/prompt/index.ts').PromptEngine = {
+					promptOne() {
+						prompted = true;
+						return Promise.resolve({ answered: true, value: 'calm' });
+					},
+				};
+				const schema = makeSchema({
+					flags: {
+						mood: createSchema('enum', {
+							enumValues: ['calm', 'happy'],
+							prompt: { kind: 'multiselect', message: 'Pick moods' },
+							presence: 'required',
+						}),
+					},
+				});
+				const parsed = makeParsed();
+
+				await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+				expect(prompted).toBe(false);
+			});
 		});
 
-		it('rejects multiselect on boolean flag', async () => {
-			const schema = makeSchema({
-				flags: {
-					force: createSchema('boolean', {
-						prompt: { kind: 'multiselect', message: 'Force?' },
-					}),
-				},
+		// --- allowed combinations
+
+		describe('allowed combinations', () => {
+			it('accepts input on enum flag', async () => {
+				const schema = makeSchema({
+					flags: {
+						region: createSchema('enum', {
+							enumValues: ['us', 'eu'],
+							prompt: { kind: 'input', message: 'Region?' },
+							presence: 'required',
+						}),
+					},
+				});
+				const parsed = makeParsed();
+				const prompter = createTestPrompter(['eu']);
+
+				const result = await resolve(schema, parsed, { prompter });
+				expect(result.flags).toEqual({ region: 'eu' });
 			});
-			const parsed = makeParsed();
-			const prompter = createTestPrompter([]);
 
-			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
-		});
+			it('accepts select on string flag', async () => {
+				const schema = makeSchema({
+					flags: {
+						format: createSchema('string', {
+							prompt: {
+								kind: 'select',
+								message: 'Format?',
+								choices: [{ value: 'json' }, { value: 'yaml' }],
+							},
+							presence: 'required',
+						}),
+					},
+				});
+				const parsed = makeParsed();
+				const prompter = createTestPrompter(['json']);
 
-		it('rejects confirm on string flag', async () => {
-			const schema = makeSchema({
-				flags: {
-					name: createSchema('string', {
-						prompt: { kind: 'confirm', message: 'Name?' },
-						presence: 'required',
-					}),
-				},
+				const result = await resolve(schema, parsed, { prompter });
+				expect(result.flags).toEqual({ format: 'json' });
 			});
-			const parsed = makeParsed();
-			const prompter = createTestPrompter([]);
-
-			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
-		});
-
-		it('rejects multiselect on number flag', async () => {
-			const schema = makeSchema({
-				flags: {
-					port: createSchema('number', {
-						prompt: { kind: 'multiselect', message: 'Port?' },
-						presence: 'required',
-					}),
-				},
-			});
-			const parsed = makeParsed();
-			const prompter = createTestPrompter([]);
-
-			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
-		});
-
-		it('rejects confirm on number flag', async () => {
-			const schema = makeSchema({
-				flags: {
-					port: createSchema('number', {
-						prompt: { kind: 'confirm', message: 'Port?' },
-						presence: 'required',
-					}),
-				},
-			});
-			const parsed = makeParsed();
-			const prompter = createTestPrompter([]);
-
-			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
-		});
-
-		it('includes flag name and suggested kind in error message', async () => {
-			const schema = makeSchema({
-				flags: {
-					mood: createSchema('enum', {
-						enumValues: ['calm', 'happy'],
-						prompt: { kind: 'multiselect', message: 'Pick moods' },
-						presence: 'required',
-					}),
-				},
-			});
-			const parsed = makeParsed();
-			const prompter = createTestPrompter([]);
-
-			try {
-				await resolve(schema, parsed, { prompter });
-				expect.unreachable('should have thrown');
-			} catch (error) {
-				expect(error).toBeInstanceOf(ValidationError);
-				const ve = error as InstanceType<typeof ValidationError>;
-				expect(ve.message).toContain('multiselect');
-				expect(ve.message).toContain('--mood');
-				expect(ve.code).toBe('CONSTRAINT_VIOLATED');
-			}
-		});
-
-		it('does not prompt the user before rejecting', async () => {
-			let prompted = false;
-			const prompter: import('#internals/core/prompt/index.ts').PromptEngine = {
-				promptOne() {
-					prompted = true;
-					return Promise.resolve({ answered: true, value: 'calm' });
-				},
-			};
-			const schema = makeSchema({
-				flags: {
-					mood: createSchema('enum', {
-						enumValues: ['calm', 'happy'],
-						prompt: { kind: 'multiselect', message: 'Pick moods' },
-						presence: 'required',
-					}),
-				},
-			});
-			const parsed = makeParsed();
-
-			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
-			expect(prompted).toBe(false);
-		});
-	});
-
-	// --- allowed prompt / flag combinations (positive tests)
-
-	describe('allowed prompt / flag combinations', () => {
-		it('accepts input on enum flag', async () => {
-			const schema = makeSchema({
-				flags: {
-					region: createSchema('enum', {
-						enumValues: ['us', 'eu'],
-						prompt: { kind: 'input', message: 'Region?' },
-						presence: 'required',
-					}),
-				},
-			});
-			const parsed = makeParsed();
-			const prompter = createTestPrompter(['eu']);
-
-			const result = await resolve(schema, parsed, { prompter });
-			expect(result.flags).toEqual({ region: 'eu' });
-		});
-
-		it('accepts select on string flag', async () => {
-			const schema = makeSchema({
-				flags: {
-					format: createSchema('string', {
-						prompt: {
-							kind: 'select',
-							message: 'Format?',
-							choices: [{ value: 'json' }, { value: 'yaml' }],
-						},
-						presence: 'required',
-					}),
-				},
-			});
-			const parsed = makeParsed();
-			const prompter = createTestPrompter(['json']);
-
-			const result = await resolve(schema, parsed, { prompter });
-			expect(result.flags).toEqual({ format: 'json' });
 		});
 	});
 

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -715,5 +715,11 @@ describe('resolve', () => {
 				expect(COMPATIBLE_PROMPT_KINDS).toHaveProperty(kind);
 			}
 		});
+
+		it('COMPATIBLE_PROMPT_KINDS contains no stale keys', () => {
+			for (const key of Object.keys(COMPATIBLE_PROMPT_KINDS)) {
+				expect(FLAG_KINDS).toContain(key);
+			}
+		});
 	});
 });

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -393,6 +393,150 @@ describe('resolve', () => {
 		});
 	});
 
+	// --- prompt kind / flag kind mismatch (issue #11)
+
+	describe('prompt kind / flag kind mismatch', () => {
+		it('rejects multiselect on enum flag', async () => {
+			const schema = makeSchema({
+				flags: {
+					mood: createSchema('enum', {
+						enumValues: ['calm', 'happy'],
+						prompt: { kind: 'multiselect', message: 'Pick moods' },
+						presence: 'required',
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter([]);
+
+			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+			await expect(resolve(schema, parsed, { prompter: createTestPrompter([]) })).rejects.toThrow(
+				/not compatible/,
+			);
+		});
+
+		it('rejects input on boolean flag', async () => {
+			const schema = makeSchema({
+				flags: {
+					force: createSchema('boolean', {
+						prompt: { kind: 'input', message: 'Force?' },
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter([]);
+
+			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+		});
+
+		it('rejects multiselect on boolean flag', async () => {
+			const schema = makeSchema({
+				flags: {
+					force: createSchema('boolean', {
+						prompt: { kind: 'multiselect', message: 'Force?' },
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter([]);
+
+			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+		});
+
+		it('rejects confirm on string flag', async () => {
+			const schema = makeSchema({
+				flags: {
+					name: createSchema('string', {
+						prompt: { kind: 'confirm', message: 'Name?' },
+						presence: 'required',
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter([]);
+
+			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+		});
+
+		it('rejects multiselect on number flag', async () => {
+			const schema = makeSchema({
+				flags: {
+					port: createSchema('number', {
+						prompt: { kind: 'multiselect', message: 'Port?' },
+						presence: 'required',
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter([]);
+
+			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+		});
+
+		it('rejects confirm on number flag', async () => {
+			const schema = makeSchema({
+				flags: {
+					port: createSchema('number', {
+						prompt: { kind: 'confirm', message: 'Port?' },
+						presence: 'required',
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter([]);
+
+			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+		});
+
+		it('includes flag name and suggested kind in error message', async () => {
+			const schema = makeSchema({
+				flags: {
+					mood: createSchema('enum', {
+						enumValues: ['calm', 'happy'],
+						prompt: { kind: 'multiselect', message: 'Pick moods' },
+						presence: 'required',
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter([]);
+
+			try {
+				await resolve(schema, parsed, { prompter });
+				expect.unreachable('should have thrown');
+			} catch (error) {
+				expect(error).toBeInstanceOf(ValidationError);
+				const ve = error as InstanceType<typeof ValidationError>;
+				expect(ve.message).toContain('multiselect');
+				expect(ve.message).toContain('--mood');
+				expect(ve.code).toBe('CONSTRAINT_VIOLATED');
+			}
+		});
+
+		it('does not prompt the user before rejecting', async () => {
+			let prompted = false;
+			const prompter: import('#internals/core/prompt/index.ts').PromptEngine = {
+				promptOne() {
+					prompted = true;
+					return Promise.resolve({ answered: true, value: 'calm' });
+				},
+			};
+			const schema = makeSchema({
+				flags: {
+					mood: createSchema('enum', {
+						enumValues: ['calm', 'happy'],
+						prompt: { kind: 'multiselect', message: 'Pick moods' },
+						presence: 'required',
+					}),
+				},
+			});
+			const parsed = makeParsed();
+
+			await expect(resolve(schema, parsed, { prompter })).rejects.toThrow(ValidationError);
+			expect(prompted).toBe(false);
+		});
+	});
+
 	// --- backward compatibility
 
 	describe('backward compatibility', () => {

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -515,6 +515,7 @@ describe('resolve', () => {
 					const ve = error as InstanceType<typeof ValidationError>;
 					expect(ve.message).toContain('multiselect');
 					expect(ve.message).toContain('--mood');
+					expect(ve.message).toContain("'select'");
 					expect(ve.code).toBe('CONSTRAINT_VIOLATED');
 				}
 			});

--- a/src/core/schema/AGENTS.md
+++ b/src/core/schema/AGENTS.md
@@ -25,6 +25,11 @@ Multi-file module in `core/`. All others (except resolve, output, completion) us
   defaults — justified, do not "fix"
 - **Phantom brand**: `Middleware<Output>` carries type info at compile time, erased at runtime.
   Same for `_value` on FlagBuilder/ArgBuilder.
+- **`flagKind` phantom discriminator**: `FlagConfig.flagKind` mirrors `FlagSchema.kind` at the type
+  level. Each factory (`flag.string()`, `.enum()`, etc.) sets a literal `flagKind` so that
+  `AllowedPromptConfig<C>` can map each kind to its compatible prompt types via the
+  `PromptConfigByFlagKind` indexed-access map. `WithPresence` propagates `flagKind` through
+  `.required()` / `.default()` chains. Never read at runtime — phantom only.
 - **Type erasure**: `eraseBuilder()` / `eraseCommand()` centralize `as unknown as` casts for
   heterogeneous subcommand storage. These are the justified `as` cast sites.
 
@@ -35,6 +40,20 @@ Multi-file module in `core/`. All others (except resolve, output, completion) us
 3. Update `InferFlag` conditional type
 4. Wire through `resolve/coerce.ts` (add coercion case in unified `coerceValue()`)
 5. Add tests in `flag.test.ts` + `resolve.test.ts`
+
+## PROMPT — FLAG KIND CONSTRAINTS
+
+`FlagBuilder.prompt()` signature is `prompt(config: AllowedPromptConfig<C>)` — a compile-time gate.
+`AllowedPromptConfig<C>` indexes into `PromptConfigByFlagKind` using `C['flagKind']`:
+
+- `boolean` → `ConfirmPromptConfig`
+- `string` → `InputPromptConfig | SelectPromptConfig`
+- `number` → `InputPromptConfig`
+- `enum` → `SelectPromptConfig | InputPromptConfig`
+- `array` → `MultiselectPromptConfig`
+- `custom` → `PromptConfig` (all kinds — the `parseFn` is responsible for handling any prompt result)
+
+Runtime enforcement lives in `resolve/flags.ts` (`COMPATIBLE_PROMPT_KINDS` + `validatePromptFlagCompatibility()`).
 
 ## GOTCHAS
 

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -54,6 +54,8 @@ interface FlagConfig {
 	readonly presence: FlagPresence;
 	/** What an unresolved optional flag becomes at the action boundary. */
 	readonly optionalFallback: OptionalFallback;
+	/** The runtime kind discriminator, mirroring {@link FlagKind}. */
+	readonly flagKind: FlagKind;
 }
 
 // --- Type-level helpers
@@ -66,6 +68,7 @@ type WithPresence<C extends FlagConfig, P extends FlagPresence> = {
 	readonly valueType: C['valueType'];
 	readonly presence: P;
 	readonly optionalFallback: C['optionalFallback'];
+	readonly flagKind: C['flagKind'];
 };
 
 /**
@@ -95,21 +98,27 @@ type InferFlags<T extends Record<string, FlagBuilder<FlagConfig>>> = {
 
 /**
  * Maps a {@linkcode FlagConfig} to the prompt config types that are compatible
- * with the flag's value type. Prevents compile-time mismatches such as
+ * with the flag's kind. Prevents compile-time mismatches such as
  * `flag.enum([…]).prompt({ kind: 'multiselect' })`.
  *
- * - Array flags (`optionalFallback: 'empty-array'`) → {@link MultiselectPromptConfig}
- * - Boolean flags → {@link ConfirmPromptConfig}
- * - Number flags → {@link InputPromptConfig}
- * - String / enum / custom flags → {@link InputPromptConfig} | {@link SelectPromptConfig}
+ * - `'boolean'` → {@link ConfirmPromptConfig}
+ * - `'string'`  → {@link InputPromptConfig} | {@link SelectPromptConfig}
+ * - `'number'`  → {@link InputPromptConfig}
+ * - `'enum'`    → {@link SelectPromptConfig} | {@link InputPromptConfig}
+ * - `'array'`   → {@link MultiselectPromptConfig}
+ * - `'custom'`  → all prompt kinds ({@link PromptConfig})
  */
-type AllowedPromptConfig<C extends FlagConfig> = C['optionalFallback'] extends 'empty-array'
+type AllowedPromptConfig<C extends FlagConfig> = C['flagKind'] extends 'array'
 	? MultiselectPromptConfig
-	: C['valueType'] extends boolean
+	: C['flagKind'] extends 'boolean'
 		? ConfirmPromptConfig
-		: C['valueType'] extends number
+		: C['flagKind'] extends 'number'
 			? InputPromptConfig
-			: InputPromptConfig | SelectPromptConfig;
+			: C['flagKind'] extends 'enum'
+				? SelectPromptConfig | InputPromptConfig
+				: C['flagKind'] extends 'custom'
+					? PromptConfig
+					: InputPromptConfig | SelectPromptConfig;
 
 // --- Runtime schema data
 
@@ -571,6 +580,7 @@ interface FlagFactory {
 		readonly valueType: string;
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'string';
 	}>;
 
 	/**
@@ -582,6 +592,7 @@ interface FlagFactory {
 		readonly valueType: number;
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'number';
 	}>;
 
 	/**
@@ -594,6 +605,7 @@ interface FlagFactory {
 		readonly valueType: boolean;
 		readonly presence: 'defaulted';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'boolean';
 	}>;
 
 	/**
@@ -617,6 +629,7 @@ interface FlagFactory {
 		readonly valueType: T[number];
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'enum';
 	}>;
 
 	/**
@@ -637,6 +650,7 @@ interface FlagFactory {
 		readonly valueType: E['valueType'][];
 		readonly presence: 'optional';
 		readonly optionalFallback: 'empty-array';
+		readonly flagKind: 'array';
 	}>;
 
 	/**
@@ -672,6 +686,7 @@ interface FlagFactory {
 		readonly valueType: T;
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'custom';
 	}>;
 }
 
@@ -684,6 +699,7 @@ const flag: FlagFactory = {
 		readonly valueType: string;
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'string';
 	}> {
 		return new FlagBuilder(createSchema('string'));
 	},
@@ -692,6 +708,7 @@ const flag: FlagFactory = {
 		readonly valueType: number;
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'number';
 	}> {
 		return new FlagBuilder(createSchema('number'));
 	},
@@ -700,6 +717,7 @@ const flag: FlagFactory = {
 		readonly valueType: boolean;
 		readonly presence: 'defaulted';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'boolean';
 	}> {
 		return new FlagBuilder(
 			createSchema('boolean', {
@@ -715,6 +733,7 @@ const flag: FlagFactory = {
 		readonly valueType: T[number];
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'enum';
 	}> {
 		return new FlagBuilder(createSchema('enum', { enumValues: values }));
 	},
@@ -725,6 +744,7 @@ const flag: FlagFactory = {
 		readonly valueType: E['valueType'][];
 		readonly presence: 'optional';
 		readonly optionalFallback: 'empty-array';
+		readonly flagKind: 'array';
 	}> {
 		return new FlagBuilder(createSchema('array', { elementSchema: element.schema }));
 	},
@@ -733,6 +753,7 @@ const flag: FlagFactory = {
 		readonly valueType: T;
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
+		readonly flagKind: 'custom';
 	}> {
 		return new FlagBuilder(createSchema('custom', { parseFn: parseFn as FlagParseFn<unknown> }));
 	},

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -108,17 +108,16 @@ type InferFlags<T extends Record<string, FlagBuilder<FlagConfig>>> = {
  * - `'array'`   → {@link MultiselectPromptConfig}
  * - `'custom'`  → all prompt kinds ({@link PromptConfig})
  */
-type AllowedPromptConfig<C extends FlagConfig> = C['flagKind'] extends 'array'
-	? MultiselectPromptConfig
-	: C['flagKind'] extends 'boolean'
-		? ConfirmPromptConfig
-		: C['flagKind'] extends 'number'
-			? InputPromptConfig
-			: C['flagKind'] extends 'enum'
-				? SelectPromptConfig | InputPromptConfig
-				: C['flagKind'] extends 'custom'
-					? PromptConfig
-					: InputPromptConfig | SelectPromptConfig;
+type PromptConfigByFlagKind = {
+	readonly string: InputPromptConfig | SelectPromptConfig;
+	readonly number: InputPromptConfig;
+	readonly boolean: ConfirmPromptConfig;
+	readonly enum: SelectPromptConfig | InputPromptConfig;
+	readonly array: MultiselectPromptConfig;
+	readonly custom: PromptConfig;
+};
+
+type AllowedPromptConfig<C extends FlagConfig> = PromptConfigByFlagKind[C['flagKind']];
 
 // --- Runtime schema data
 

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -9,7 +9,13 @@
  * @module dreamcli/core/schema/flag
  */
 
-import type { PromptConfig } from './prompt.ts';
+import type {
+	ConfirmPromptConfig,
+	InputPromptConfig,
+	MultiselectPromptConfig,
+	PromptConfig,
+	SelectPromptConfig,
+} from './prompt.ts';
 
 // --- Type-level configuration (phantom state tracked through the chain)
 
@@ -86,6 +92,24 @@ type InferFlag<B> = B extends FlagBuilder<infer C extends FlagConfig> ? Resolved
 type InferFlags<T extends Record<string, FlagBuilder<FlagConfig>>> = {
 	[K in keyof T]: InferFlag<T[K]>;
 };
+
+/**
+ * Maps a {@linkcode FlagConfig} to the prompt config types that are compatible
+ * with the flag's value type. Prevents compile-time mismatches such as
+ * `flag.enum([…]).prompt({ kind: 'multiselect' })`.
+ *
+ * - Array flags (`optionalFallback: 'empty-array'`) → {@link MultiselectPromptConfig}
+ * - Boolean flags → {@link ConfirmPromptConfig}
+ * - Number flags → {@link InputPromptConfig}
+ * - String / enum / custom flags → {@link InputPromptConfig} | {@link SelectPromptConfig}
+ */
+type AllowedPromptConfig<C extends FlagConfig> = C['optionalFallback'] extends 'empty-array'
+	? MultiselectPromptConfig
+	: C['valueType'] extends boolean
+		? ConfirmPromptConfig
+		: C['valueType'] extends number
+			? InputPromptConfig
+			: InputPromptConfig | SelectPromptConfig;
 
 // --- Runtime schema data
 
@@ -469,7 +493,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * // $ mycli init --name foo   → skips prompt, uses CLI value
 	 * ```
 	 */
-	prompt(config: PromptConfig): FlagBuilder<C> {
+	prompt(config: AllowedPromptConfig<C>): FlagBuilder<C> {
 		return new FlagBuilder({
 			...this.schema,
 			prompt: config,
@@ -730,6 +754,7 @@ export type {
 } from './prompt.ts';
 export { PROMPT_KINDS } from './prompt.ts';
 export type {
+	AllowedPromptConfig,
 	FlagAlias,
 	FlagConfig,
 	FlagFactory,

--- a/src/core/schema/prompt.test.ts
+++ b/src/core/schema/prompt.test.ts
@@ -413,6 +413,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly valueType: boolean;
 			readonly presence: 'defaulted';
 			readonly optionalFallback: 'undefined';
+			readonly flagKind: 'boolean';
 		};
 		expectTypeOf<AllowedPromptConfig<BoolConfig>>().toEqualTypeOf<ConfirmPromptConfig>();
 	});
@@ -422,6 +423,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly valueType: number;
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
+			readonly flagKind: 'number';
 		};
 		expectTypeOf<AllowedPromptConfig<NumConfig>>().toEqualTypeOf<InputPromptConfig>();
 	});
@@ -431,20 +433,22 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly valueType: string;
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
+			readonly flagKind: 'string';
 		};
 		expectTypeOf<AllowedPromptConfig<StrConfig>>().toEqualTypeOf<
 			InputPromptConfig | SelectPromptConfig
 		>();
 	});
 
-	it('enum flag allows input or select', () => {
+	it('enum flag allows select or input', () => {
 		type EnumConfig = {
 			readonly valueType: 'us' | 'eu';
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
+			readonly flagKind: 'enum';
 		};
 		expectTypeOf<AllowedPromptConfig<EnumConfig>>().toEqualTypeOf<
-			InputPromptConfig | SelectPromptConfig
+			SelectPromptConfig | InputPromptConfig
 		>();
 	});
 
@@ -453,8 +457,19 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly valueType: string[];
 			readonly presence: 'optional';
 			readonly optionalFallback: 'empty-array';
+			readonly flagKind: 'array';
 		};
 		expectTypeOf<AllowedPromptConfig<ArrConfig>>().toEqualTypeOf<MultiselectPromptConfig>();
+	});
+
+	it('custom flag allows all prompt kinds', () => {
+		type CustomConfig = {
+			readonly valueType: unknown;
+			readonly presence: 'optional';
+			readonly optionalFallback: 'undefined';
+			readonly flagKind: 'custom';
+		};
+		expectTypeOf<AllowedPromptConfig<CustomConfig>>().toEqualTypeOf<PromptConfig>();
 	});
 
 	it('multiselect is not assignable to enum flag prompt', () => {
@@ -462,6 +477,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly valueType: 'us' | 'eu';
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
+			readonly flagKind: 'enum';
 		};
 		expectTypeOf<MultiselectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<EnumConfig>>();
 	});
@@ -471,6 +487,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly valueType: boolean;
 			readonly presence: 'defaulted';
 			readonly optionalFallback: 'undefined';
+			readonly flagKind: 'boolean';
 		};
 		expectTypeOf<MultiselectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<BoolConfig>>();
 	});
@@ -480,6 +497,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly valueType: string;
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
+			readonly flagKind: 'string';
 		};
 		expectTypeOf<ConfirmPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<StrConfig>>();
 	});
@@ -489,6 +507,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly valueType: boolean;
 			readonly presence: 'defaulted';
 			readonly optionalFallback: 'undefined';
+			readonly flagKind: 'boolean';
 		};
 		expectTypeOf<InputPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<BoolConfig>>();
 	});
@@ -498,6 +517,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly valueType: string[];
 			readonly presence: 'optional';
 			readonly optionalFallback: 'empty-array';
+			readonly flagKind: 'array';
 		};
 		expectTypeOf<SelectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<ArrConfig>>();
 	});
@@ -513,9 +533,12 @@ describe('AllowedPromptConfig type constraints', () => {
 		flag.array(flag.string()).prompt({ kind: 'multiselect', message: 'Tags?' });
 	});
 
-	it('custom flag allows input and select', () => {
-		flag.custom((raw) => raw).prompt({ kind: 'input', message: 'Value?' });
-		flag.custom((raw) => raw).prompt({ kind: 'select', message: 'Pick', choices: [{ value: 'a' }] });
+	it('custom flag allows all prompt kinds', () => {
+		const custom = flag.custom((raw) => raw);
+		custom.prompt({ kind: 'input', message: 'Value?' });
+		custom.prompt({ kind: 'select', message: 'Pick', choices: [{ value: 'a' }] });
+		custom.prompt({ kind: 'confirm', message: 'Continue?' });
+		custom.prompt({ kind: 'multiselect', message: 'Tags?', choices: [{ value: 'x' }] });
 	});
 
 	it('invalid combinations rejected by FlagBuilder.prompt()', () => {

--- a/src/core/schema/prompt.test.ts
+++ b/src/core/schema/prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type {
+	AllowedPromptConfig,
 	ConfirmPromptConfig,
 	FlagSchema,
 	InferFlag,
@@ -401,6 +402,140 @@ describe('command builder with prompted flags', () => {
 			kind: 'input',
 			message: 'Project name',
 		});
+	});
+});
+
+// --- AllowedPromptConfig type constraints (issue #11)
+
+describe('AllowedPromptConfig type constraints', () => {
+	it('boolean flag allows only confirm', () => {
+		type BoolConfig = {
+			readonly valueType: boolean;
+			readonly presence: 'defaulted';
+			readonly optionalFallback: 'undefined';
+		};
+		expectTypeOf<AllowedPromptConfig<BoolConfig>>().toEqualTypeOf<ConfirmPromptConfig>();
+	});
+
+	it('number flag allows only input', () => {
+		type NumConfig = {
+			readonly valueType: number;
+			readonly presence: 'optional';
+			readonly optionalFallback: 'undefined';
+		};
+		expectTypeOf<AllowedPromptConfig<NumConfig>>().toEqualTypeOf<InputPromptConfig>();
+	});
+
+	it('string flag allows input or select', () => {
+		type StrConfig = {
+			readonly valueType: string;
+			readonly presence: 'optional';
+			readonly optionalFallback: 'undefined';
+		};
+		expectTypeOf<AllowedPromptConfig<StrConfig>>().toEqualTypeOf<
+			InputPromptConfig | SelectPromptConfig
+		>();
+	});
+
+	it('enum flag allows input or select', () => {
+		type EnumConfig = {
+			readonly valueType: 'us' | 'eu';
+			readonly presence: 'optional';
+			readonly optionalFallback: 'undefined';
+		};
+		expectTypeOf<AllowedPromptConfig<EnumConfig>>().toEqualTypeOf<
+			InputPromptConfig | SelectPromptConfig
+		>();
+	});
+
+	it('array flag allows only multiselect', () => {
+		type ArrConfig = {
+			readonly valueType: string[];
+			readonly presence: 'optional';
+			readonly optionalFallback: 'empty-array';
+		};
+		expectTypeOf<AllowedPromptConfig<ArrConfig>>().toEqualTypeOf<MultiselectPromptConfig>();
+	});
+
+	it('multiselect is not assignable to enum flag prompt', () => {
+		type EnumConfig = {
+			readonly valueType: 'us' | 'eu';
+			readonly presence: 'optional';
+			readonly optionalFallback: 'undefined';
+		};
+		expectTypeOf<MultiselectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<EnumConfig>>();
+	});
+
+	it('multiselect is not assignable to boolean flag prompt', () => {
+		type BoolConfig = {
+			readonly valueType: boolean;
+			readonly presence: 'defaulted';
+			readonly optionalFallback: 'undefined';
+		};
+		expectTypeOf<MultiselectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<BoolConfig>>();
+	});
+
+	it('confirm is not assignable to string flag prompt', () => {
+		type StrConfig = {
+			readonly valueType: string;
+			readonly presence: 'optional';
+			readonly optionalFallback: 'undefined';
+		};
+		expectTypeOf<ConfirmPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<StrConfig>>();
+	});
+
+	it('input is not assignable to boolean flag prompt', () => {
+		type BoolConfig = {
+			readonly valueType: boolean;
+			readonly presence: 'defaulted';
+			readonly optionalFallback: 'undefined';
+		};
+		expectTypeOf<InputPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<BoolConfig>>();
+	});
+
+	it('select is not assignable to array flag prompt', () => {
+		type ArrConfig = {
+			readonly valueType: string[];
+			readonly presence: 'optional';
+			readonly optionalFallback: 'empty-array';
+		};
+		expectTypeOf<SelectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<ArrConfig>>();
+	});
+
+	it('valid combinations accepted by FlagBuilder.prompt()', () => {
+		// These should compile without errors
+		flag.string().prompt({ kind: 'input', message: 'Name?' });
+		flag.string().prompt({ kind: 'select', message: 'Pick', choices: [{ value: 'a' }] });
+		flag.number().prompt({ kind: 'input', message: 'Port?' });
+		flag.boolean().prompt({ kind: 'confirm', message: 'Force?' });
+		flag.enum(['a', 'b']).prompt({ kind: 'select', message: 'Pick' });
+		flag.array(flag.string()).prompt({ kind: 'multiselect', message: 'Tags?' });
+	});
+
+	it('invalid combinations rejected by FlagBuilder.prompt()', () => {
+		// @ts-expect-error — multiselect is not compatible with enum flags
+		flag.enum(['a', 'b']).prompt({ kind: 'multiselect', message: 'Pick' });
+
+		// @ts-expect-error — input is not compatible with boolean flags
+		flag.boolean().prompt({ kind: 'input', message: 'Force?' });
+
+		// @ts-expect-error — multiselect is not compatible with string flags
+		flag.string().prompt({ kind: 'multiselect', message: 'Name?' });
+
+		// @ts-expect-error — confirm is not compatible with string flags
+		flag.string().prompt({ kind: 'confirm', message: 'Name?' });
+
+		// @ts-expect-error — multiselect is not compatible with number flags
+		flag.number().prompt({ kind: 'multiselect', message: 'Port?' });
+
+		// @ts-expect-error — confirm is not compatible with number flags
+		flag.number().prompt({ kind: 'confirm', message: 'Port?' });
+
+		// @ts-expect-error — confirm is not compatible with array flags
+		flag.array(flag.string()).prompt({ kind: 'confirm', message: 'Tags?' });
+
+		// @ts-expect-error — input is not compatible with array flags
+		flag.array(flag.string()).prompt({ kind: 'input', message: 'Tags?' });
 	});
 });
 

--- a/src/core/schema/prompt.test.ts
+++ b/src/core/schema/prompt.test.ts
@@ -509,7 +509,13 @@ describe('AllowedPromptConfig type constraints', () => {
 		flag.number().prompt({ kind: 'input', message: 'Port?' });
 		flag.boolean().prompt({ kind: 'confirm', message: 'Force?' });
 		flag.enum(['a', 'b']).prompt({ kind: 'select', message: 'Pick' });
+		flag.enum(['a', 'b']).prompt({ kind: 'input', message: 'Enter value' });
 		flag.array(flag.string()).prompt({ kind: 'multiselect', message: 'Tags?' });
+	});
+
+	it('custom flag allows input and select', () => {
+		flag.custom((raw) => raw).prompt({ kind: 'input', message: 'Value?' });
+		flag.custom((raw) => raw).prompt({ kind: 'select', message: 'Pick', choices: [{ value: 'a' }] });
 	});
 
 	it('invalid combinations rejected by FlagBuilder.prompt()', () => {


### PR DESCRIPTION
## Summary
Add compile-time and runtime validation to ensure prompt kinds are compatible with their corresponding flag types. This prevents invalid configurations like using `multiselect` prompts with enum flags or `confirm` prompts with string flags.

- Fixes #11

## Key Changes

- **Type-level validation**: Introduced `AllowedPromptConfig<C>` type that constrains which prompt kinds are allowed for each flag type:
  - Boolean flags → `confirm` only
  - Number flags → `input` only
  - String/enum flags → `input` or `select`
  - Array flags → `multiselect` only
  - Custom flags → all prompt kinds allowed

- **Runtime validation**: Added `validatePromptFlagCompatibility()` function that checks prompt-flag compatibility during resolution and returns a `ValidationError` with helpful suggestions if there's a mismatch

- **Updated `FlagBuilder.prompt()` signature**: Changed parameter type from `PromptConfig` to `AllowedPromptConfig<C>` to enforce type safety at the API level

- **Comprehensive test coverage**: Added 9 test cases covering:
  - Invalid combinations (multiselect on enum, input on boolean, etc.)
  - Error message validation (includes flag name and suggested kind)
  - Early rejection before prompting the user
  - Type-level constraint verification

## Implementation Details

- Validation happens before prompting to fail fast without user interaction
- Error messages include the flag name, incompatible prompt kind, and suggested alternative
- Uses a `COMPATIBLE_PROMPT_KINDS` lookup table to define valid combinations
- Maintains backward compatibility for custom flag types (allows all prompt kinds)

https://claude.ai/code/session_01Xsmxjjw5T6t2jPLUdNMgDM