### PR TITLE
fix(output): make Out & activity-handle methods safe to destructure

### DIFF
--- a/src/core/output/AGENTS.md
+++ b/src/core/output/AGENTS.md
@@ -1,8 +1,8 @@
 # output — OutputChannel, spinner/progress, TTY rendering
 
-Six source files: `writer.ts` (leaf), `contracts.ts` (type contracts), `display-value.ts` (value
-formatting), `renderers.ts` (table/list rendering), `activity.ts` (handle classes, ~568 lines),
-`index.ts` (OutputChannel + factories, ~698 lines).
+Seven source files: `writer.ts` (leaf), `contracts.ts` (type contracts), `display-value.ts` (value
+formatting), `renderers.ts` (table/list rendering), `bind.ts` (method-binding helper), `activity.ts`
+(handle classes, ~568 lines), `index.ts` (OutputChannel + factories, ~698 lines).
 
 Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- `index.ts` ->
 `writer.ts`. `renderers.ts` + `display-value.ts` consumed by `index.ts`.
@@ -26,6 +26,7 @@ Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- 
 | `contracts.ts`     |   177 | Output type contracts, mode types, option interfaces      |
 | `renderers.ts`     |   101 | Table + list rendering logic                              |
 | `display-value.ts` |    48 | Value display formatting utilities                        |
+| `bind.ts`          |    59 | `bindMethods()` — binds instance methods (see GOTCHAS)    |
 | `writer.ts`        |    30 | `WriteFn` type + `writeLine` helper (leaf)                |
 
 ## OUTPUT MODES
@@ -64,15 +65,22 @@ Starting a new one implicitly stops the previous. All activity output routes to 
 - Spinner/progress tests use `vi.useFakeTimers()` inline with `try/finally`
 - `ActivityEvent` has 10 variants (including `progress:increment` distinct from `progress:update`)
 - Ambient `setInterval`/`clearInterval` declared in `activity.ts` (zero-dep, no `@types/node`)
+- **Consumer-facing value objects (`OutputChannel` + all spinner/progress handle classes) call
+  `bindMethods(this)` as the last constructor statement.** This makes methods safe to destructure
+  (`const { log } = out`, `const { succeed } = spinner`) or pass as detached callbacks
+  (`promise.finally(spinner.stop)`) — unbound, they would lose `this` and crash. Any new method on
+  these classes is bound automatically (the helper reads the prototype chain), so don't hand-list
+  methods. The noop handle singletons are plain object literals that use no `this`, so they need no
+  binding.
 
 ## TEST FILES (6)
 
 | File                               | Tests | Focus                                                 |
 | ---------------------------------- | ----: | ----------------------------------------------------- |
-| `output.test.ts`                   |    53 | Core OutputChannel: log/warn/error, modes, exit codes |
+| `output.test.ts`                   |    56 | Core OutputChannel: log/warn/error, modes, exit codes |
 | `output-tty.test.ts`               |    20 | TTY-specific rendering, color, formatting             |
 | `output-table.test.ts`             |    16 | Table output in various modes                         |
-| `output-spinner.test.ts`           |    45 | Spinner handles: noop/static/TTY/capture, fake timers |
-| `output-progress.test.ts`          |    40 | Progress handles: noop/static/TTY/capture, fake timer |
+| `output-spinner.test.ts`           |    48 | Spinner handles: noop/static/TTY/capture, fake timers |
+| `output-progress.test.ts`          |    43 | Progress handles: noop/static/TTY/capture, fake timer |
 | `output-activity-dispatch.test.ts` |    32 | OutputChannel wiring: mode dispatch, overlap, testkit |
 | `contracts.test.ts`                |     — | Output contract verification                          |

--- a/src/core/output/activity.ts
+++ b/src/core/output/activity.ts
@@ -21,6 +21,7 @@ import type {
 	ProgressOptions,
 	SpinnerHandle,
 } from '#internals/core/schema/activity.ts';
