### PR TITLE
fix(cli): make command dispatch flag-arity-aware

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -52,7 +52,7 @@
 	"ruff": { "preview": true, "indentWidth": 4 },
 	"excludes": ["**/node_modules", "**/{*-,bun}lock(.*)?", "**/snapshots", "**/*.schema.json"],
 	"plugins": [
-		"https://plugins.dprint.dev/biome-0.12.12.wasm",
+		"https://plugins.dprint.dev/biome-0.13.0.wasm",
 		"https://plugins.dprint.dev/g-plane/malva-v0.16.0.wasm",
 		"https://plugins.dprint.dev/g-plane/markup_fmt-v0.27.3.wasm",
 		"https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
@@ -60,7 +60,7 @@
 		"https://plugins.dprint.dev/kjanat/svg-v0.4.1.wasm",
 		"https://plugins.dprint.dev/exec-0.6.2.json@df98f54ffd3092b8a841aedd6d098a2651f16d0a796a40535774f1a8b4b9d463",
 		"https://plugins.dprint.dev/prettier-0.72.0.json@6e7af2cb2182a5a11358d3adde9ae0ef3b94b7d2e5dcfdd252e3f7c3916541fe",
-		"https://plugins.dprint.dev/ruff-0.7.15.wasm",
-		"https://plugins.dprint.dev/json-0.21.3.wasm",
+		"https://plugins.dprint.dev/ruff-0.7.17.wasm",
+		"https://plugins.dprint.dev/json-0.22.0.wasm",
 	],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-20
