### PR TITLE
Fix default command UX and status exits

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -58,7 +58,7 @@
 		"https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
 		"https://plugins.dprint.dev/markdown-0.22.1.wasm",
 		"https://plugins.dprint.dev/kjanat/svg-v0.4.1.wasm",
-		"https://plugins.dprint.dev/exec-0.6.2.json@df98f54ffd3092b8a841aedd6d098a2651f16d0a796a40535774f1a8b4b9d463",
+		"https://plugins.dprint.dev/exec-0.7.2.json@6c30bd00dfb176774ece412d0fbf149478269ecc92c55ab2d6f4116938ed993e",
 		"https://plugins.dprint.dev/prettier-0.72.0.json@6e7af2cb2182a5a11358d3adde9ae0ef3b94b7d2e5dcfdd252e3f7c3916541fe",
 		"https://plugins.dprint.dev/ruff-0.7.17.wasm",
 		"https://plugins.dprint.dev/json-0.22.0.wasm",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`out.setExitCode(code)` for normal-output status exits** — command handlers can now request a
+  process exit code without throwing or emitting error-shaped output, covering status/check CLIs that
+  should print their normal report while still signalling degraded state to scripts
+  (https://github.com/kjanat/dreamcli/issues/27).
+
+### Fixed
+
+- **Unknown root commands under no-arg defaults now report `UNKNOWN_COMMAND`** — when a CLI has a
+  `.default()` command with no positional args, an unknown root token no longer falls through to the
+  default parser as an unexpected positional. Defaults that declare positional args still receive
+  those root tokens as before (https://github.com/kjanat/dreamcli/issues/26).
+
 ## [2.3.0] - 2026-06-20
 
 ### Fixed

--- a/docs/concepts/exit-codes.md
+++ b/docs/concepts/exit-codes.md
@@ -62,6 +62,24 @@ If you're building a CLI:
 - **1** when something goes wrong at runtime (network error, file not found)
 - **2** when the user gave bad input (unknown flag, missing required argument)
 
+## Setting Exit Codes In DreamCLI
+
+Throw a `CLIError` when the result is error-shaped and should render an error
+message. Use `out.setExitCode(code)` when the command should keep normal output
+but still return a status code.
+
+```ts twoslash
+import { command } from '@kjanat/dreamcli';
+
+command('status').action(({ out }) => {
+  out.log('Service is degraded');
+  out.setExitCode(7);
+});
+```
+
+This is useful for check/status commands: humans see the normal report, while
+shell scripts can still react to `$?`.
+
 ## Signals
 
 When you press **Ctrl+C**, you're not typing a character — you're sending a **signal** called

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -27,6 +27,23 @@ out.json({ status: 'ok', count: 42 });
 When the CLI is invoked with `--json`, structured payloads stay on stdout while
 plain text (`log`, `info`, `warn`, `error`) routes to stderr.
 
+## Exit Codes Without Error Output
+
+Use `out.setExitCode(code)` when a command should emit normal output but still
+return a non-zero status to scripts.
+
+```ts twoslash
+import { command } from '@kjanat/dreamcli';
+
+command('status').action(({ out }) => {
+  out.json({ status: 'degraded' });
+  out.setExitCode(7);
+});
+```
+
+`setExitCode()` does not print anything and does not stop execution. Later calls
+win, and thrown `CLIError`s still use their own exit codes and error rendering.
+
 ## Tables
 
 ```ts twoslash

--- a/docs/reference/main.md
+++ b/docs/reference/main.md
@@ -340,6 +340,10 @@ import type { RunResult } from '@kjanat/dreamcli';
 Create an output channel.
 Typically not called directly — commands receive `out` in the action handler.
 
+Handlers can call `out.setExitCode(code)` to request a process exit code without
+printing error output. The command still completes normally and `RunResult.error`
+stays `undefined` unless an error is thrown.
+
 ## Parsing
 
 ### `tokenize(argv)`

--- a/docs/reference/testkit.md
+++ b/docs/reference/testkit.md
@@ -48,13 +48,16 @@ const result = await runCommand(greet, ['Alice', '--loud']);
 
 ### RunResult
 
-| Field      | Type                    | Description                              |
-| ---------- | ----------------------- | ---------------------------------------- |
-| `exitCode` | `number`                | Process exit code                        |
-| `stdout`   | `string[]`              | Captured stdout lines                    |
-| `stderr`   | `string[]`              | Captured stderr lines                    |
-| `error`    | `CLIError \| undefined` | Structured error, `undefined` on success |
-| `activity` | `ActivityEvent[]`       | Spinner/progress events                  |
+| Field      | Type                    | Description                                    |
+| ---------- | ----------------------- | ---------------------------------------------- |
+| `exitCode` | `number`                | Process exit code                              |
+| `stdout`   | `string[]`              | Captured stdout lines                          |
+| `stderr`   | `string[]`              | Captured stderr lines                          |
+| `error`    | `CLIError \| undefined` | Structured error, `undefined` when none thrown |
+| `activity` | `ActivityEvent[]`       | Spinner/progress events                        |
+
+`exitCode` can be non-zero while `error` is `undefined` when a handler calls
+`out.setExitCode(code)` for normal-output status results.
 
 ## `createCaptureOutput()`
 

--- a/skills/cli-creation/SKILL.md
+++ b/skills/cli-creation/SKILL.md
@@ -55,6 +55,7 @@ Use this skill for user-facing app code, not DreamCLI framework internals.
 - Add typed flags with defaults and aliases via `flag.*()`.
 - Add env/config/prompt sources on each flag before action logic.
 - Branch on `out.jsonMode` for machine-readable responses.
+- Use `out.setExitCode(code)` for check/status commands that need normal output plus non-zero status.
 - Use `runCommand()` from `@kjanat/dreamcli/testkit` for in-process tests.
 - Keep output assertions explicit, including trailing newlines.
 

--- a/skills/cli-creation/references/consumer-workflow.md
+++ b/skills/cli-creation/references/consumer-workflow.md
@@ -39,6 +39,7 @@ Build a consumer-facing CLI app with DreamCLI, starting from a working template 
    - Use `out.log()` for human messages.
    - Use `out.table()` for list-shaped data.
    - For object responses, branch on `out.jsonMode` and use `out.json(data)`.
+   - For check/status results, use `out.setExitCode(code)` to keep normal output while signalling non-zero status.
 
 5. Validate behavior.
 

--- a/skills/cli-creation/references/pattern-cookbook.md
+++ b/skills/cli-creation/references/pattern-cookbook.md
@@ -68,3 +68,15 @@ expect(result.stdout).toEqual(['Deploying production to us\n']);
 ```
 
 Prefer `runCommand()` over subprocess tests for speed and deterministic assertions.
+
+## 6) Normal output with non-zero status
+
+```ts
+.action(({ out }) => {
+	out.log('Service api is degraded');
+	out.setExitCode(7);
+});
+```
+
+Use this for check/status commands. It keeps stdout/stderr normal, avoids error
+payloads in `--json` mode, and still lets scripts react to the exit code.

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -1,6 +1,6 @@
 # cli — CLIBuilder, multi-command dispatch, plugins
 
-`index.ts` (~1015 lines) — heavily split: 7 `@internal` extraction files.
+`index.ts` (~1021 lines) — heavily split: 7 `@internal` extraction files.
 
 ## KEY TYPES
 
@@ -20,7 +20,7 @@
 
 | File                   | Lines | Purpose                                                              |
 | ---------------------- | ----: | -------------------------------------------------------------------- |
-| `index.ts`             |  1015 | CLIBuilder class + cli() factory + JSON error handling               |
+| `index.ts`             |  1021 | CLIBuilder class + cli() factory + JSON error handling               |
 | `dispatch.ts`          |   349 | `@internal` — command dispatch (value-flag-arity aware), levenshtein |
 | `planner.ts`           |   431 | `@internal` — execution planner, command resolution strategy         |
 | `runtime-preflight.ts` |   304 | `@internal` — runtime adapter setup, env/config preflight            |
@@ -61,6 +61,9 @@ command map building, 3-way dispatch result (`unknown` / `needs-subcommand` / `m
   value (`consumesFollowingToken` + `ValueFlagLookup`, built from the default/matched command's flags)
   so the value isn't mistaken for a command name — reuses `buildFlagLookup`/`flagExpectsValue` from
   `parse/` as the single source of truth (#25)
+- `planner.ts` delegates unknown root tokens to `.default()` only when the token is absent/flags-only
+  or the default declares positional args. No-arg defaults surface `UNKNOWN_COMMAND` for unknown root
+  tokens, while unknown flags before positionals still surface `UNKNOWN_FLAG` (#26).
 - `extractConfigFlag()` handles both `--config path` and `--config=path` forms
 - Direct imports: `schema/command.ts`, `schema/flag.ts`, `schema/arg.ts` (not through barrel)
 - Cross-layer imports: `runtime/adapter.ts`, `runtime/auto.ts` (not through runtime barrel)

--- a/src/core/cli/cli-default.test.ts
+++ b/src/core/cli/cli-default.test.ts
@@ -197,6 +197,15 @@ describe('.default()', () => {
 			expect(result.stdout.join('')).toContain('serve:9090');
 		});
 
+		it('reports unknown commands when the default accepts no positionals', async () => {
+			const app = cli('mycli').default(noArgCommand()).command(statusCommand());
+			const result = await app.execute(['wat']);
+
+			expect(result.exitCode).toBe(2);
+			expect(result.stderr.join('')).toContain('Unknown command: wat');
+			expect(result.stderr.join('')).toContain("Run 'mycli --help' for available commands");
+		});
+
 		it('preserves typo detection — mistyped sibling shows suggestion', async () => {
 			const app = cli('mycli').default(deployCommand()).command(statusCommand());
 			const result = await app.execute(['stattus']);

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -18,7 +18,11 @@ import { buildRunResult, executeCommand } from '#internals/core/execution/index.
 import type { HelpOptions } from '#internals/core/help/index.ts';
 import { formatHelp } from '#internals/core/help/index.ts';
 import type { CapturedOutput } from '#internals/core/output/index.ts';
-import { createCaptureOutput, createOutput } from '#internals/core/output/index.ts';
+import {
+	clearRequestedExitCode,
+	createCaptureOutput,
+	createOutput,
+} from '#internals/core/output/index.ts';
 import { includesBeforeSeparator } from '#internals/core/parse/index.ts';
 import type { ArgBuilder, ArgConfig } from '#internals/core/schema/arg.ts';
 import { arg } from '#internals/core/schema/arg.ts';
@@ -826,6 +830,7 @@ class CLIBuilder {
 				Object.keys(captureOptions).length > 0 ? captureOptions : undefined,
 			);
 		}
+		clearRequestedExitCode(out);
 
 		// Resolve help options — default binName to CLI program name,
 		// hyperlinks to TTY detection (escapes never leak into piped output)

--- a/src/core/cli/planner.test.ts
+++ b/src/core/cli/planner.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { CLIError } from '#internals/core/errors/index.ts';
 import type { HelpOptions } from '#internals/core/help/index.ts';
 import type { OutputPolicy } from '#internals/core/output/contracts.ts';
+import { createArgSchema } from '#internals/core/schema/arg.ts';
 import type { CommandSchema, ErasedCommand } from '#internals/core/schema/command.ts';
 import { createSchema } from '#internals/core/schema/flag.ts';
 import { mergeCommandSchema, planInvocation } from './planner.ts';
@@ -141,8 +142,13 @@ describe('planInvocation() — root interception', () => {
 // === Default-command behavior
 
 describe('planInvocation() — default command behavior', () => {
-	it('delegates unknown root argv without suggestions', () => {
-		const deploy = erased(commandSchema({ name: 'deploy' }));
+	it('delegates unknown root argv to defaults with positional args', () => {
+		const deploy = erased(
+			commandSchema({
+				name: 'deploy',
+				args: [{ name: 'target', schema: createArgSchema('string') }],
+			}),
+		);
 		const status = erased(commandSchema({ name: 'status' }));
 
 		const result = planFor([deploy, status], ['production', '--force'], deploy);
@@ -152,6 +158,34 @@ describe('planInvocation() — default command behavior', () => {
 			expect(result.plan.command).toBe(deploy);
 			expect(result.plan.argv).toEqual(['production', '--force']);
 			expect(result.plan.meta.command).toBe('deploy');
+		}
+	});
+
+	it('rejects unknown root argv for defaults without positional args', () => {
+		const deploy = erased(commandSchema({ name: 'deploy' }));
+		const status = erased(commandSchema({ name: 'status' }));
+
+		const result = planFor([deploy, status], ['production'], deploy);
+
+		expect(result.kind).toBe('dispatch-error');
+		if (result.kind === 'dispatch-error') {
+			expect(result.error.message).toBe('Unknown command: production');
+			expect(result.error.code).toBe('UNKNOWN_COMMAND');
+			expect(result.error.suggest).toBe("Run 'dream --help' for available commands");
+		}
+	});
+
+	it('reports unknown flags before unknown positional values for no-arg defaults', () => {
+		const deploy = erased(commandSchema({ name: 'deploy' }));
+		const status = erased(commandSchema({ name: 'status' }));
+
+		const result = planFor([deploy, status], ['--bogus', 'production'], deploy);
+
+		expect(result.kind).toBe('dispatch-error');
+		if (result.kind === 'dispatch-error') {
+			expect(result.error.message).toBe('Unknown flag --bogus');
+			expect(result.error.code).toBe('UNKNOWN_FLAG');
+			expect(result.error.suggest).toBe("Run 'dream --help' for available commands");
 		}
 	});
 

--- a/src/core/cli/planner.ts
+++ b/src/core/cli/planner.ts
@@ -12,7 +12,11 @@
 
 import { CLIError, ParseError } from '#internals/core/errors/index.ts';
 import type { HelpOptions } from '#internals/core/help/index.ts';
-import { buildFlagLookup, includesBeforeSeparator } from '#internals/core/parse/index.ts';
+import {
+	buildFlagLookup,
+	flagExpectsValue,
+	includesBeforeSeparator,
+} from '#internals/core/parse/index.ts';
 import type { OutputPolicy } from '#internals/core/output/contracts.ts';
 import type { CommandMeta, CommandSchema, ErasedCommand } from '#internals/core/schema/command.ts';
 import { dispatch, findClosestCommand } from './dispatch.ts';
@@ -249,6 +253,44 @@ function buildPlannerMatchOutcome(
 	};
 }
 
+function canDelegateUnknownRootToDefault(command: ErasedCommand, input: string): boolean {
+	return input === '' || command.schema.args.length > 0;
+}
+
+function findUnknownFlagBeforePositional(
+	argv: readonly string[],
+	flags: CommandSchema['flags'],
+): string | undefined {
+	const lookup = buildFlagLookup(flags);
+
+	for (let index = 0; index < argv.length; index++) {
+		const token = argv[index];
+		if (token === undefined || token === '--') return undefined;
+		if (token === '-' || !token.startsWith('-')) return undefined;
+
+		if (token.startsWith('--')) {
+			const equalsIndex = token.indexOf('=');
+			const name = token.slice(2, equalsIndex === -1 ? undefined : equalsIndex);
+			const entry = lookup.get(name);
+			if (entry === undefined) return equalsIndex === -1 ? token : `--${name}`;
+			if (equalsIndex === -1 && flagExpectsValue(entry[1])) index++;
+			continue;
+		}
+
+		const chars = token.slice(1);
+		for (let charIndex = 0; charIndex < chars.length; charIndex++) {
+			const char = chars.charAt(charIndex);
+			const entry = lookup.get(char);
+			if (entry === undefined) return `-${char}`;
+			if (!flagExpectsValue(entry[1])) continue;
+			if (charIndex === chars.length - 1) index++;
+			break;
+		}
+	}
+
+	return undefined;
+}
+
 /**
  * Decide what to do with an argv invocation before any command executes.
  *
@@ -342,7 +384,7 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 			if (defaultCommand !== undefined && result.parentPath.length === 0) {
 				const suggestion =
 					result.input !== '' ? findClosestCommand(result.input, result.candidates) : undefined;
-				if (suggestion === undefined) {
+				if (suggestion === undefined && canDelegateUnknownRootToDefault(defaultCommand, result.input)) {
 					return buildPlannerMatchOutcome(
 						options.schema,
 						defaultCommand,
@@ -351,6 +393,20 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 						options.help,
 						options.output,
 					);
+				}
+
+				const unknownFlag = findUnknownFlagBeforePositional(
+					filteredArgv,
+					defaultCommand.schema.flags,
+				);
+				if (unknownFlag !== undefined) {
+					return {
+						kind: 'dispatch-error',
+						error: new ParseError(`Unknown flag ${unknownFlag}`, {
+							code: 'UNKNOWN_FLAG',
+							suggest: `Run '${options.schema.name} --help' for available commands`,
+						}),
+					};
 				}
 			}
 

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -16,6 +16,10 @@ import type {
 import { CLIError } from '#internals/core/errors/index.ts';
 import { formatHelp } from '#internals/core/help/index.ts';
 import type { CapturedOutput } from '#internals/core/output/index.ts';
+import {
+	clearRequestedExitCode,
+	getRequestedExitCode,
+} from '#internals/core/output/index.ts';
 import { includesBeforeSeparator, parse } from '#internals/core/parse/index.ts';
 import { createTestPrompter } from '#internals/core/prompt/index.ts';
 import type { DeprecationWarning, ResolveOptions } from '#internals/core/resolve/index.ts';
@@ -67,6 +71,7 @@ interface CommandExecutionResult {
  */
 async function executeCommand(request: CommandExecutionRequest): Promise<CommandExecutionResult> {
 	const { argv, command, meta, options, out, schema } = request;
+	clearRequestedExitCode(out);
 
 	try {
 		if (includesBeforeSeparator(argv, '--help') || includesBeforeSeparator(argv, '-h')) {
@@ -123,7 +128,7 @@ async function executeCommand(request: CommandExecutionRequest): Promise<Command
 		await executeWithExecutionSteps(command, handler, resolved.flags, resolved.args, out, meta);
 		await runResolvedHooks(options?.plugins, 'afterAction', resolvedParams);
 
-		return { exitCode: 0, error: undefined };
+		return { exitCode: getRequestedExitCode(out) ?? 0, error: undefined };
 	} catch (error: unknown) {
 		if (error instanceof CLIError) {
 			if (options?.jsonMode === true) {
@@ -150,6 +155,7 @@ async function executeCommand(request: CommandExecutionRequest): Promise<Command
 		return { exitCode: 1, error: wrapped };
 	} finally {
 		out.stopActive();
+		clearRequestedExitCode(out);
 	}
 }
 

--- a/src/core/output/AGENTS.md
+++ b/src/core/output/AGENTS.md
@@ -2,7 +2,7 @@
 
 Six source files: `writer.ts` (leaf), `contracts.ts` (type contracts), `display-value.ts` (value
 formatting), `renderers.ts` (table/list rendering), `activity.ts` (handle classes, ~568 lines),
-`index.ts` (OutputChannel + factories, ~669 lines).
+`index.ts` (OutputChannel + factories, ~698 lines).
 
 Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- `index.ts` ->
 `writer.ts`. `renderers.ts` + `display-value.ts` consumed by `index.ts`.
@@ -13,6 +13,7 @@ Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- 
 | ----------------------- | ----------- | ------------------------------------------------- |
 | `createOutput()`        | **Public**  | Factory -> `Out` interface (mode-dispatched)      |
 | `createCaptureOutput()` | **Public**  | Factory -> `Out` + `CapturedOutput` (for testkit) |
+| `out.setExitCode()`     | **Public**  | Request success-path exit code without output     |
 | `OutputChannel`         | `@internal` | Concrete class implementing `Out`                 |
 | `CaptureOutputChannel`  | `@internal` | Subclass capturing output + activity events       |
 
@@ -20,7 +21,7 @@ Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- 
 
 | File               | Lines | Purpose                                                   |
 | ------------------ | ----: | --------------------------------------------------------- |
-| `index.ts`         |   669 | OutputChannel class + factories + mode dispatch           |
+| `index.ts`         |   698 | OutputChannel class + factories + mode dispatch           |
 | `activity.ts`      |   568 | Spinner/progress handle classes (TTY/static/capture/noop) |
 | `contracts.ts`     |   177 | Output type contracts, mode types, option interfaces      |
 | `renderers.ts`     |   101 | Table + list rendering logic                              |
@@ -56,6 +57,8 @@ Starting a new one implicitly stops the previous. All activity output routes to 
 - Imports `schema/activity.ts` directly for activity types, `schema/command.ts` for `Out` — bypasses
   barrel to avoid circular dep
 - `writer.ts` is a leaf: `WriteFn` type + `writeLine` helper. Shared by `index.ts` and `activity.ts`
+- Exit-code requests live in a module-private `WeakMap<Out, number>`; executor reads and clears it.
+  `out.setExitCode()` does not short-circuit and writes no output.
 - Terminal escape sequences (`HIDE_CURSOR`, `ERASE_LINE`, etc.) are `@internal` constants in
   `activity.ts`
 - Spinner/progress tests use `vi.useFakeTimers()` inline with `try/finally`
@@ -66,7 +69,7 @@ Starting a new one implicitly stops the previous. All activity output routes to 
 
 | File                               | Tests | Focus                                                 |
 | ---------------------------------- | ----: | ----------------------------------------------------- |
-| `output.test.ts`                   |    49 | Core OutputChannel: log/warn/error, modes             |
+| `output.test.ts`                   |    53 | Core OutputChannel: log/warn/error, modes, exit codes |
 | `output-tty.test.ts`               |    20 | TTY-specific rendering, color, formatting             |
 | `output-table.test.ts`             |    16 | Table output in various modes                         |
 | `output-spinner.test.ts`           |    45 | Spinner handles: noop/static/TTY/capture, fake timers |

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -115,6 +115,27 @@ interface ResolvedOutputOptions {
  */
 const noopWrite: WriteFn = () => {};
 
+const requestedExitCodes = new WeakMap<Out, number>();
+
+function validateExitCode(code: number): number {
+	if (!Number.isInteger(code) || code < 0 || code > 255) {
+		throw new RangeError('Exit code must be an integer from 0 to 255');
+	}
+	return code;
+}
+
+function setRequestedExitCode(out: Out, code: number): void {
+	requestedExitCodes.set(out, validateExitCode(code));
+}
+
+function getRequestedExitCode(out: Out): number | undefined {
+	return requestedExitCodes.get(out);
+}
+
+function clearRequestedExitCode(out: Out): void {
+	requestedExitCodes.delete(out);
+}
+
 /** Merge user-supplied options with defaults. */
 function resolveOptions(options?: OutputOptions): ResolvedOutputOptions {
 	return {
@@ -197,6 +218,11 @@ class OutputChannel implements Out {
 	/** Error to stderr. Always emitted. */
 	error(message: string): void {
 		writeLine(this.options.stderr, message);
+	}
+
+	/** Request a successful-process exit code without writing error output. */
+	setExitCode(code: number): void {
+		setRequestedExitCode(this, code);
 	}
 
 	/**
@@ -658,9 +684,12 @@ export {
 	CaptureSpinnerHandle,
 	createCaptureOutput,
 	createOutput,
+	clearRequestedExitCode,
+	getRequestedExitCode,
 	noopProgressHandle,
 	noopSpinnerHandle,
 	OutputChannel,
+	setRequestedExitCode,
 	StaticProgressHandle,
 	StaticSpinnerHandle,
 	TTYProgressHandle,

--- a/src/core/output/output.test.ts
+++ b/src/core/output/output.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { Out } from '#internals/core/schema/command.ts';
 import type { CapturedOutput, OutputOptions, Verbosity, WriteFn } from './index.ts';
-import { createCaptureOutput, createOutput, OutputChannel } from './index.ts';
+import { createCaptureOutput, createOutput, getRequestedExitCode, OutputChannel } from './index.ts';
 
 // --- createOutput — factory
 
@@ -13,6 +13,7 @@ describe('createOutput', () => {
 		expect(typeof out.info).toBe('function');
 		expect(typeof out.warn).toBe('function');
 		expect(typeof out.error).toBe('function');
+		expect(typeof out.setExitCode).toBe('function');
 	});
 
 	it('discards output when no writers are provided', () => {
@@ -67,6 +68,36 @@ describe('createOutput', () => {
 		out.error('err2');
 		expect(stdoutLines).toEqual(['out1\n', 'out2\n']);
 		expect(stderrLines).toEqual(['err1\n', 'err2\n']);
+	});
+});
+
+// --- Exit code requests
+
+describe('exit code requests', () => {
+	it('records a requested exit code', () => {
+		const out = createOutput();
+
+		out.setExitCode(7);
+
+		expect(getRequestedExitCode(out)).toBe(7);
+	});
+
+	it('uses the last requested exit code', () => {
+		const out = createOutput();
+
+		out.setExitCode(3);
+		out.setExitCode(8);
+
+		expect(getRequestedExitCode(out)).toBe(8);
+	});
+
+	it('rejects invalid exit codes', () => {
+		const out = createOutput();
+
+		expect(() => out.setExitCode(-1)).toThrow(RangeError);
+		expect(() => out.setExitCode(1.5)).toThrow(RangeError);
+		expect(() => out.setExitCode(Number.POSITIVE_INFINITY)).toThrow(RangeError);
+		expect(() => out.setExitCode(256)).toThrow(RangeError);
 	});
 });
 

--- a/src/core/schema/AGENTS.md
+++ b/src/core/schema/AGENTS.md
@@ -6,7 +6,7 @@ Multi-file module in `core/`. All others (except resolve, output, completion) us
 
 | File            | Lines | Purpose                                                                                        |
 | --------------- | ----: | ---------------------------------------------------------------------------------------------- |
-| `command.ts`    |  1466 | `CommandBuilder<F, A, C>` — fluent builder + `Out` interface + schema                          |
+| `command.ts`    |  1474 | `CommandBuilder<F, A, C>` — fluent builder + `Out` interface + schema                          |
 | `flag.ts`       |   753 | `FlagBuilder` — `flag.string()`, `.boolean()`, `.number()`, `.count()`, `.enum()`, `.custom()` |
 | `arg.ts`        |   713 | `ArgBuilder` — `arg.string()`, `.number()`, `.enum()`                                          |
 | `activity.ts`   |   150 | Activity types — `SpinnerHandle`, `ProgressHandle`, `ActivityEvent`, etc.                      |
@@ -63,6 +63,8 @@ Runtime enforcement lives in `resolve/flags.ts` (`COMPATIBLE_PROMPT_KINDS` + `va
 - `deprecated()` modifier on both FlagBuilder and ArgBuilder — collects `DeprecationWarning` structs
 - Activity types live in `activity.ts` (not in output/) because `Out` needs them in
   `CommandBuilder.action()` signature
+- `Out.setExitCode(code)` is part of the public action-handler output surface. It requests a
+  success-path process exit code without error output; thrown errors still own failure exits.
 - `command.ts` imports activity types from `./activity.ts` directly
 
 ## TEST FILES (6)

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -329,6 +329,7 @@ describe('full command composition', () => {
 			info: vi.fn(),
 			warn: vi.fn(),
 			error: vi.fn(),
+			setExitCode: vi.fn(),
 			json: vi.fn(),
 			table: vi.fn(),
 			spinner: vi.fn(),

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -153,6 +153,14 @@ interface Out {
 	/** Error to stderr. */
 	error(message: string): void;
 	/**
+	 * Request a process exit code without emitting error-shaped output.
+	 *
+	 * Use this for check/status commands that should print normal output but
+	 * still signal a non-zero status to scripts. This does not stop execution;
+	 * later calls overwrite earlier calls, and thrown errors still win.
+	 */
+	setExitCode(code: number): void;
+	/**
 	 * Emit a structured JSON value to stdout.
 	 *
 	 * Always serialises `value` as JSON to stdout regardless of output

--- a/src/core/schema/run.ts
+++ b/src/core/schema/run.ts
@@ -155,9 +155,10 @@ export interface RunOptions {
 /**
  * Structured result from {@linkcode runCommand}.
  *
- * Contains the exit code, captured stdout/stderr output, recorded
- * {@linkcode ActivityEvent | activity events}, and an `error` field
- * that is `undefined` on success and a {@linkcode CLIError} on failure.
+	 * Contains the exit code, captured stdout/stderr output, recorded
+	 * {@linkcode ActivityEvent | activity events}, and an `error` field.
+	 * `error` is `undefined` when execution completed without throwing, even if
+	 * the handler requested a non-zero status via {@linkcode Out.setExitCode}.
  *
  * @example
  * ```ts
@@ -188,8 +189,10 @@ export interface RunResult {
 	readonly activity: readonly ActivityEvent[];
 
 	/**
-	 * The error that caused a non-zero exit, or `undefined` on success.
-	 * {@linkcode CLIError} instances are preserved; unknown errors are wrapped.
+	 * The error that caused a failure, or `undefined` when execution completed.
+	 * A non-zero `exitCode` can still have no error when a handler calls
+	 * {@linkcode Out.setExitCode}. {@linkcode CLIError} instances are preserved;
+	 * unknown errors are wrapped.
 	 */
 	readonly error: CLIError | undefined;
 }

--- a/src/core/testkit/executor-contract.test.ts
+++ b/src/core/testkit/executor-contract.test.ts
@@ -193,4 +193,67 @@ describe('runCommand() executor contract', () => {
 		expect(result.error?.code).toBe('NO_ACTION');
 		expect(stopActive).toHaveBeenCalledTimes(1);
 	});
+
+	it('allows normal output with a requested non-zero exit code', async () => {
+		const cmd = command('check').action(({ out }) => {
+			out.log('degraded');
+			out.setExitCode(7);
+		});
+
+		const result = await runCommand(cmd, []);
+
+		expect(result.exitCode).toBe(7);
+		expect(result.stdout).toEqual(['degraded\n']);
+		expect(result.stderr).toEqual([]);
+		expect(result.error).toBeUndefined();
+	});
+
+	it('lets afterAction hooks override requested exit codes', async () => {
+		const cmd = command('check').action(({ out }) => {
+			out.setExitCode(3);
+		});
+
+		const result = await runCommand(cmd, [], {
+			plugins: [
+				plugin({
+					afterAction: ({ out }) => {
+						out.setExitCode(4);
+					},
+				}),
+			],
+		});
+
+		expect(result.exitCode).toBe(4);
+		expect(result.error).toBeUndefined();
+	});
+
+	it('does not leak requested exit codes across reused output channels', async () => {
+		const [out, captured] = createCaptureOutput();
+		const failingStatus = command('check').action(({ out }) => {
+			out.setExitCode(5);
+		});
+		const healthyStatus = command('check').action(({ out }) => {
+			out.log('ok');
+		});
+
+		const first = await runCommand(failingStatus, [], { out, captured });
+		const second = await runCommand(healthyStatus, [], { out, captured });
+
+		expect(first.exitCode).toBe(5);
+		expect(second.exitCode).toBe(0);
+		expect(second.error).toBeUndefined();
+	});
+
+	it('lets thrown CLIError exit codes win over requested exit codes', async () => {
+		const cmd = command('check').action(({ out }) => {
+			out.setExitCode(7);
+			throw new CLIError('boom', { code: 'BOOM', exitCode: 3 });
+		});
+
+		const result = await runCommand(cmd, []);
+
+		expect(result.exitCode).toBe(3);
+		expect(result.stderr).toEqual(['boom\n']);
+		expect(result.error?.code).toBe('BOOM');
+	});
 });

--- a/src/core/testkit/testkit-json.test.ts
+++ b/src/core/testkit/testkit-json.test.ts
@@ -93,6 +93,20 @@ describe('runCommand', () => {
 	// --- jsonMode
 
 	describe('jsonMode', () => {
+		it('keeps normal JSON payloads when a handler requests a non-zero exit code', async () => {
+			const cmd = command('status').action(({ out }) => {
+				out.json({ status: 'degraded' });
+				out.setExitCode(7);
+			});
+
+			const result = await runCommand(cmd, [], { jsonMode: true });
+
+			expect(result.exitCode).toBe(7);
+			expect(result.stdout).toEqual(['{"status":"degraded"}\n']);
+			expect(result.stderr).toEqual([]);
+			expect(result.error).toBeUndefined();
+		});
+
 		it('redirects log() to stderr in JSON mode', async () => {
 			const cmd = mixedOutputCommand();
 			const result = await runCommand(cmd, [], { jsonMode: true });

--- a/src/runtime/runtime.test.ts
+++ b/src/runtime/runtime.test.ts
@@ -384,6 +384,35 @@ describe('CLIBuilder.run() with adapter', () => {
 		expect(stdoutLines.join('')).toContain('mycli');
 	});
 
+	it('exits with a handler-requested non-zero code without error output', async () => {
+		const stdoutLines: string[] = [];
+		const stderrLines: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'cli.js', 'check'],
+			stdout: (s) => stdoutLines.push(s),
+			stderr: (s) => stderrLines.push(s),
+		});
+		const app = cli('mycli').command(
+			command('check').action(({ out }) => {
+				out.log('degraded');
+				out.setExitCode(7);
+			}),
+		);
+
+		try {
+			await app.run({ adapter });
+		} catch (e) {
+			expect(e).toBeInstanceOf(ExitError);
+			if (!(e instanceof ExitError)) {
+				expect.unreachable('expected ExitError');
+			}
+			expect(e.code).toBe(7);
+		}
+
+		expect(stdoutLines).toEqual(['degraded\n']);
+		expect(stderrLines).toEqual([]);
+	});
+
 	it('slices argv correctly (removes binary + script)', async () => {
 		const stdoutLines: string[] = [];
 		const adapter = createTestAdapter({

--- a/src/runtime/runtime.test.ts
+++ b/src/runtime/runtime.test.ts
@@ -399,15 +399,9 @@ describe('CLIBuilder.run() with adapter', () => {
 			}),
 		);
 
-		try {
-			await app.run({ adapter });
-		} catch (e) {
-			expect(e).toBeInstanceOf(ExitError);
-			if (!(e instanceof ExitError)) {
-				expect.unreachable('expected ExitError');
-			}
-			expect(e.code).toBe(7);
-		}
+		const run = app.run({ adapter });
+		await expect(run).rejects.toThrow(ExitError);
+		await expect(run).rejects.toMatchObject({ code: 7 });
 
 		expect(stdoutLines).toEqual(['degraded\n']);
 		expect(stderrLines).toEqual([]);


### PR DESCRIPTION
## Summary
- add `out.setExitCode(code)` for normal-output non-zero status exits
- report unknown root tokens as `UNKNOWN_COMMAND` when a default command has no positional args
- document the exit-code seam in docs, skills, and changelog

Closes #26.
Closes #27.

## Tests
- `bun test src/core/cli/planner.test.ts src/core/cli/cli-default.test.ts src/core/output/output.test.ts src/core/testkit/executor-contract.test.ts src/core/testkit/testkit-json.test.ts src/runtime/runtime.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test`
- `bun run docs:build`