+import { bindMethods } from './bind.ts';
 import type { WriteFn } from './writer.ts';
 import { writeLine } from './writer.ts';
 
@@ -90,6 +91,7 @@ class StaticSpinnerHandle implements SpinnerHandle {
 		private readonly write: WriteFn,
 	) {
 		writeLine(write, text);
+		bindMethods(this);
 	}
 
 	update(_text: string): void {
@@ -153,6 +155,7 @@ class StaticProgressHandle implements ProgressHandle {
 		if (label !== undefined) {
 			writeLine(write, label);
 		}
+		bindMethods(this);
 	}
 
 	increment(_n?: number): void {
@@ -263,6 +266,7 @@ class TTYSpinnerHandle implements SpinnerHandle {
 			this.frameIndex = (this.frameIndex + 1) % SPINNER_FRAMES.length;
 			this.render();
 		}, SPINNER_INTERVAL_MS);
+		bindMethods(this);
 	}
 
 	/** Render the current frame + text, overwriting the current line. */
@@ -372,6 +376,7 @@ class TTYProgressHandle implements ProgressHandle {
 				this.render();
 			}, PULSE_INTERVAL_MS);
 		}
+		bindMethods(this);
 	}
 
 	/** Advance the indeterminate pulse position with bounce logic. */
@@ -472,6 +477,7 @@ class CaptureSpinnerHandle implements SpinnerHandle {
 		private readonly events: ActivityEvent[],
 	) {
 		events.push({ type: 'spinner:start', text });
+		bindMethods(this);
 	}
 
 	update(text: string): void {
@@ -529,6 +535,7 @@ class CaptureProgressHandle implements ProgressHandle {
 		private readonly events: ActivityEvent[],
 	) {
 		events.push({ type: 'progress:start', label: opts.label ?? '', total: opts.total });
+		bindMethods(this);
 	}
 
 	increment(n?: number): void {

--- a/src/core/output/bind.ts
+++ b/src/core/output/bind.ts
@@ -1,0 +1,59 @@
+/**
+ * Method-binding helper for value objects handed to consumers.
+ *
+ * Output value objects — the `Out` channel and the spinner/progress handles
+ * — expose methods that read instance state via `this`. Consumers naturally
+ * detach those methods, either by destructuring
+ * (`const { log } = out` / `const { succeed, fail } = spinner`) or by passing
+ * them as callbacks (`promise.finally(spinner.stop)`). Detached, an unbound
+ * prototype method loses its `this` and crashes on the first field access.
+ *
+ * {@linkcode bindMethods} eliminates that footgun by installing instance-bound
+ * copies of every method, so the ergonomic usage is also the correct one.
+ *
+ * @module dreamcli/core/output/bind
+ * @internal
+ */
+
+/**
+ * Bind every method on an instance's prototype chain to the instance.
+ *
+ * Walks the prototype chain up to (but excluding) `Object.prototype`, binding
+ * each method name exactly once — the most-derived definition wins, so subclass
+ * overrides (e.g. `CaptureOutputChannel.spinner`) are preserved rather than
+ * clobbered by a base-class version. Bound methods are installed as
+ * non-enumerable own properties, mirroring the enumerability of the prototype
+ * methods they shadow. Getters and non-function members are left untouched.
+ *
+ * Call this once, last, in a class constructor. Because it reads the live
+ * prototype rather than a hand-maintained name list, methods added later are
+ * bound automatically — the binding can't silently fall out of date.
+ *
+ * @param instance - The object whose methods should be bound to it.
+ * @internal
+ */
+function bindMethods(instance: object): void {
+	const bound = instance as Record<PropertyKey, unknown>;
+	const seen = new Set<string>();
+	let proto: object | null = Object.getPrototypeOf(instance);
+
+	while (proto !== null && proto !== Object.prototype) {
+		for (const name of Object.getOwnPropertyNames(proto)) {
+			if (name === 'constructor' || seen.has(name)) continue;
+			seen.add(name);
+
+			const descriptor = Object.getOwnPropertyDescriptor(proto, name);
+			if (descriptor === undefined || typeof descriptor.value !== 'function') continue;
+
+			Object.defineProperty(bound, name, {
+				value: descriptor.value.bind(instance),
+				writable: true,
+				enumerable: false,
+				configurable: true,
+			});
+		}
+		proto = Object.getPrototypeOf(proto);
+	}
+}
+
+export { bindMethods };

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -31,6 +31,7 @@ import {
 	TTYProgressHandle,
 	TTYSpinnerHandle,
 } from './activity.ts';
+import { bindMethods } from './bind.ts';
 import type { OutputPolicy, Verbosity } from './contracts.ts';
 import {
 	resolveOutputPolicy,
@@ -186,23 +187,10 @@ class OutputChannel implements Out {
 		this.jsonMode = options.jsonMode;
 		this.isTTY = options.isTTY;
 
-		// Bind the public method surface to the instance so methods keep
-		// working when destructured off `out` (e.g. `const { log } = out`).
-		// Detached, an unbound method loses `this` and crashes on
-		// `this.options`/`this.policy`. Binding here resolves subclass
-		// overrides (spinner/progress in CaptureOutputChannel) automatically.
-		this.log = this.log.bind(this);
-		this.info = this.info.bind(this);
-		this.warn = this.warn.bind(this);
-		this.error = this.error.bind(this);
-		this.setExitCode = this.setExitCode.bind(this);
-		this.json = this.json.bind(this);
-		// `.bind()` collapses `table`'s overloads to the last signature; cast
-		// back to the declared overloaded type.
-		this.table = this.table.bind(this) as Out['table'];
-		this.spinner = this.spinner.bind(this);
-		this.progress = this.progress.bind(this);
-		this.stopActive = this.stopActive.bind(this);
+		// Bind methods to the instance so they keep working when destructured
+		// off `out` (e.g. `const { log } = out`). Resolves subclass overrides
+		// (spinner/progress in CaptureOutputChannel) automatically.
+		bindMethods(this);
 	}
 
 	/**

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -185,6 +185,24 @@ class OutputChannel implements Out {
 		this.policy = resolveOutputPolicy(options);
 		this.jsonMode = options.jsonMode;
 		this.isTTY = options.isTTY;
+
+		// Bind the public method surface to the instance so methods keep
+		// working when destructured off `out` (e.g. `const { log } = out`).
+		// Detached, an unbound method loses `this` and crashes on
+		// `this.options`/`this.policy`. Binding here resolves subclass
+		// overrides (spinner/progress in CaptureOutputChannel) automatically.
+		this.log = this.log.bind(this);
+		this.info = this.info.bind(this);
+		this.warn = this.warn.bind(this);
+		this.error = this.error.bind(this);
+		this.setExitCode = this.setExitCode.bind(this);
+		this.json = this.json.bind(this);
+		// `.bind()` collapses `table`'s overloads to the last signature; cast
+		// back to the declared overloaded type.
+		this.table = this.table.bind(this) as Out['table'];
+		this.spinner = this.spinner.bind(this);
+		this.progress = this.progress.bind(this);
+		this.stopActive = this.stopActive.bind(this);
 	}
 
 	/**

--- a/src/core/output/output-progress.test.ts
+++ b/src/core/output/output-progress.test.ts
@@ -464,12 +464,18 @@ describe('progress handle methods survive destructuring', () => {
 
 	it('TTYProgressHandle — destructured done clears the timer', () => {
 		const { write } = makeWriter();
-		// Indeterminate mode (no total) starts an animation timer.
-		const handle = new TTYProgressHandle({ label: 'work' }, write);
-		const { done } = handle;
+		// Indeterminate mode (no total) starts a real animation timer; fake
+		// timers keep it from leaking into the runner if cleanup misbehaves.
+		vi.useFakeTimers();
+		try {
+			const handle = new TTYProgressHandle({ label: 'work' }, write);
+			const { done } = handle;
 
-		// Detached call must still run cleanup (clearInterval) without `this`.
-		expect(() => done()).not.toThrow();
+			// Detached call must still run cleanup (clearInterval) without `this`.
+			expect(() => done()).not.toThrow();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it('CaptureProgressHandle — destructured methods record events', () => {

--- a/src/core/output/output-progress.test.ts
+++ b/src/core/output/output-progress.test.ts
@@ -448,3 +448,42 @@ describe('CaptureProgressHandle — testkit event recording', () => {
 		]);
 	});
 });
+
+// === Destructuring — methods stay bound to the instance
+
+describe('progress handle methods survive destructuring', () => {
+	it('StaticProgressHandle — destructured methods keep working', () => {
+		const { write, output } = makeWriter();
+		const handle = new StaticProgressHandle('Building', write);
+		const { done } = handle;
+
+		// Detached call would crash on `this.stopped`/`this.write` if unbound.
+		expect(() => done('complete')).not.toThrow();
+		expect(output).toEqual(['Building\n', 'complete\n']);
+	});
+
+	it('TTYProgressHandle — destructured done clears the timer', () => {
+		const { write } = makeWriter();
+		// Indeterminate mode (no total) starts an animation timer.
+		const handle = new TTYProgressHandle({ label: 'work' }, write);
+		const { done } = handle;
+
+		// Detached call must still run cleanup (clearInterval) without `this`.
+		expect(() => done()).not.toThrow();
+	});
+
+	it('CaptureProgressHandle — destructured methods record events', () => {
+		const events: ActivityEvent[] = [];
+		const handle = new CaptureProgressHandle({ total: 10 }, events);
+		const { increment, done } = handle;
+
+		increment(3);
+		done('finished');
+
+		expect(events).toEqual([
+			{ type: 'progress:start', label: '', total: 10 },
+			{ type: 'progress:increment', delta: 3 },
+			{ type: 'progress:done', text: 'finished' },
+		]);
+	});
+});

--- a/src/core/output/output-spinner.test.ts
+++ b/src/core/output/output-spinner.test.ts
@@ -532,11 +532,18 @@ describe('spinner handle methods survive destructuring', () => {
 
 	it('TTYSpinnerHandle — destructured stop clears the timer', () => {
 		const { write } = makeWriter();
-		const handle = new TTYSpinnerHandle('work', write);
-		const { stop } = handle;
+		// The constructor starts a real animation timer; fake timers keep it
+		// from leaking into the runner if cleanup misbehaves.
+		vi.useFakeTimers();
+		try {
+			const handle = new TTYSpinnerHandle('work', write);
+			const { stop } = handle;
 
-		// Detached call must still run cleanup (clearInterval) without `this`.
-		expect(() => stop()).not.toThrow();
+			// Detached call must still run cleanup (clearInterval) without `this`.
+			expect(() => stop()).not.toThrow();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it('CaptureSpinnerHandle — destructured methods record events', () => {

--- a/src/core/output/output-spinner.test.ts
+++ b/src/core/output/output-spinner.test.ts
@@ -516,3 +516,41 @@ describe('CaptureSpinnerHandle — testkit event recording', () => {
 		expect(events[1]).toEqual({ type: 'spinner:fail', text: '' });
 	});
 });
+
+// === Destructuring — methods stay bound to the instance
+
+describe('spinner handle methods survive destructuring', () => {
+	it('StaticSpinnerHandle — destructured methods keep working', () => {
+		const { write, output } = makeWriter();
+		const handle = new StaticSpinnerHandle('work', write);
+		const { succeed } = handle;
+
+		// Detached call would crash on `this.stopped`/`this.write` if unbound.
+		expect(() => succeed('done')).not.toThrow();
+		expect(output).toEqual(['work\n', 'done\n']);
+	});
+
+	it('TTYSpinnerHandle — destructured stop clears the timer', () => {
+		const { write } = makeWriter();
+		const handle = new TTYSpinnerHandle('work', write);
+		const { stop } = handle;
+
+		// Detached call must still run cleanup (clearInterval) without `this`.
+		expect(() => stop()).not.toThrow();
+	});
+
+	it('CaptureSpinnerHandle — destructured methods record events', () => {
+		const events: ActivityEvent[] = [];
+		const handle = new CaptureSpinnerHandle('work', events);
+		const { update, succeed } = handle;
+
+		update('still');
+		succeed('ok');
+
+		expect(events).toEqual([
+			{ type: 'spinner:start', text: 'work' },
+			{ type: 'spinner:update', text: 'still' },
+			{ type: 'spinner:succeed', text: 'ok' },
+		]);
+	});
+});

--- a/src/core/output/output.test.ts
+++ b/src/core/output/output.test.ts
@@ -71,6 +71,41 @@ describe('createOutput', () => {
 	});
 });
 
+// --- Destructuring — methods stay bound to the instance
+
+describe('destructured methods', () => {
+	it('text methods work when destructured off the instance', () => {
+		const [out, captured] = createCaptureOutput();
+		const { log, info, warn, error } = out;
+
+		log('hi');
+		info('details');
+		warn('careful');
+		error('boom');
+
+		expect(captured.stdout).toEqual(['hi\n', 'details\n']);
+		expect(captured.stderr).toEqual(['careful\n', 'boom\n']);
+	});
+
+	it('json works when destructured off the instance', () => {
+		const [out, captured] = createCaptureOutput();
+		const { json } = out;
+
+		json({ ok: true });
+
+		expect(captured.stdout).toEqual(['{"ok":true}\n']);
+	});
+
+	it('setExitCode works when destructured off the instance', () => {
+		const out = createOutput();
+		const { setExitCode } = out;
+
+		setExitCode(5);
+
+		expect(getRequestedExitCode(out)).toBe(5);
+	});
+});
+
 // --- Exit code requests
 
 describe('exit code requests', () => {


### PR DESCRIPTION
## Problem

The `Out` channel and every spinner/progress handle expose methods that read instance state via `this`. Consumers naturally detach those methods — by destructuring (`const { json, log } = out`, `const { succeed, fail } = spinner`) or by passing them as callbacks (`promise.finally(spinner.stop)`). Detached, an unbound prototype method loses its `this` and crashes on the first field access (e.g. `this.options is undefined`).

This was the reported failure for `out`, and the identical footgun existed on all six concrete handle classes.

## Fix

Add a shared `bindMethods(this)` helper (`src/core/output/bind.ts`) called as the last statement in the constructors of `OutputChannel` and all six handle classes (`Static`/`TTY`/`Capture` × spinner/progress). The helper:

- walks the prototype chain, binding each method once — **most-derived wins**, so subclass overrides (`CaptureOutputChannel.spinner`/`progress`) are preserved;
- installs **non-enumerable** bound own-properties, mirroring prototype-method semantics;
- skips getters and non-function members.

Because it reads the live prototype instead of a hand-maintained name list, methods added later are bound automatically — the binding can't silently fall out of date. This also replaces `OutputChannel`'s explicit per-method binds and the `table` overload cast, so the whole module uses one mechanism.

## Scope / what was ruled out

A full audit of every class and returned object in the codebase:

- **Noop handle singletons** — plain object literals using no `this`; safe, unchanged.
- **Builders** (`FlagBuilder`, `ArgBuilder`, `CommandBuilder`, `CLIBuilder`, `SchemaParser`) — immutable and fluent-inline only; no realistic detach path; unchanged.
- **Error classes** (`CLIError`/`ParseError`/`ValidationError`) — `toJSON()` is invoked by `JSON.stringify` with correct `this`; unchanged.
- No internal code passes methods as detached callbacks.

## Tests

- New destructuring regression tests for the `Out` channel and each concrete handle class (Static/TTY/Capture × spinner/progress).
- Convention documented in `src/core/output/AGENTS.md` to prevent reintroduction.

## Verification

- `2392` tests pass (75 files; +6 new)
- `typecheck` (tsgo), `lint` (biome), `format:check` (dprint) all clean
