### PR TITLE
chore(docs): add analytics beacon and robots.txt

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -108,6 +108,14 @@ export default defineConfig({
 			},
 		],
 		['meta', { name: 'theme-color', content: '#f8f3e7' }],
+		[
+			'script',
+			{
+				defer: '',
+				src: 'https://static.cloudflareinsights.com/beacon.min.js',
+				'data-cf-beacon': '{"token": "ee9b04d68d3740bebb38f5c20629b7c1"}',
+			},
+		],
 	],
 	themeConfig: {
 		logo: {

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
The deployed docs site had zero analytics and no crawler hint.

- Add the Cloudflare Web Analytics `beacon.min.js` script entry to the VitePress `head` array (right after the `theme-color` meta).
- Add `docs/public/robots.txt` with `User-agent: *` / `Allow: /`.

Salvaged from the `workspace` branch (c517f92, 34b405d) per the PR #10 salvage audit. Re-applied to the flat `master` layout (`apps/docs/*` -> `docs/*`).

Gate: `bun run format:check` passes.