### PR TITLE
Fix README CLI examples

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -58,7 +58,7 @@
 		"https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
 		"https://plugins.dprint.dev/markdown-0.22.1.wasm",
 		"https://plugins.dprint.dev/kjanat/svg-v0.4.1.wasm",
-		"https://plugins.dprint.dev/exec-0.6.2.json@df98f54ffd3092b8a841aedd6d098a2651f16d0a796a40535774f1a8b4b9d463",
+		"https://plugins.dprint.dev/exec-0.7.2.json@6c30bd00dfb176774ece412d0fbf149478269ecc92c55ab2d6f4116938ed993e",
 		"https://plugins.dprint.dev/prettier-0.72.0.json@6e7af2cb2182a5a11358d3adde9ae0ef3b94b7d2e5dcfdd252e3f7c3916541fe",
 		"https://plugins.dprint.dev/ruff-0.7.17.wasm",
 		"https://plugins.dprint.dev/json-0.22.0.wasm",

--- a/README.md
+++ b/README.md
@@ -125,8 +125,31 @@ const login = command('login')
 const migrate = command('migrate')
   .description('Run migrations')
   .flag('steps', flag.number())
-  .action(({ flags, out }) => {
-    out.log(`migrating ${flags.steps ?? 'all'} steps`);
+  .action(async ({ flags, meta, out }) => {
+    const steps = flags.steps ?? 3;
+
+    out.log(`${meta.name} ${meta.version ?? ''}`.trim());
+    out.log(`Command: ${meta.command}`);
+
+    const spinner = out.spinner('Preparing migrations');
+    await new Promise((resolve) =>
+      setTimeout(resolve, 1000),
+    );
+    spinner.succeed(`Ready to run ${steps} steps`);
+
+    const progress = out.progress({
+      label: 'Migrating',
+      total: steps,
+    });
+
+    for (let step = 1; step <= steps; step++) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, 700),
+      );
+      progress.update(step);
+    }
+
+    progress.done(`Migrated ${steps} steps`);
   });
 
 const seed = command('seed')
@@ -153,6 +176,12 @@ cli('mycli')
 // mycli db migrate --steps 3
 // mycli db seed
 ```
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/REPLACE-WITH-DARK-GIF-ID">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/REPLACE-WITH-LIGHT-GIF-ID">
+  <img alt="DreamCLI migration progress demo" src="https://github.com/user-attachments/assets/REPLACE-WITH-LIGHT-GIF-ID">
+</picture>
 
 ## Why dreamcli
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ cli('greet').default(greet).run();
 
 ### Multi-command CLI
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" width="700" height="400" alt="dreamcli-migrate-dark" srcset="https://github.com/user-attachments/assets/1ef7f20c-9ffb-4cb6-a6bc-fb562895aa6f">
+  <source media="(prefers-color-scheme: light)" width="700" height="400" alt="dreamcli-migrate-light" srcset="https://github.com/user-attachments/assets/1ee5f38d-cad8-47ec-94b2-c826eabab76b">
+  <img alt="DreamCLI migration progress demo" width="700" height="400" src="https://github.com/user-attachments/assets/1ee5f38d-cad8-47ec-94b2-c826eabab76b">
+</picture>
+
 ```ts
 import {
   cli,
@@ -176,12 +182,6 @@ cli('mycli')
 // mycli db migrate --steps 3
 // mycli db seed
 ```
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/REPLACE-WITH-DARK-GIF-ID">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/REPLACE-WITH-LIGHT-GIF-ID">
-  <img alt="DreamCLI migration progress demo" src="https://github.com/user-attachments/assets/REPLACE-WITH-LIGHT-GIF-ID">
-</picture>
 
 ## Why dreamcli
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,7 @@ Schema-first, fully typed TypeScript CLI framework. Zero runtime dependencies.
 One flag declaration configures the entire resolution pipeline:
 
 ```ts
-import {
-  cli,
-  command,
-  flag,
-  arg,
-  middleware,
-  CLIError,
-} from '@kjanat/dreamcli';
+import { cli, command, flag, arg } from '@kjanat/dreamcli';
 
 const deploy = command('deploy')
   .description('Deploy to an environment')
@@ -34,6 +27,8 @@ const deploy = command('deploy')
   .action(({ args, flags, out }) => {
     out.log(`Deploying ${args.target} to ${flags.region}`);
   });
+
+cli('deploy').default(deploy).run();
 ```
 
 By the time `action` runs, `flags.region` is `"us" | "eu" | "ap"` — not `string | undefined`.
@@ -64,7 +59,7 @@ deno add jsr:@kjanat/dreamcli  # or npm:@kjanat/dreamcli
 ### Single command
 
 ```ts
-import { command, flag, arg } from '@kjanat/dreamcli';
+import { cli, command, flag, arg } from '@kjanat/dreamcli';
 
 const greet = command('greet')
   .description('Greet someone')
@@ -87,7 +82,7 @@ const greet = command('greet')
     }
   });
 
-greet.run();
+cli('greet').default(greet).run();
 ```
 
 ### Multi-command CLI
@@ -190,6 +185,8 @@ the insight was wiring them so types flow end-to-end.
 ### Flag types
 
 ```ts
