### PR TITLE
fix(examples): clamp starter greet repeat count

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ const greet = command('greet')
     flag.number().default(1).describe('Repeat count'),
   )
   .action(({ args, flags, out }) => {
-    for (let i = 0; i < flags.times; i++) {
+    const repeatCount = Number.isFinite(flags.times)
+      ? Math.max(0, Math.min(100, Math.floor(flags.times)))
+      : 1;
+
+    for (let i = 0; i < repeatCount; i++) {
       const msg = `Hello, ${args.name}!`;
       out.log(flags.loud ? msg.toUpperCase() : msg);
     }

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -43,7 +43,11 @@ const greet = command('greet')
     flag.number().default(1).describe('Repeat count'),
   )
   .action(({ args, flags, out }) => {
-    for (let i = 0; i < flags.times; i++) {
+    const repeatCount = Number.isFinite(flags.times)
+      ? Math.max(0, Math.min(100, Math.floor(flags.times)))
+      : 1;
+
+    for (let i = 0; i < repeatCount; i++) {
       const msg = `Hello, ${args.name}!`;
       out.log(flags.loud ? msg.toUpperCase() : msg);
     }

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -24,7 +24,11 @@ const greet = command('greet')
 		// args.name: string — required positional
 		// flags.loud: boolean — defaults to false (all booleans do)
 		// flags.times: number — defaults to 1 (never undefined)
-		for (let i = 0; i < flags.times; i++) {
+		const repeatCount = Number.isFinite(flags.times)
+			? Math.max(0, Math.min(100, Math.floor(flags.times)))
+			: 1;
+
+		for (let i = 0; i < repeatCount; i++) {
 			const msg = `Hello, ${args.name}!`;
 			out.log(flags.loud ? msg.toUpperCase() : msg);
 		}

--- a/skills/cli-creation/assets/templates/single-command.ts.tpl
+++ b/skills/cli-creation/assets/templates/single-command.ts.tpl
@@ -30,7 +30,11 @@ export const hello = command('hello')
 	.flag('times', flag.number().default(1).alias('n').describe('Repeat count'))
 	.middleware(sparkle)
 	.action(({ args, flags, ctx, out }) => {
-		for (let i = 0; i < flags.times; i++) {
+		const repeatCount = Number.isFinite(flags.times)
+			? Math.max(0, Math.min(100, Math.floor(flags.times)))
+			: 1;
+
+		for (let i = 0; i < repeatCount; i++) {
 			const base = `Hello, ${args.name}!`;
 			out.log(ctx.sparkle(base));
 		}


### PR DESCRIPTION
## What

Starter `greet` examples loop directly on the unvalidated `--times` flag. Huge or non-finite input (e.g. `Infinity`, `NaN`, or values like `1e9`) makes the generated and documented hello-world CLIs misbehave — spinning forever on `Infinity` or producing absurd output counts.

This clamps the repeat count to a sane range before the loop. A `repeatCount` is computed as:

```ts
Number.isFinite(flags.times)
  ? Math.max(0, Math.min(100, Math.floor(flags.times)))
  : 1
```

so non-finite input falls back to `1` and finite input is floored into `0..100`.

## Files

- `examples/basic.ts`
- `README.md` (greet code block)
- `docs/guide/getting-started.md` (greet code block)
- `skills/cli-creation/assets/templates/single-command.ts.tpl`

## Provenance

Salvaged from the `workspace` branch (`6deb385`) per the PR #10 salvage audit. Only the repeat-count clamp was re-applied to the flat `master` layout; unrelated parts of the source commit (test rename, `scaffold_cli.py` edit) were intentionally left out.

## Gates

- `bun run typecheck` — pass
- `bun run format:check` — pass