### PR TITLE
Add transport-launcher example and document flag naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,13 +531,16 @@ expect(activity.activity).toContainEqual(
 
 ## Package structure
 
-Three subpath exports, each with a focused API surface:
+The code lives behind three focused subpath exports:
 
 | Import                     | Purpose                                                                                |
 | -------------------------- | -------------------------------------------------------------------------------------- |
 | `@kjanat/dreamcli`         | Schema builders, CLI runner, output, parsing, resolution, errors                       |
 | `@kjanat/dreamcli/testkit` | `runCommand()`, `createCaptureOutput()`, `createTestPrompter()`, `createTestAdapter()` |
 | `@kjanat/dreamcli/runtime` | `createAdapter()`, `RuntimeAdapter`, runtime detection, platform adapters              |
+
+A fourth export, `@kjanat/dreamcli/schema`, ships the bundled JSON Schema (`dreamcli.schema.json`)
+for editor and config validation.
 
 ESM-only. Source included in package (`src/`).
 

--- a/docs/.vitepress/data/examples.test.ts
+++ b/docs/.vitepress/data/examples.test.ts
@@ -25,6 +25,7 @@ describe('example docs generation', () => {
 			'multi-command',
 			'spinner-progress',
 			'testing',
+			'transport-launcher',
 		]);
 
 		const basic = examples.find((example) => example.slug === 'basic');

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -102,6 +102,57 @@ an empty array `[]`.
 For the exact parser rules around repeated flags, short-flag stacking, `--`
 separator handling, and `--no-*` spellings, see [CLI Semantics](/guide/semantics).
 
+## Flag Names
+
+The string you pass to `.flag(name, …)` is the flag's **canonical name**, and it is used in two
+places at once:
+
+- on the command line as `--name`;
+- as the key on the `flags` object inside your handler.
+
+No case conversion happens — the name you declare is the name you read. Single-word names are
+valid identifiers, so dot access works (`flags.region`). Hyphenated names are not valid
+identifiers, so read them with bracket access (`flags['node-ipc']`).
+
+```ts twoslash
+import { command, flag } from '@kjanat/dreamcli';
+
+command('serve')
+  .flag(
+    'node-ipc',
+    flag.boolean().describe('Use the Node IPC transport'),
+  )
+  .flag('dry-run', flag.boolean())
+  .action(({ flags, out }) => {
+    // Hyphenated names are read with bracket access — there is no `flags.nodeIpc`.
+    if (flags['node-ipc']) out.log('ipc');
+    if (flags['dry-run']) out.log('dry run');
+  });
+```
+
+Reach for a hyphenated name when you want the conventional CLI spelling (`--node-ipc`,
+`--dry-run`); reach for a single-word or camelCase name (`--nodeIpc`) when ergonomic dot access
+matters more.
+
+### Aliases Are CLI Tokens, Not Handler Keys
+
+`.alias()` adds an alternate **spelling on the command line**. It resolves back to the canonical
+name — it never becomes a second property on `flags`.
+
+```ts twoslash
+import { command, flag } from '@kjanat/dreamcli';
+
+command('serve')
+  // Accepts both `--skip-pass` and `--skipPass` on the CLI…
+  .flag('skip-pass', flag.boolean().alias('skipPass'))
+  .action(({ flags, out }) => {
+    // …but the handler has exactly one key: the canonical name.
+    if (flags['skip-pass']) out.log('skipping');
+  });
+```
+
+So typing `--skipPass` still arrives as `flags['skip-pass']`.
+
 ## Modifiers
 
 Every flag type supports the same modifier chain:

--- a/docs/guide/limitations.md
+++ b/docs/guide/limitations.md
@@ -90,6 +90,53 @@ Workarounds:
 
 References: [CLI Semantics](/guide/semantics), [Flags](/guide/flags)
 
+## "Exactly One Of" Is Not Built In
+
+DreamCLI has no declarative mutual-exclusion modifier.
+There is no `.exclusive()`, no `.conflicts()`, and no required-one-of group — flags are resolved independently of one another.
+
+Why:
+
+- the schema models each flag as a standalone, independently resolved value;
+- cross-flag rules are open-ended (exactly-one, at-most-one, all-or-none, implies), and a single declarative knob would cover only a slice of them.
+
+Workaround — enforce the rule in `.derive()`, which runs after resolution and before the action, and throw a `CLIError`:
+
+```ts twoslash
+import { CLIError, command, flag } from '@kjanat/dreamcli';
+
+command('lsp-server')
+  .flag('stdio', flag.boolean())
+  .flag('node-ipc', flag.boolean())
+  .flag('socket', flag.number())
+  .derive(({ flags }) => {
+    const count =
+      Number(flags.stdio) +
+      Number(flags['node-ipc']) +
+      Number(flags.socket !== undefined);
+    if (count === 0) {
+      throw new CLIError('No transport selected.', {
+        code: 'NO_TRANSPORT',
+        suggest:
+          'Pass exactly one of --stdio, --node-ipc, or --socket <port>',
+      });
+    }
+    if (count > 1) {
+      throw new CLIError(
+        'Choose exactly one transport flag.',
+        { code: 'TOO_MANY_TRANSPORTS' },
+      );
+    }
+    return {};
+  })
+  .action(({ out }) => out.log('starting'));
+```
+
+The thrown `CLIError` renders a friendly message on stderr and exits with code `1`.
+For a complete, typed version that hands the chosen transport to the action, see the `transport-launcher` example.
+
+References: [Flags](/guide/flags), [Errors](/guide/errors), [CLI Semantics](/guide/semantics)
+
 ## The Framework Is Overkill For Tiny One-Off Scripts
 
 dreamcli is optimized for typed multi-source resolution, middleware, structured output, completions, and in-process testing.

--- a/examples/transport-launcher.ts
+++ b/examples/transport-launcher.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env bun
+/**
+ * Single-transport launcher (language-server style).
+ *
+ * A launcher that must be started over exactly one transport. dreamcli has no
+ * native "mutually exclusive" / "exactly one of" modifier, so the rule is
+ * expressed in `.derive()` — the resolution-time hook that runs after flags
+ * resolve and before the action. The derived, fully typed `Transport` is then
+ * handed to `.action()` through `ctx`.
+ *
+ * Demonstrates: an "exactly one of" rule via `.derive()` throwing `CLIError`, a
+ * kebab-case flag name accessed with bracket notation (`flags['node-ipc']`), and
+ * passing a typed result to the action through derived context.
+ *
+ * Usage:
+ *   npx tsx examples/transport-launcher.ts --stdio
+ *   npx tsx examples/transport-launcher.ts --node-ipc
+ *   npx tsx examples/transport-launcher.ts --socket 6009
+ *   npx tsx examples/transport-launcher.ts            # error: pick exactly one
+ *   npx tsx examples/transport-launcher.ts --stdio --node-ipc  # error: only one
+ *   npx tsx examples/transport-launcher.ts --help
+ */
+
+import { CLIError, cli, command, flag } from '@kjanat/dreamcli';
+
+// One resolved transport — illegal states are unrepresentable.
+type Transport =
+	| { readonly kind: 'stdio' }
+	| { readonly kind: 'node-ipc' }
+	| { readonly kind: 'socket'; readonly port: number };
+
+const launcher = command('lsp-server')
+	.description('Launch the language server over exactly one transport')
+	.flag('stdio', flag.boolean().describe('Use the stdio transport'))
+	.flag('node-ipc', flag.boolean().describe('Use the Node IPC transport'))
+	.flag('socket', flag.number().describe('Use a TCP socket on <port>'))
+	// `.derive()` runs after resolution and before the action — the idiomatic
+	// place for a constraint dreamcli does not express declaratively.
+	.derive(({ flags }): { transport: Transport } => {
+		const selected: Transport[] = [];
+		if (flags.stdio) selected.push({ kind: 'stdio' });
+		// Kebab-case flag names stay kebab in the handler: bracket access, no camelCasing.
+		if (flags['node-ipc']) selected.push({ kind: 'node-ipc' });
+		if (flags.socket !== undefined) {
+			if (!Number.isInteger(flags.socket)) {
+				throw new CLIError(`--socket expects an integer port (got ${flags.socket}).`, {
+					code: 'INVALID_SOCKET_PORT',
+					suggest: 'Pass a whole number, e.g. --socket 6009',
+				});
+			}
+			selected.push({ kind: 'socket', port: flags.socket });
+		}
+
+		const [transport, ...rest] = selected;
+		if (transport === undefined) {
+			throw new CLIError('No transport selected.', {
+				code: 'NO_TRANSPORT',
+				suggest: 'Pass exactly one of --stdio, --node-ipc, or --socket <port>',
+			});
+		}
+		if (rest.length > 0) {
+			throw new CLIError('Choose exactly one transport flag.', {
+				code: 'TOO_MANY_TRANSPORTS',
+				suggest: 'Use only one of --stdio, --node-ipc, or --socket <port>',
+			});
+		}
+
+		return { transport };
+	})
+	.action(({ ctx, out }) => {
+		// ctx.transport: Transport — fully typed, ready to hand to the server.
+		switch (ctx.transport.kind) {
+			case 'stdio':
+				out.log('Starting language server over stdio');
+				break;
+			case 'node-ipc':
+				out.log('Starting language server over node-ipc');
+				break;
+			case 'socket':
+				out.log(`Starting language server over socket :${ctx.transport.port}`);
+				break;
+		}
+	});
+
+void cli('lsp-server').default(launcher).run();

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -1191,7 +1191,9 @@ class CommandBuilder<
 	 * The builder controls the flag's type, presence, aliases, env/config
 	 * bindings, and description. See {@link FlagBuilder} for available modifiers.
 	 *
-	 * @param name - Flag name (used as `--name` on CLI and `flags.*` in handler).
+	 * @param name - Flag name: the `--name` CLI token and the matching key on `flags`
+	 *   in the handler. The name is preserved as-is (no camelCasing); read non-identifier
+	 *   names such as `'dry-run'` with bracket access (`flags['dry-run']`).
 	 * @param builder - Configured {@linkcode FlagBuilder} from {@linkcode flag | flag.string()},
 	 *   `flag.boolean()`, `flag.number()`, `flag.enum()`, `flag.array()`, or `flag.custom()`.
 	 *


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and a working example for handling "exactly one of" constraints in dreamcli, along with clarification on flag naming conventions.

## Key Changes

- **New example**: `examples/transport-launcher.ts` — a complete, runnable example demonstrating:
  - How to enforce "exactly one of" mutual exclusion using `.derive()` and `CLIError`
  - Proper handling of kebab-case flag names with bracket access (`flags['node-ipc']`)
  - Passing typed, derived context to the action handler
  - Comprehensive error messages with error codes and suggestions

- **Documentation updates**:
  - Added "Flag Names" section to `docs/guide/flags.md` explaining:
    - How canonical flag names map to CLI tokens and handler keys
    - No case conversion occurs (names are preserved as-is)
    - Bracket access for non-identifier names like `'dry-run'`
    - How aliases work (CLI tokens only, not handler keys)
  - Added ""Exactly One Of" Is Not Built In" section to `docs/guide/limitations.md` with:
    - Explanation of why mutual exclusion isn't declarative
    - Workaround pattern using `.derive()` and `CLIError`
    - Reference to the new transport-launcher example for a complete typed version

- **Minor improvements**:
  - Updated README.md package structure section to mention the `@kjanat/dreamcli/schema` export
  - Enhanced JSDoc for `CommandBuilder.flag()` to clarify naming behavior
  - Added transport-launcher to the examples test suite

## Implementation Details

The transport-launcher example uses `.derive()` as the idiomatic place to enforce cross-flag constraints that dreamcli doesn't express declaratively. The derived context returns a discriminated union `Transport` type that makes illegal states unrepresentable, demonstrating type-safe constraint handling.