+import { flag } from '@kjanat/dreamcli';
+
 flag.string(); // string | undefined
 flag.number(); // number | undefined
 flag.boolean(); // boolean (defaults to false)
@@ -217,6 +214,8 @@ non-interactive contexts (CI, piped stdin), prompts are automatically skipped.
 Four prompt types, declared per-flag or per-command:
 
 ```ts
+import { command, flag } from '@kjanat/dreamcli';
+
 // Per-flag
 flag.string().prompt({ kind: 'input', message: 'Name?' });
 flag
@@ -245,7 +244,7 @@ command('deploy')
 ### Derive typed context from resolved input
 
 ```ts
-import { CLIError } from '@kjanat/dreamcli';
+import { CLIError, command, flag } from '@kjanat/dreamcli';
 
 command('deploy')
   .flag('token', flag.string().env('AUTH_TOKEN'))
@@ -268,7 +267,7 @@ the action handler runs.
 ### Middleware with typed context
 
 ```ts
-import { middleware } from '@kjanat/dreamcli';
+import { command, middleware } from '@kjanat/dreamcli';
 
 const timing = middleware<{ startTime: number }>(
   async ({ next }) => {
@@ -301,26 +300,33 @@ Use middleware when you need wrapper behavior with `next()`.
 Handlers receive `out` instead of `console`. Adapts to context automatically:
 
 ```ts
-cli('mycli')
-  // ... omitted for brevity
-  .action(({ out }) => {
-    out.log('Human-readable message');
-    out.json({ status: 'ok', count: 42 });
-    out.table(rows, [
-      { key: 'name', header: 'Name' },
-      { key: 'status', header: 'Status' },
-    ]);
+import { cli, command } from '@kjanat/dreamcli';
 
-    const spinner = out.spinner('Deploying...');
-    spinner.succeed('Done');
+const rows = [
+  { name: 'api', status: 'ok' },
+  { name: 'worker', status: 'deploying' },
+];
 
-    const progress = out.progress({
-      label: 'Uploading',
-      total: 100,
-    });
-    progress.update(50);
-    progress.done('Upload complete');
+const status = command('status').action(({ out }) => {
+  out.log('Human-readable message');
+  out.json({ status: 'ok', count: 42 });
+  out.table(rows, [
+    { key: 'name', header: 'Name' },
+    { key: 'status', header: 'Status' },
+  ]);
+
+  const spinner = out.spinner('Deploying...');
+  spinner.succeed('Done');
+
+  const progress = out.progress({
+    label: 'Uploading',
+    total: 100,
   });
+  progress.update(50);
+  progress.done('Upload complete');
+});
+
+cli('mycli').default(status).run();
 ```
 
 - TTY → pretty formatting, spinners animate
@@ -332,7 +338,24 @@ cli('mycli')
 Generated from the command schema — always in sync:
 
 ```ts
-import { generateCompletion } from '@kjanat/dreamcli';
+import { cli, command } from '@kjanat/dreamcli';
+
+cli('mycli').command(command('deploy')).completions().run();
+
+// mycli completions bash
+// mycli completion zsh
+```
+
+For programmatic integrations, call the generator directly:
+
+```ts
+import {
+  cli,
+  command,
+  generateCompletion,
+} from '@kjanat/dreamcli';
+
+const myCli = cli('mycli').command(command('deploy'));
 
 generateCompletion(myCli.schema, 'bash');
 generateCompletion(myCli.schema, 'zsh');
@@ -341,6 +364,8 @@ generateCompletion(myCli.schema, 'zsh');
 ### Config file discovery
 
 ```ts
+import { command, flag } from '@kjanat/dreamcli';
+
 command('deploy').flag(
   'region',
   flag.enum(['us', 'eu']).config('deploy.region'),
@@ -350,7 +375,7 @@ command('deploy').flag(
 Searches XDG-standard paths automatically. JSON built-in, plugin hook for YAML/TOML:
 
 ```ts
-import { configFormat } from '@kjanat/dreamcli';
+import { cli, configFormat } from '@kjanat/dreamcli';
 import { parse as parseYAML } from 'yaml';
 
 cli('mycli')
@@ -361,6 +386,11 @@ cli('mycli')
 ### Structured errors
 
 ```ts
+import { CLIError } from '@kjanat/dreamcli';
+
+const target = 'production';
+const region = 'us';
+
 throw new CLIError('Deployment failed', {
   code: 'DEPLOY_FAILED',
   exitCode: 1,
@@ -378,6 +408,7 @@ In `--json` mode, errors serialize to machine-readable JSON.
 subprocesses, no `process.argv` mutation, no mocking.
 
 ```ts
+import { expect } from 'vitest';
 import { arg, command, flag } from '@kjanat/dreamcli';
 import {
   runCommand,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "2.3.0",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
+		"dreamcli",
 		"cli",
 		"typescript",
 		"framework",


### PR DESCRIPTION
## Summary
- wrap single-command examples in `cli(...).default(...).run()`
- add missing imports so README snippets are complete
- clarify completion examples with runnable CLI setup

## Tests
- `bun run format:check`