### PR TITLE
fix(jsr): wrap `./schema` export in typed TS module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: actions/setup-node@v6
         with: { node-version: "${{ matrix.node-version }}" }
-      - run: runner install --frozen
+      - run: runner install --frozen schema:emit
       - name: Test in parallel (Bun) (Node ${{ matrix.node-version }})
         run: run -pk test:bun test:gh test:node
 
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - run: runner install --frozen coverage
+      - run: runner install --frozen schema:emit coverage
 
   test-deno:
     runs-on: ubuntu-latest
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - run: runner install --frozen docs:build
+      - run: runner install --frozen schema:emit docs:build
       - run: git diff --exit-code && test -z "$(git status --porcelain --untracked-files=all)"
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - run: runner install --frozen version:check
+      - run: runner install --frozen schema:emit version:check
       - run: run -pk typecheck typecheck:tsc meta-descriptions:check lint format:check typecheck:gh
 
   test:

--- a/deno.json
+++ b/deno.json
@@ -40,7 +40,7 @@
 		".": "./src/index.ts",
 		"./runtime": "./src/runtime.ts",
 		"./testkit": "./src/testkit.ts",
-		"./schema": "./dreamcli.schema.json"
+		"./schema": "./src/schema.ts"
 	},
 	"compilerOptions": {
 		"strict": true,
@@ -49,7 +49,7 @@
 			"@kjanat/dreamcli": ["./src/index.ts"],
 			"@kjanat/dreamcli/runtime": ["./src/runtime.ts"],
 			"@kjanat/dreamcli/testkit": ["./src/testkit.ts"],
-			"@kjanat/dreamcli/schema": ["./dreamcli.schema.json"],
+			"@kjanat/dreamcli/schema": ["./src/schema.ts"],
 			"@kjanat/dreamcli/package.json": ["./package.json"]
 		}
 	},

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { normalize } from 'node:path';
 import { env } from 'node:process';
 import { transformerTwoslash } from '@shikijs/vitepress-twoslash';
@@ -17,6 +18,18 @@ import { dreamcliDocsPlugin, shikiClasses } from './vite-plugins/index.ts';
 import { fixTsProcessedLinkcode, transformerJSDocTags } from './vite-plugins/shiki-jsdoc-tags.ts';
 
 const projectRoot = normalize(`${import.meta.dirname}/../..`);
+
+// `src/schema.ts` statically imports `../dreamcli.schema.json`, a gitignored
+// build artifact. TypeDoc (run by `*.paths.ts` dynamic-route loaders and
+// `*.data.ts` data loaders) typechecks that import, so the schema must exist
+// before route/data resolution. VitePress bundles those loaders in a transient
+// esbuild step that bypasses this Vite config's plugins, so the source-artifacts
+// plugin's `buildStart` hook fires too late. Emitting here at config
+// module-evaluation time — the first thing VitePress runs — guarantees the
+// artifact exists before any loader is bundled or executed. Run via subprocess
+// so the script resolves `@kjanat/dreamcli` in its own Bun context; importing it
+// here breaks VitePress's esbuild config loader (cannot resolve the self-import).
+execFileSync('bun', ['scripts/emit-definition-schema.ts'], { cwd: projectRoot });
 const exampleMeta = await collectExampleMeta(examplesRoot);
 const apiIndex = await collectPublicApiIndex(packageJsonPath);
 const symbolRoutes = new Map<string, string>();

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -36,7 +36,7 @@ and `examples/**` during docs build.
 | `@kjanat/dreamcli`         | schema builders, CLI assembly, parsing, resolution, errors, completions, schema export | [`@kjanat/dreamcli`](/reference/main)            |
 | `@kjanat/dreamcli/testkit` | command tests, output capture, scripted prompts, test adapters                         | [`@kjanat/dreamcli/testkit`](/reference/testkit) |
 | `@kjanat/dreamcli/runtime` | runtime detection, explicit adapters, runtime-only helpers                             | [`@kjanat/dreamcli/runtime`](/reference/runtime) |
-| `@kjanat/dreamcli/schema`  | generated CLI definition meta-schema JSON                                              | schema asset only                                |
+| `@kjanat/dreamcli/schema`  | generated CLI definition meta-schema (export mapping differs by package target)        | [`@kjanat/dreamcli/schema`](/reference/schema)   |
 
 ## Generated Index
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -1,11 +1,12 @@
 # Schema
 