+
+### Fixed
+
+- **Command dispatch now respects flag value-arity** — a space-separated value-flag value (e.g.
+  `--source anthropic`) is no longer mistaken for a command name when it collides with a registered
+  command, so the default-command fallback runs as intended
+  ([#25](https://github.com/kjanat/dreamcli/issues/25)). The command-name scan now skips the token a
+  space-separated value-flag consumes (mirroring the parser's own value-consumption rules); the
+  inline `--source=anthropic` form already worked, and both forms are now consistent.
+
 ## [2.2.1] - 2026-06-10
 
 ### Added
@@ -790,7 +801,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MIT License.
 - Markdownlint configuration.
 
-[Unreleased]: https://github.com/kjanat/dreamcli/compare/v2.2.1...HEAD
+[Unreleased]: https://github.com/kjanat/dreamcli/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/kjanat/dreamcli/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/kjanat/dreamcli/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/kjanat/dreamcli/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/kjanat/dreamcli/compare/v2.0.1...v2.1.0

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
-	"version": "2.2.1",
+	"version": "2.3.0",
 	"license": "MIT",
 	"tasks": {
 		"check": {

--- a/docs/guide/semantics.md
+++ b/docs/guide/semantics.md
@@ -238,6 +238,24 @@ Examples:
 | default `serve` + sibling `status` | `surface`     | commands + root built-ins + `serve` root flags     |
 | single visible default `serve`     | `subcommands` | command name + root built-ins + `serve` root flags |
 
+### Command resolution with value-flags
+
+When locating the command name in argv, dreamcli skips the token a space-separated value-flag
+consumes, so that value is never mistaken for a command name. This is most visible with a default
+command, where every token sits at the root level:
+
+```bash
+mycli --region status   # `status` is the value of --region (even if a command
+                        # named `status` exists), so this runs the default command
+mycli --region=status   # inline form, same result
+mycli status            # a bare token dispatches the `status` command
+```
+
+The same applies one level down: `mycli db --tag x migrate` resolves `migrate`, not `x`. Boolean
+flags take no value, so a following token is still treated as a command name. For example,
+`mycli --verbose deploy` runs `deploy`. The `--` separator stops command-name scanning entirely;
+everything after it is positional.
+
 ## Related Guides
 
 - [Commands](/guide/commands)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kjanat/dreamcli",
-	"version": "2.2.1",
+	"version": "2.3.0",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
 		"cli",

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -4,23 +4,25 @@
 
 ## KEY TYPES
 
-| Symbol             | Role                                                        |
-| ------------------ | ----------------------------------------------------------- |
-| `CLIBuilder`       | Fluent builder: `.command()`, `.default()`, `.execute()`    |
-| `cli(name)`        | Factory function -> `CLIBuilder`                            |
-| `CLISchema`        | Runtime descriptor for the full CLI                         |
-| `CLIRunOptions`    | Extends `RunOptions` with CLI-level settings                |
-| `ConfigSettings`   | Config file discovery settings for CLI                      |
-| `ErasedCommand`    | `@internal` — type-erased command for dispatch map          |
-| `formatRootHelp()` | `@internal` — root-level help rendering (in `root-help.ts`) |
+| Symbol                     | Role                                                                    |
+| -------------------------- | ----------------------------------------------------------------------- |
+| `CLIBuilder`               | Fluent builder: `.command()`, `.default()`, `.execute()`                |
+| `cli(name)`                | Factory function -> `CLIBuilder`                                        |
+| `CLISchema`                | Runtime descriptor for the full CLI                                     |
+| `CLIRunOptions`            | Extends `RunOptions` with CLI-level settings                            |
+| `ConfigSettings`           | Config file discovery settings for CLI                                  |
+| `ErasedCommand`            | `@internal` — type-erased command for dispatch map                      |
+| `formatRootHelp()`         | `@internal` — root-level help rendering (in `root-help.ts`)             |
+| `ValueFlagLookup`          | `@internal` — value-flag arity lookup threaded into `dispatch()`        |
+| `consumesFollowingToken()` | `@internal` — whether a flag token consumes the next argv token (arity) |
 
 ## FILES
 
 | File                   | Lines | Purpose                                                              |
 | ---------------------- | ----: | -------------------------------------------------------------------- |
 | `index.ts`             |  1015 | CLIBuilder class + cli() factory + JSON error handling               |
-| `dispatch.ts`          |   285 | `@internal` — command dispatch, nested resolution, levenshtein       |
-| `planner.ts`           |   345 | `@internal` — execution planner, command resolution strategy         |
+| `dispatch.ts`          |   349 | `@internal` — command dispatch (value-flag-arity aware), levenshtein |
+| `planner.ts`           |   424 | `@internal` — execution planner, command resolution strategy         |
 | `runtime-preflight.ts` |   304 | `@internal` — runtime adapter setup, env/config preflight            |
 | `plugin.ts`            |   111 | `@internal` — plugin system + lifecycle hooks                        |
 | `propagate.ts`         |    87 | `@internal` — flag propagation through command tree                  |
@@ -54,6 +56,10 @@ command map building, 3-way dispatch result (`unknown` / `needs-subcommand` / `m
 - `root-help.ts` uses structural `CLISchemaLike` instead of importing `CLISchema` — avoids circular
   dep through barrel
 - `levenshtein()` in `dispatch.ts` uses `Uint16Array` rolling buffer — different impl from `parse/`
+- `dispatch.ts` is value-flag-arity aware: the command-name scan skips a space-separated value-flag's
+  value (`consumesFollowingToken` + `ValueFlagLookup`, built from the default/matched command's flags)
+  so the value isn't mistaken for a command name — reuses `buildFlagLookup`/`flagExpectsValue` from
+  `parse/` as the single source of truth (#25)
 - `extractConfigFlag()` handles both `--config path` and `--config=path` forms
 - Direct imports: `schema/command.ts`, `schema/flag.ts`, `schema/arg.ts` (not through barrel)
 - Cross-layer imports: `runtime/adapter.ts`, `runtime/auto.ts` (not through runtime barrel)

--- a/src/core/cli/cli-default.test.ts
+++ b/src/core/cli/cli-default.test.ts
@@ -487,4 +487,47 @@ describe('formatRootHelp — default command', () => {
 			expect(deployDescStart).toBe(statusDescStart);
 		}
 	});
+
+	// --- value-flag value matching a command name (#25)
+
+	describe('value-flag value matching a command name (#25)', () => {
+		function buildApp() {
+			const status = command('status')
+				.description('Show status')
+				.flag('source', flag.string().alias('s').describe('Data source'))
+				.action(({ flags, out }) => {
+					out.log(`status:${flags.source ?? 'none'}`);
+				});
+			const anthropic = command('anthropic')
+				.description('Anthropic source command')
+				.action(({ out }) => {
+					out.log('anthropic-cmd');
+				});
+			return cli('mycli').default(status).command(anthropic);
+		}
+
+		it('routes --source <commandName> to the default command (space form)', async () => {
+			const result = await buildApp().execute(['--source', 'anthropic']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toContain('status:anthropic');
+		});
+
+		it('routes -s <commandName> to the default command (short alias)', async () => {
+			const result = await buildApp().execute(['-s', 'anthropic']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toContain('status:anthropic');
+		});
+
+		it('inline --source=<commandName> still works', async () => {
+			const result = await buildApp().execute(['--source=anthropic']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toContain('status:anthropic');
+		});
+
+		it('still dispatches the explicit command when typed directly', async () => {
+			const result = await buildApp().execute(['anthropic']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toContain('anthropic-cmd');
+		});
+	});
 });

--- a/src/core/cli/cli-dispatch.test.ts
+++ b/src/core/cli/cli-dispatch.test.ts
@@ -3,8 +3,16 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { buildFlagLookup } from '#internals/core/parse/index.ts';
 import type { CommandSchema, ErasedCommand } from '#internals/core/schema/command.ts';
-import { dispatch, findClosestCommand, levenshtein, uniqueCommands } from './dispatch.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import {
+	consumesFollowingToken,
+	dispatch,
+	findClosestCommand,
+	levenshtein,
+	uniqueCommands,
+} from './dispatch.ts';
 
 // === Helpers
 
@@ -280,5 +288,90 @@ describe('uniqueCommands()', () => {
 		const unique = uniqueCommands(map);
 		expect(unique).toHaveLength(1);
 		expect(unique[0]).toBe(deploy);
+	});
+});
+
+// === consumesFollowingToken()
+
+describe('consumesFollowingToken()', () => {
+	const lookup = buildFlagLookup({
+		source: flag.string().alias('s').schema,
+		verbose: flag.boolean().alias('v').schema,
+	});
+
+	it('long value-flag consumes the next token', () => {
+		expect(consumesFollowingToken('--source', lookup)).toBe(true);
+	});
+
+	it('long value-flag with inline = consumes nothing', () => {
+		expect(consumesFollowingToken('--source=anthropic', lookup)).toBe(false);
+	});
+
+	it('boolean long flag consumes nothing', () => {
+		expect(consumesFollowingToken('--verbose', lookup)).toBe(false);
+	});
+
+	it('short value alias consumes the next token', () => {
+		expect(consumesFollowingToken('-s', lookup)).toBe(true);
+	});
+
+	it('short boolean alias consumes nothing', () => {
+		expect(consumesFollowingToken('-v', lookup)).toBe(false);
+	});
+
+	it('short bundle ending in a value-flag consumes the next token', () => {
+		expect(consumesFollowingToken('-vs', lookup)).toBe(true);
+	});
+
+	it('short bundle with a non-trailing value-flag consumes nothing (inline value)', () => {
+		expect(consumesFollowingToken('-sv', lookup)).toBe(false);
+	});
+
+	it('unknown flag conservatively consumes nothing', () => {
+		expect(consumesFollowingToken('--nope', lookup)).toBe(false);
+	});
+});
+
+// === dispatch() flag-arity awareness (#25)
+
+describe('dispatch() flag-arity awareness', () => {
+	const valueFlags = buildFlagLookup({ source: flag.string().alias('s').schema });
+	const booleanFlags = buildFlagLookup({ verbose: flag.boolean().alias('v').schema });
+
+	it('does not match a value-flag value that collides with a command name', () => {
+		const anthropic = erased(commandSchema({ name: 'anthropic' }));
+		const result = dispatch(['--source', 'anthropic'], commandMap(anthropic), [], valueFlags);
+		// The value was skipped, so no command token remains → fall through (default cmd).
+		expect(result.kind).toBe('unknown');
+		if (result.kind === 'unknown') expect(result.input).toBe('');
+	});
+
+	it('handles the short-alias form too', () => {
+		const anthropic = erased(commandSchema({ name: 'anthropic' }));
+		const result = dispatch(['-s', 'anthropic'], commandMap(anthropic), [], booleanFlags);
+		// booleanFlags has no `s`; arity-unaware → would match. With value arity:
+		const arityResult = dispatch(['-s', 'anthropic'], commandMap(anthropic), [], valueFlags);
+		expect(arityResult.kind).toBe('unknown');
+		expect(result.kind).toBe('match'); // contrast: unknown short flag is not a value-flag here
+	});
+
+	it('without arity info, the value is mis-matched as a command (legacy behaviour)', () => {
+		const anthropic = erased(commandSchema({ name: 'anthropic' }));
+		const result = dispatch(['--source', 'anthropic'], commandMap(anthropic));
+		expect(result.kind).toBe('match');
+	});
+
+	it('a boolean flag does not swallow the following command token', () => {
+		const anthropic = erased(commandSchema({ name: 'anthropic' }));
+		const result = dispatch(['-v', 'anthropic'], commandMap(anthropic), [], booleanFlags);
+		expect(result.kind).toBe('match');
+		if (result.kind === 'match') expect(result.command.schema.name).toBe('anthropic');
+	});
+
+	it('the inline = form leaves the command token matchable', () => {
+		const anthropic = erased(commandSchema({ name: 'anthropic' }));
+		const result = dispatch(['--source=eu', 'anthropic'], commandMap(anthropic), [], valueFlags);
+		expect(result.kind).toBe('match');
+		if (result.kind === 'match') expect(result.command.schema.name).toBe('anthropic');
 	});
 });

--- a/src/core/cli/dispatch.ts
+++ b/src/core/cli/dispatch.ts
@@ -10,7 +10,18 @@
  * @internal
  */
 
+import { buildFlagLookup, flagExpectsValue } from '#internals/core/parse/index.ts';
 import type { CommandSchema, ErasedCommand } from '#internals/core/schema/command.ts';
+import type { FlagSchema } from '#internals/core/schema/flag.ts';
+
+/**
+ * Flag lookup (name/alias → `[canonicalName, schema]`) used to make the
+ * command-name scan aware of value-flag arity. Built from the flags valid at
+ * the current dispatch level via {@link buildFlagLookup}.
+ *
+ * @internal
+ */
+type ValueFlagLookup = ReadonlyMap<string, readonly [name: string, schema: FlagSchema]>;
 
 // --- Dispatch result types (discriminated union)
 
@@ -72,6 +83,9 @@ type DispatchResult = DispatchMatch | DispatchNeedsSubcommand | DispatchUnknown;
  * @param argv - Remaining argv tokens (command names + flags + args).
  * @param commands - Command map at the current tree level.
  * @param ancestorPath - Schema path from root to current level (exclusive).
+ * @param valueFlags - Lookup of flags valid at this level, used so a
+ *   space-separated value-flag's value (`--region eu`) is not mistaken for a
+ *   command name. Empty by default (arity-unaware, legacy behaviour).
  * @returns Discriminated dispatch result.
  *
  * @internal
@@ -80,22 +94,29 @@ function dispatch(
 	argv: readonly string[],
 	commands: ReadonlyMap<string, ErasedCommand>,
 	ancestorPath: readonly CommandSchema[] = [],
+	valueFlags: ValueFlagLookup = new Map(),
 ): DispatchResult {
 	// Find first non-flag token (potential command name).
 	// Flags may appear before the command name (e.g. `--verbose db migrate`).
 	// `--` terminates flag scanning — the next token is treated as a command name.
+	// Value-flags in space-separated form (`--region eu`, `-r eu`) consume the
+	// following token as their value, so it must be skipped rather than matched
+	// as a command name (see #25).
 	let cmdIdx = -1;
 	for (let i = 0; i < argv.length; i++) {
 		const token = argv[i];
+		if (token === undefined) continue;
 		if (token === '--') {
 			// End-of-flags marker: next token (if any) is the command name.
 			if (i + 1 < argv.length) cmdIdx = i + 1;
 			break;
 		}
-		if (token !== undefined && !token.startsWith('-')) {
-			cmdIdx = i;
-			break;
+		if (token.startsWith('-')) {
+			if (consumesFollowingToken(token, valueFlags)) i++; // skip the flag's value
+			continue;
 		}
+		cmdIdx = i;
+		break;
 	}
 
 	if (cmdIdx === -1) {
@@ -132,9 +153,15 @@ function dispatch(
 	const remaining = [...argv.slice(0, cmdIdx), ...argv.slice(cmdIdx + 1)];
 	const currentPath = [...ancestorPath, matched.schema];
 
-	// If command has subcommands, try to descend.
+	// If command has subcommands, try to descend. The matched command's own
+	// flags govern arity at the child level (e.g. `db --config x migrate`).
 	if (matched.subcommands.size > 0) {
-		const subResult = dispatch(remaining, matched.subcommands, currentPath);
+		const subResult = dispatch(
+			remaining,
+			matched.subcommands,
+			currentPath,
+			buildFlagLookup(matched.schema.flags),
+		);
 
 		switch (subResult.kind) {
 			case 'match':
@@ -186,6 +213,42 @@ function dispatch(
 		commandPath: currentPath,
 		remainingArgv: remaining,
 	};
+}
+
+// --- Flag-arity awareness
+
+/**
+ * Whether a flag token consumes the following argv token as its value.
+ *
+ * Mirrors the parser's value-consumption rules (`parseLongFlag` /
+ * `parseShortFlags`) so the command-name scan skips exactly the tokens the
+ * parser would treat as flag values:
+ * - `--flag value` → consumes when `--flag` is a known value-flag.
+ * - `--flag=value` → self-contained, consumes nothing.
+ * - `-abc value`   → consumes only when the trailing short flag is a value-flag;
+ *   an earlier value-flag char takes the rest of the group as an inline value.
+ *
+ * Unknown flags conservatively consume nothing (the parser reports them later).
+ *
+ * @internal
+ */
+function consumesFollowingToken(token: string, valueFlags: ValueFlagLookup): boolean {
+	if (token.startsWith('--')) {
+		if (token.includes('=')) return false;
+		const entry = valueFlags.get(token.slice(2));
+		return entry !== undefined && flagExpectsValue(entry[1]);
+	}
+
+	// Short flag group (`-abc`). A value attaches to the trailing flag only; an
+	// earlier value-flag char swallows the remaining chars as an inline value.
+	const chars = token.slice(1);
+	for (let i = 0; i < chars.length; i++) {
+		const entry = valueFlags.get(chars.charAt(i));
+		if (entry === undefined) return false;
+		if (!flagExpectsValue(entry[1])) continue;
+		return i === chars.length - 1;
+	}
+	return false;
 }
 
 // --- "Did you mean?" suggestion
@@ -282,5 +345,5 @@ function uniqueCommands(commands: ReadonlyMap<string, ErasedCommand>): readonly 
 
 // --- Exports
 
-export type { DispatchMatch, DispatchNeedsSubcommand, DispatchResult, DispatchUnknown };
-export { dispatch, findClosestCommand, levenshtein, uniqueCommands };
+export type { DispatchMatch, DispatchNeedsSubcommand, DispatchResult, DispatchUnknown, ValueFlagLookup };
+export { consumesFollowingToken, dispatch, findClosestCommand, levenshtein, uniqueCommands };

--- a/src/core/cli/planner.ts
+++ b/src/core/cli/planner.ts
@@ -12,6 +12,7 @@
 
 import { CLIError, ParseError } from '#internals/core/errors/index.ts';
 import type { HelpOptions } from '#internals/core/help/index.ts';
+import { buildFlagLookup } from '#internals/core/parse/index.ts';
 import type { OutputPolicy } from '#internals/core/output/contracts.ts';
 import type { CommandMeta, CommandSchema, ErasedCommand } from '#internals/core/schema/command.ts';
 import { dispatch, findClosestCommand } from './dispatch.ts';
@@ -316,8 +317,18 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 		};
 	}
 
-	const result = dispatch(filteredArgv, buildRootCommandMap(options.schema.commands));
 	const defaultCommand = options.schema.defaultCommand;
+	// At the root, a default command's flags govern value-flag arity so a
+	// space-separated value (`mycli --region eu`) is not misread as a command
+	// name and stolen from the default-command fallback (see #25).
+	const rootValueFlags =
+		defaultCommand !== undefined ? buildFlagLookup(defaultCommand.schema.flags) : undefined;
+	const result = dispatch(
+		filteredArgv,
+		buildRootCommandMap(options.schema.commands),
+		[],
+		rootValueFlags,
+	);
 
 	switch (result.kind) {
 		case 'unknown': {

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -658,4 +658,4 @@ function levenshtein(a: string, b: string): number {
 // --- Exports
 
 export type { ParseResult, Token };
-export { parse, tokenize };
+export { buildFlagLookup, flagExpectsValue, parse, tokenize };


### PR DESCRIPTION
## What

Makes command dispatch aware of value-flag arity so a space-separated value-flag value is no longer mistaken for a command name.

Fixes #25.

## Why

`dispatch()` resolved the target command by scanning argv for the first non-`-` token, with no awareness of whether the preceding token is a value-flag that consumes it. When the value collides with a registered command name — most visibly under a `.default()` command — the value was matched as a command, so the default-command fallback never ran:

```console
$ demo --source anthropic     # `anthropic` is also a registered command
Unknown flag --source         # ← routed into the `anthropic` command
$ demo --source=anthropic     # worked (no bare token to grab)
```

## How

- Thread a value-flag lookup into `dispatch()`:
  - at the **root**, built from the default command's flags (`planner.ts`);
  - on **recursion**, built from the just-matched command's flags (the same bug bites one level down, e.g. `db --config x migrate`).
- New `consumesFollowingToken()` mirrors the parser's own value-consumption rules — long `--flag value`, inline `--flag=value` (consumes nothing), and short bundles (`-vs value` consumes; `-sv` takes the rest inline).
- Export `buildFlagLookup` / `flagExpectsValue` from the parser so dispatch reuses the **single source of truth** for flag-token semantics instead of duplicating it.
- Unknown flags conservatively consume nothing (the parser reports them downstream); boolean flags are unaffected (`--verbose deploy` still treats `deploy` as a command).

## Tests

- `consumesFollowingToken()` — 8 unit cases (long/short/inline/bundle/boolean/unknown).
- `dispatch()` arity — value collides with command name (long + short alias), legacy contrast without arity info, boolean does-not-swallow, inline `=` form.
- e2e (`.default()`) — `--source anthropic`, `-s anthropic`, `--source=anthropic` all route to the default command; explicit `anthropic` still dispatches.

Full suite green (2355 tests), typecheck / lint / format clean.
