### PR TITLE
fix(cli): respect `--` end-of-options separator in root `--version`/`--json` interception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Command dispatch now respects flag value-arity** — a space-separated value-flag value (e.g.
   `--source anthropic`) is no longer mistaken for a command name when it collides with a registered
   command, so the default-command fallback runs as intended
-  ([#25](https://github.com/kjanat/dreamcli/issues/25)). The command-name scan now skips the token a
+  (https://github.com/kjanat/dreamcli/issues/25). The command-name scan now skips the token a
   space-separated value-flag consumes (mirroring the parser's own value-consumption rules); the
   inline `--source=anthropic` form already worked, and both forms are now consistent.
+- **Root `--version`/`--json` interception now respects the `--` end-of-options separator**
+  (https://github.com/kjanat/dreamcli/issues/28). A `--version` or `--json` token after `--` is
+  treated as a literal positional instead of triggering version output or JSON mode.
 
 ## [2.2.1] - 2026-06-10
 

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -22,7 +22,7 @@
 | ---------------------- | ----: | -------------------------------------------------------------------- |
 | `index.ts`             |  1015 | CLIBuilder class + cli() factory + JSON error handling               |
 | `dispatch.ts`          |   349 | `@internal` — command dispatch (value-flag-arity aware), levenshtein |
-| `planner.ts`           |   424 | `@internal` — execution planner, command resolution strategy         |
+| `planner.ts`           |   431 | `@internal` — execution planner, command resolution strategy         |
 | `runtime-preflight.ts` |   304 | `@internal` — runtime adapter setup, env/config preflight            |
 | `plugin.ts`            |   111 | `@internal` — plugin system + lifecycle hooks                        |
 | `propagate.ts`         |    87 | `@internal` — flag propagation through command tree                  |
@@ -32,7 +32,7 @@
 ## DISPATCH FLOW
 
 ```
-argv -> strip --json flag -> match subcommand (nested) -> resolve -> middleware -> action -> output
+argv -> strip --json flag (before --) -> match subcommand (nested) -> resolve -> middleware -> action -> output
         | (no match)
         -> error (unknown command / no action) -> render as JSON if --json
 ```
@@ -46,7 +46,8 @@ command map building, 3-way dispatch result (`unknown` / `needs-subcommand` / `m
 
 ## `--json` MODE
 
-- Stripped from argv before command dispatch
+- Stripped from argv before command dispatch, but only before the `--` separator (a `--json` after
+  `--` stays a literal positional)
 - CLI-level errors rendered as JSON when active
 - Propagated to `OutputChannel` via `jsonMode` option
 - `out.log`/`out.info` redirect to stderr in JSON mode (stdout reserved for data)

--- a/src/core/cli/cli-default.test.ts
+++ b/src/core/cli/cli-default.test.ts
@@ -550,32 +550,32 @@ describe('formatRootHelp — default command', () => {
 		it('treats --version after -- as a literal positional', async () => {
 			const result = await buildApp().execute(['--', '--version']);
 			expect(result.exitCode).toBe(0);
-			expect(result.stdout.join('')).toContain('names=["--version"]');
+			expect(result.stdout).toEqual(['names=["--version"]\n']);
 		});
 
 		it('treats a later --version after -- as a literal positional', async () => {
 			const result = await buildApp().execute(['--', 'literal', '--version']);
 			expect(result.exitCode).toBe(0);
-			expect(result.stdout.join('')).toContain('names=["literal","--version"]');
+			expect(result.stdout).toEqual(['names=["literal","--version"]\n']);
 		});
 
 		it('treats --json after -- as a literal positional (no JSON mode)', async () => {
 			const result = await buildApp().execute(['--', '--json']);
 			expect(result.exitCode).toBe(0);
 			// Text output with the literal, not a JSON object.
-			expect(result.stdout.join('')).toContain('names=["--json"]');
+			expect(result.stdout).toEqual(['names=["--json"]\n']);
 		});
 
 		it('still intercepts --version before --', async () => {
 			const result = await buildApp().execute(['--version']);
 			expect(result.exitCode).toBe(0);
-			expect(result.stdout.join('').trim()).toBe('9.9.9');
+			expect(result.stdout).toEqual(['9.9.9\n']);
 		});
 
 		it('still enables JSON mode for --json before --', async () => {
 			const result = await buildApp().execute(['--json', 'hi']);
 			expect(result.exitCode).toBe(0);
-			expect(result.stdout.join('')).toContain('"names":["hi"]');
+			expect(result.stdout).toEqual(['{"names":["hi"]}\n']);
 		});
 	});
 });

--- a/src/core/cli/cli-default.test.ts
+++ b/src/core/cli/cli-default.test.ts
@@ -530,4 +530,52 @@ describe('formatRootHelp — default command', () => {
 			expect(result.stdout.join('')).toContain('anthropic-cmd');
 		});
 	});
+
+	// --- end-of-options separator (--) interception (#28)
+
+	describe('end-of-options separator (--) interception (#28)', () => {
+		function buildApp() {
+			const greet = command('greet')
+				.arg('name', arg.string().variadic().optional())
+				.action(({ args, out }) => {
+					if (out.jsonMode) {
+						out.json({ names: args.name });
+						return;
+					}
+					out.log(`names=${JSON.stringify(args.name)}`);
+				});
+			return cli('mytool').version('9.9.9').default(greet);
+		}
+
+		it('treats --version after -- as a literal positional', async () => {
+			const result = await buildApp().execute(['--', '--version']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toContain('names=["--version"]');
+		});
+
+		it('treats a later --version after -- as a literal positional', async () => {
+			const result = await buildApp().execute(['--', 'literal', '--version']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toContain('names=["literal","--version"]');
+		});
+
+		it('treats --json after -- as a literal positional (no JSON mode)', async () => {
+			const result = await buildApp().execute(['--', '--json']);
+			expect(result.exitCode).toBe(0);
+			// Text output with the literal, not a JSON object.
+			expect(result.stdout.join('')).toContain('names=["--json"]');
+		});
+
+		it('still intercepts --version before --', async () => {
+			const result = await buildApp().execute(['--version']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('').trim()).toBe('9.9.9');
+		});
+
+		it('still enables JSON mode for --json before --', async () => {
+			const result = await buildApp().execute(['--json', 'hi']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toContain('"names":["hi"]');
+		});
+	});
 });

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -19,6 +19,7 @@ import type { HelpOptions } from '#internals/core/help/index.ts';
 import { formatHelp } from '#internals/core/help/index.ts';
 import type { CapturedOutput } from '#internals/core/output/index.ts';
 import { createCaptureOutput, createOutput } from '#internals/core/output/index.ts';
+import { includesBeforeSeparator } from '#internals/core/parse/index.ts';
 import type { ArgBuilder, ArgConfig } from '#internals/core/schema/arg.ts';
 import { arg } from '#internals/core/schema/arg.ts';
 import type {
@@ -805,7 +806,9 @@ class CLIBuilder {
 	 */
 	async execute(argv: readonly string[], options?: CLIRunOptions): Promise<RunResult> {
 		// -- Detect global --json mode before building output ---------------------
-		const hasJsonFlag = argv.includes('--json');
+		// Only a `--json` before the `--` separator toggles JSON mode; a literal
+		// `--json` positional (after `--`) must reach the command unchanged (#28).
+		const hasJsonFlag = includesBeforeSeparator(argv, '--json');
 		const jsonMode = hasJsonFlag || options?.jsonMode === true;
 
 		const captureOptions = {

--- a/src/core/cli/planner.ts
+++ b/src/core/cli/planner.ts
@@ -12,7 +12,7 @@
 
 import { CLIError, ParseError } from '#internals/core/errors/index.ts';
 import type { HelpOptions } from '#internals/core/help/index.ts';
-import { buildFlagLookup } from '#internals/core/parse/index.ts';
+import { buildFlagLookup, includesBeforeSeparator } from '#internals/core/parse/index.ts';
 import type { OutputPolicy } from '#internals/core/output/contracts.ts';
 import type { CommandMeta, CommandSchema, ErasedCommand } from '#internals/core/schema/command.ts';
 import { dispatch, findClosestCommand } from './dispatch.ts';
@@ -258,13 +258,20 @@ function buildPlannerMatchOutcome(
  * @internal
  */
 function planInvocation(options: PlanInvocationOptions): InvocationPlan {
-	const filteredArgv = options.argv.includes('--json')
-		? options.argv.filter((arg) => arg !== '--json')
-		: options.argv;
+	// `--json` is a root-level flag, not part of any command schema, so it is
+	// stripped before dispatch/parse — but only before the `--` separator, so a
+	// literal `--json` positional (after `--`) survives and reaches the command
+	// (#28). The `--json` *output mode* is detected separately in `.execute()`.
+	const separatorIndex = options.argv.indexOf('--');
+	const head = separatorIndex === -1 ? options.argv : options.argv.slice(0, separatorIndex);
+	const tail = separatorIndex === -1 ? [] : options.argv.slice(separatorIndex);
+	const filteredHead = head.includes('--json') ? head.filter((arg) => arg !== '--json') : head;
+	const filteredArgv = separatorIndex === -1 ? filteredHead : [...filteredHead, ...tail];
 
 	if (
 		options.schema.version !== undefined &&
-		(filteredArgv.includes('--version') || filteredArgv.includes('-V'))
+		(includesBeforeSeparator(options.argv, '--version') ||
+			includesBeforeSeparator(options.argv, '-V'))
 	) {
 		return {
 			kind: 'root-version',

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -16,7 +16,7 @@ import type {
 import { CLIError } from '#internals/core/errors/index.ts';
 import { formatHelp } from '#internals/core/help/index.ts';
 import type { CapturedOutput } from '#internals/core/output/index.ts';
-import { parse } from '#internals/core/parse/index.ts';
+import { includesBeforeSeparator, parse } from '#internals/core/parse/index.ts';
 import { createTestPrompter } from '#internals/core/prompt/index.ts';
 import type { DeprecationWarning, ResolveOptions } from '#internals/core/resolve/index.ts';
 import { resolve } from '#internals/core/resolve/index.ts';
@@ -256,14 +256,6 @@ function formatDeprecation(deprecation: DeprecationWarning): string {
 	return typeof deprecation.message === 'string'
 		? `Warning: ${entity} is deprecated: ${deprecation.message}`
 		: `Warning: ${entity} is deprecated`;
-}
-
-function includesBeforeSeparator(argv: readonly string[], token: string): boolean {
-	for (const arg of argv) {
-		if (arg === '--') return false;
-		if (arg === token) return true;
-	}
-	return false;
 }
 
 export type { CommandExecutionRequest, CommandExecutionResult };

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -101,6 +101,26 @@ function tokenize(argv: readonly string[]): readonly Token[] {
 	return tokens;
 }
 
+/**
+ * Whether `token` appears in argv before the `--` end-of-options separator.
+ *
+ * Everything at or after the first `--` is a literal positional, so root-level
+ * flag interception (`--help` / `--version` / `--json`) must use this instead of
+ * a naive `Array.includes()` — otherwise a post-separator literal (`-- --json`)
+ * is wrongly treated as the flag.
+ *
+ * @param argv - Raw argument strings.
+ * @param token - Exact flag token to look for (e.g. `--version`).
+ * @returns `true` if `token` occurs before any `--` separator.
+ */
+function includesBeforeSeparator(argv: readonly string[], token: string): boolean {
+	for (const arg of argv) {
+		if (arg === '--') return false;
+		if (arg === token) return true;
+	}
+	return false;
+}
+
 // --- Parse result
 
 /**
@@ -658,4 +678,4 @@ function levenshtein(a: string, b: string): number {
 // --- Exports
 
 export type { ParseResult, Token };
-export { buildFlagLookup, flagExpectsValue, parse, tokenize };
+export { buildFlagLookup, flagExpectsValue, includesBeforeSeparator, parse, tokenize };

--- a/src/core/parse/parse.test.ts
+++ b/src/core/parse/parse.test.ts
@@ -3,7 +3,7 @@ import { ParseError } from '#internals/core/errors/index.ts';
 import { createArgSchema } from '#internals/core/schema/arg.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createSchema } from '#internals/core/schema/flag.ts';
-import { parse, tokenize } from './index.ts';
+import { includesBeforeSeparator, parse, tokenize } from './index.ts';
 
 // --- Helpers — build minimal CommandSchema for testing
 
@@ -911,5 +911,22 @@ describe('parse', () => {
 			expect(result.flags).toEqual({});
 			expect(result.args).toEqual({});
 		});
+	});
+});
+
+describe('includesBeforeSeparator()', () => {
+	it('finds a token before the -- separator', () => {
+		expect(includesBeforeSeparator(['--version', 'x'], '--version')).toBe(true);
+		expect(includesBeforeSeparator(['--flag', '--json', 'x'], '--json')).toBe(true);
+	});
+
+	it('ignores a token at or after the -- separator', () => {
+		expect(includesBeforeSeparator(['--', '--version'], '--version')).toBe(false);
+		expect(includesBeforeSeparator(['a', '--', '--json'], '--json')).toBe(false);
+	});
+
+	it('returns false when the token is absent', () => {
+		expect(includesBeforeSeparator(['--other'], '--version')).toBe(false);
+		expect(includesBeforeSeparator([], '--version')).toBe(false);
 	});
 });


### PR DESCRIPTION
## What

Makes root-level `--version` / `--json` interception respect the POSIX `--` end-of-options separator.

Fixes #28.

## Why

`--version`/`-V` and `--json` were detected with a naive `Array.includes()` over the **whole** argv, so a token appearing **after** `--` — i.e. an intended literal positional — still triggered version output / JSON mode:

```console
$ mytool -- --version
9.9.9                       # ← should be the literal positional "--version"

$ mytool -- --json
{"...json..."}              # ← JSON mode wrongly activated
```

## How

The executor already had a `--`-aware `includesBeforeSeparator()` helper (used for command-level `--help`). This PR:

- **Promotes** that helper into `src/core/parse/index.ts` — its natural home alongside the tokenizer, which already understands `--` — and exports it. The executor now imports it instead of keeping a private copy (single source of truth).
- Uses it for **`--json` output-mode detection** in `CLIBuilder.execute()`.
- Uses it for **`--version` / `-V` root interception** in `planInvocation()`.
- `planInvocation()` now strips the root-only `--json` flag **only before the separator**, so a literal `-- --json` reaches the command as a positional instead of being swallowed before parse.

## Behaviour

| argv | before | after |
| --- | --- | --- |
| `mytool -- --version` | prints version | literal positional ✅ |
| `mytool -- --json` | JSON mode on | literal positional ✅ |
| `mytool --version` | prints version | prints version (unchanged) |
| `mytool --json deploy` | JSON mode on | JSON mode on (unchanged) |

## Tests

- `parse`: unit tests for `includesBeforeSeparator()` (before / at-or-after `--` / absent).
- `cli` e2e (`.default()` command): `--version`/`--json` after `--` are literal positionals; pre-`--` interception still works.

Full suite green (2346 tests), typecheck / lint / format clean.

## Not in scope

This deliberately does **not** change the `--help` vs `--version` positional relationship (#29) — that's a separate UX decision. The interception code paths now share `includesBeforeSeparator`, so a follow-up for #29 can build on this.