-`@kjanat/dreamcli/schema` is the package's published JSON Schema export.
-It resolves to `dreamcli.schema.json`, the same definition schema referenced by
-`generateSchema()` output.
+`@kjanat/dreamcli/schema` is the package's published definition-schema export.\
+It resolves to the same schema referenced by `generateSchema()` output, with a package-target specific mapping:
 
-Use it when you want local or offline validation of dreamcli definition metadata without depending
-on the CDN `$schema` URL.
+- npm/package export (`package.json`): `./schema` -> `dreamcli.schema.json`
+- Deno/JSR export (`deno.json`): `./schema` -> `src/schema.ts` (which re-exports the same schema)
+
+Use it when you want local or offline validation of dreamcli definition metadata without depending on the CDN `$schema` URL.
 
 ## Importing The Schema
 
@@ -16,8 +17,9 @@ schema.$schema;
 schema.$defs.command;
 ```
 
-In TypeScript, this works with `resolveJsonModule`.
-At runtime, your loader needs to support JSON imports for the target environment.
+In TypeScript, this works with `resolveJsonModule`.\
+Runtime loading behavior depends on the host runtime export target (see notes above).
+For Node on the npm/package target, import with `with { type: 'json' }`.
 
 ## Common Uses
 
@@ -42,8 +44,7 @@ definition.$schema;
 schema.$id;
 ```
 
-`definition.$schema` points at the public schema URL, while the package export gives you the same
-definition locally from the installed package.
+`definition.$schema` points at the public schema URL, while the package export gives you the same definition locally from the installed package.
 
 ## Related Pages
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,16 @@
+/**
+ * JSON Schema for DreamCLI definition files.
+ *
+ * Re-exports the generated `dreamcli.schema.json` meta-schema so tooling,
+ * editors, and validation libraries can import it as a typed module.
+ *
+ * @example
+ * ```ts
+ * import schema from '@kjanat/dreamcli/schema';
+ *
+ * console.log(schema.$id); // "dreamcli.schema.json"
+ * ```
+ *
+ * @module @kjanat/dreamcli/schema
+ */
+export { default } from '../dreamcli.schema.json' with { type: 'json' };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
 			"@kjanat/dreamcli": ["./src/index.ts"],
 			"@kjanat/dreamcli/runtime": ["./src/runtime.ts"],
 			"@kjanat/dreamcli/testkit": ["./src/testkit.ts"],
-			"@kjanat/dreamcli/schema": ["./dreamcli.schema.json"],
+			"@kjanat/dreamcli/schema": ["./src/schema.ts"],
 			"@kjanat/dreamcli/package.json": ["./package.json"]
 		}
 	},


### PR DESCRIPTION
## Why

JSR scores every package entrypoint on whether it carries an `@module` doc comment. JSON files can't have doc comments, so the `./schema` export — which resolved straight to `dreamcli.schema.json` — silently dinged the JSR score with no way to fix it in place.

## What

- Add `src/schema.ts`: a thin typed wrapper that `export { default } from '../dreamcli.schema.json' with { type: 'json' }` and carries an `@module` JSDoc block. This is the Deno/JSR entrypoint, so it now satisfies the `@module`-on-entrypoint requirement.
- Repoint the Deno/JSR `./schema` export and the `@kjanat/dreamcli/schema` path aliases in `deno.json` and `tsconfig.json` to `./src/schema.ts`.
- **npm target unchanged**: `package.json` `exports["./schema"]` still points at `./dreamcli.schema.json` (raw JSON), so Node consumers keep importing the asset directly.
- CI lint job runs `schema:emit` before typecheck. `src/schema.ts` now typechecks an import of the build-emitted, gitignored `dreamcli.schema.json`; the lint job previously never resolved that artifact. This mirrors the existing `publish-npm.yml` step.
- Docs (`reference/schema.md`, `reference/api.md`) document the npm-vs-JSR `./schema` split.

The wrapper serves Deno/JSR; npm keeps raw JSON. Net: JSR gets a documented TS entrypoint, npm consumers are unaffected.

## Provenance

Salvaged from the `workspace` branch (`2fce8c4` code + `c1d52ee` docs) and re-applied to the flat master layout per the PR #10 salvage audit. Only the `./schema` split is included from `c1d52ee` — the non-breaking-space sweep and nav/Links changes were intentionally left out.

## Gates

- `bun run typecheck` — pass
- `bun run format:check` — pass