### PR TITLE
feat(schema): numeric constraints for number flags and args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   parse path and the env/config/prompt resolution path (order: finite → int →
   min → max): parse-time (CLI) violations throw `INVALID_VALUE`, while
   env/config/prompt coercion reports `CONSTRAINT_VIOLATED` (both exit code `2`).
-  They are
-  also surfaced in the exported JSON Schema as `minimum` / `maximum` and
-  `type: "integer"` when `int` is set. The resolved TypeScript value type stays
-  `number`.
+  They are also surfaced in the exported JSON Schema as `minimum` / `maximum` and
+  `type: "integer"` when `int` is set. `min` / `max` must be finite — a
+  non-finite bound (`Infinity` / `-Infinity` / `NaN`) throws at construction. The
+  resolved TypeScript value type stays `number`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Numeric constraints for number flags and args** — `flag.number()` and
+  `arg.number()` now accept `{ min?, max?, int?, finite? }` (bounds inclusive),
+  and the same constraints compose via chained `.int()` / `.min(n)` / `.max(n)` /
+  `.finite(allow?)` methods (a later call overrides an earlier value, including
+  one set in the options object). The chained methods are compile-time guarded
+  to number-kind builders only. Constraints are enforced identically across the
+  parse path and the env/config/prompt resolution path (order: finite → int →
+  min → max), throwing `INVALID_VALUE` (exit code `2`) on violation. They are
+  also surfaced in the exported JSON Schema as `minimum` / `maximum` and
+  `type: "integer"` when `int` is set. The resolved TypeScript value type stays
+  `number`.
+
+### Changed
+
+- **`finite` defaults to `true` (behavior change)** — `flag.number()` /
+  `arg.number()` now **reject `Infinity` and `-Infinity`**, which previously
+  passed straight through to handlers (`Number("Infinity")` is not `NaN`). Pass
+  `{ finite: false }` (or `.finite(false)`) to opt back into accepting non-finite
+  values. `NaN` continues to be rejected as before.
+
 ## [2.5.0] - 2026-06-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   one set in the options object). The chained methods are compile-time guarded
   to number-kind builders only. Constraints are enforced identically across the
   parse path and the env/config/prompt resolution path (order: finite → int →
-  min → max), throwing `INVALID_VALUE` (exit code `2`) on violation. They are
+  min → max): parse-time (CLI) violations throw `INVALID_VALUE`, while
+  env/config/prompt coercion reports `CONSTRAINT_VIOLATED` (both exit code `2`).
+  They are
   also surfaced in the exported JSON Schema as `minimum` / `maximum` and
   `type: "integer"` when `int` is set. The resolved TypeScript value type stays
   `number`.

--- a/docs/guide/arguments.md
+++ b/docs/guide/arguments.md
@@ -32,6 +32,17 @@ argTypes.number;
 //         ^?
 ```
 
+`arg.number()` takes the same numeric constraints as `flag.number()` — an
+options object or chained `.int()` / `.min()` / `.max()` / `.finite()` methods,
+which compose. `finite` defaults to `true`, so `Infinity` / `-Infinity` (and
+`NaN`) are rejected with error code `INVALID_VALUE` (exit `2`). See
+[Numeric constraints](/guide/flags#numeric-constraints) for the full table.
+
+```ts
+arg.number({ min: 0, max: 100, int: true });
+arg.number().int().min(0).max(100); // equivalent
+```
+
 ### Custom
 
 ```ts twoslash

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -65,8 +65,9 @@ non-finite values.
 :::
 
 Constraints are checked in order **finite → int → min → max**, and apply to
-every source (CLI, env, config). The first failure throws with error code
-`INVALID_VALUE` (exit code `2`):
+every source — CLI, env, config, and prompt. On the first failure, CLI parsing
+throws `INVALID_VALUE` while env/config/prompt resolution reports
+`CONSTRAINT_VIOLATED` (both exit code `2`):
 
 | Input (`flag.number({ int: true, min: 0, max: 100 })`) | Result                               |
 | ------------------------------------------------------ | ------------------------------------ |

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -35,6 +35,52 @@ flagTypes.number;
 //         ^?
 ```
 
+#### Numeric constraints
+
+`flag.number()` accepts optional numeric constraints, either as an options
+object or via chained methods (they compose — a later chained call overrides an
+earlier value, including one set in the options object):
+
+```ts
+flag.number({ min: 0, max: 100, int: true });
+flag.number().int().min(0).max(100); // equivalent
+flag.number({ min: 0 }).max(100); // composes to { min: 0, max: 100 }
+```
+
+| Option   | Meaning                         | Default |
+| -------- | ------------------------------- | ------- |
+| `min`    | Inclusive lower bound           | none    |
+| `max`    | Inclusive upper bound           | none    |
+| `int`    | Require an integer              | `false` |
+| `finite` | Reject `Infinity` / `-Infinity` | `true`  |
+
+The resolved value type stays `number` — constraints are enforced at runtime
+and surfaced in the exported JSON Schema (`minimum` / `maximum`, and
+`type: "integer"` when `int` is set), not at the type level.
+
+::: warning Finite by default
+`flag.number()` now **rejects `Infinity` and `-Infinity`** (as well as `NaN`,
+which was always rejected). Pass `finite: false` (or `.finite(false)`) to accept
+non-finite values.
+:::
+
+Constraints are checked in order **finite → int → min → max**, and apply to
+every source (CLI, env, config). The first failure throws with error code
+`INVALID_VALUE` (exit code `2`):
+
+| Input (`flag.number({ int: true, min: 0, max: 100 })`) | Result                               |
+| ------------------------------------------------------ | ------------------------------------ |
+| `42`                                                   | accepted                             |
+| `0` / `100`                                            | accepted (bounds are inclusive)      |
+| `NaN`                                                  | rejected — invalid number            |
+| `Infinity`                                             | rejected — `must be a finite number` |
+| `3.7`                                                  | rejected — `must be an integer`      |
+| `-1`                                                   | rejected — `must be >= 0`            |
+| `101`                                                  | rejected — `must be <= 100`          |
+
+The same options and methods are available on `arg.number()` for positional
+arguments.
+
 ### Boolean
 
 ```ts twoslash

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -56,7 +56,9 @@ flag.number({ min: 0 }).max(100); // composes to { min: 0, max: 100 }
 
 The resolved value type stays `number` — constraints are enforced at runtime
 and surfaced in the exported JSON Schema (`minimum` / `maximum`, and
-`type: "integer"` when `int` is set), not at the type level.
+`type: "integer"` when `int` is set), not at the type level. `min` / `max` must
+be finite; passing `Infinity` / `-Infinity` / `NaN` as a bound throws when the
+flag is declared (omit the field for "no bound").
 
 ::: warning Finite by default
 `flag.number()` now **rejects `Infinity` and `-Infinity`** (as well as `NaN`,

--- a/src/core/completion/shells/shared.ts
+++ b/src/core/completion/shells/shared.ts
@@ -154,6 +154,7 @@ function createSyntheticRootFlag(description: string): FlagSchema {
 		configPath: undefined,
 		description,
 		enumValues: undefined,
+		numberConstraints: undefined,
 		elementSchema: undefined,
 		prompt: undefined,
 		parseFn: undefined,

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -579,9 +579,17 @@ function flagToJsonSchemaType(schema: FlagSchema): Record<string, unknown> {
 		case 'string':
 			result.type = 'string';
 			break;
-		case 'number':
-			result.type = 'number';
+		case 'number': {
+			const constraints = schema.numberConstraints;
+			result.type = constraints?.int === true ? 'integer' : 'number';
+			if (constraints?.min !== undefined) {
+				result.minimum = constraints.min;
+			}
+			if (constraints?.max !== undefined) {
+				result.maximum = constraints.max;
+			}
 			break;
+		}
 		case 'boolean':
 			result.type = 'boolean';
 			break;
@@ -641,8 +649,19 @@ function argKindToType(schema: ArgSchema): Record<string, unknown> {
 	switch (schema.kind) {
 		case 'string':
 			return { type: 'string' };
-		case 'number':
-			return { type: 'number' };
+		case 'number': {
+			const constraints = schema.numberConstraints;
+			const result: Record<string, unknown> = {
+				type: constraints?.int === true ? 'integer' : 'number',
+			};
+			if (constraints?.min !== undefined) {
+				result.minimum = constraints.min;
+			}
+			if (constraints?.max !== undefined) {
+				result.maximum = constraints.max;
+			}
+			return result;
+		}
 		case 'enum': {
 			const result: Record<string, unknown> = { type: 'string' };
 			if (schema.enumValues !== undefined) {

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -98,6 +98,7 @@ function argEntry(
 			description: undefined,
 			envVar: undefined,
 			enumValues: undefined,
+			numberConstraints: undefined,
 			parseFn: undefined,
 			deprecated: undefined,
 			...overrides,
@@ -927,5 +928,56 @@ describe('generateInputSchema — input validation', () => {
 		const cmd = commandDef({ name: 'deploy' });
 		const result = generateInputSchema(cmd);
 		expect(result).not.toHaveProperty(['properties', 'command']);
+	});
+});
+
+// === Numeric constraints → JSON Schema
+
+describe('numeric constraints — JSON Schema integration', () => {
+	it('emits type: integer and minimum/maximum for constrained number flags', () => {
+		const cmd = commandDef({
+			name: 'test',
+			flags: {
+				times: flagDef({ kind: 'number', numberConstraints: { int: true, min: 0, max: 100 } }),
+			},
+		});
+		const result = generateInputSchema(cmd);
+		expect(result).toHaveProperty(['properties', 'times'], {
+			type: 'integer',
+			minimum: 0,
+			maximum: 100,
+		});
+	});
+
+	it('emits type: number (not integer) when int is not set', () => {
+		const cmd = commandDef({
+			name: 'test',
+			flags: { ratio: flagDef({ kind: 'number', numberConstraints: { min: 0 } }) },
+		});
+		const result = generateInputSchema(cmd);
+		expect(result).toHaveProperty(['properties', 'ratio', 'type'], 'number');
+		expect(result).toHaveProperty(['properties', 'ratio', 'minimum'], 0);
+		expect(result).not.toHaveProperty(['properties', 'ratio', 'maximum']);
+	});
+
+	it('omits minimum/maximum when no bounds are set (finite has no JSON-Schema field)', () => {
+		const cmd = commandDef({
+			name: 'test',
+			flags: { plain: flagDef({ kind: 'number', numberConstraints: { finite: false } }) },
+		});
+		const result = generateInputSchema(cmd);
+		expect(result).toHaveProperty(['properties', 'plain', 'type'], 'number');
+		expect(result).not.toHaveProperty(['properties', 'plain', 'minimum']);
+		expect(result).not.toHaveProperty(['properties', 'plain', 'maximum']);
+	});
+
+	it('emits constraints consistently for number args', () => {
+		const cmd = commandDef({
+			name: 'test',
+			args: [argEntry('count', { kind: 'number', numberConstraints: { int: true, min: 1 } })],
+		});
+		const result = generateInputSchema(cmd);
+		expect(result).toHaveProperty(['properties', 'count', 'type'], 'integer');
+		expect(result).toHaveProperty(['properties', 'count', 'minimum'], 1);
 	});
 });

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -21,6 +21,10 @@ import type {
 	CommandSchema,
 	FlagSchema,
 } from '#internals/core/schema/index.ts';
+import {
+	describeNumberConstraintViolation,
+	validateNumberConstraints,
+} from '#internals/core/schema/index.ts';
 
 // --- Tokenizer — schema-agnostic argv splitting
 
@@ -198,6 +202,20 @@ function coerceFlagValue(
 					details: { flag: flagName, input: displayName, value: raw, expected: 'number' },
 				});
 			}
+			const violation = validateNumberConstraints(n, schema.numberConstraints);
+			if (violation !== undefined) {
+				const reason = describeNumberConstraintViolation(violation);
+				throw new ParseError(`Invalid number value '${raw}' for flag ${displayName}: ${reason}`, {
+					code: 'INVALID_VALUE',
+					details: {
+						flag: flagName,
+						input: displayName,
+						value: raw,
+						expected: 'number',
+						constraint: violation.kind,
+					},
+				});
+			}
 			return n;
 		}
 
@@ -282,6 +300,14 @@ function coerceArgValue(argName: string, raw: string, schema: ArgSchema): unknow
 				throw new ParseError(`Invalid number value '${raw}' for argument <${argName}>`, {
 					code: 'INVALID_VALUE',
 					details: { arg: argName, value: raw, expected: 'number' },
+				});
+			}
+			const violation = validateNumberConstraints(n, schema.numberConstraints);
+			if (violation !== undefined) {
+				const reason = describeNumberConstraintViolation(violation);
+				throw new ParseError(`Invalid number value '${raw}' for argument <${argName}>: ${reason}`, {
+					code: 'INVALID_VALUE',
+					details: { arg: argName, value: raw, expected: 'number', constraint: violation.kind },
 				});
 			}
 			return n;

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -213,6 +213,7 @@ function coerceFlagValue(
 						value: raw,
 						expected: 'number',
 						constraint: violation.kind,
+						...('bound' in violation ? { bound: violation.bound } : {}),
 					},
 				});
 			}
@@ -307,7 +308,13 @@ function coerceArgValue(argName: string, raw: string, schema: ArgSchema): unknow
 				const reason = describeNumberConstraintViolation(violation);
 				throw new ParseError(`Invalid number value '${raw}' for argument <${argName}>: ${reason}`, {
 					code: 'INVALID_VALUE',
-					details: { arg: argName, value: raw, expected: 'number', constraint: violation.kind },
+					details: {
+						arg: argName,
+						value: raw,
+						expected: 'number',
+						constraint: violation.kind,
+						...('bound' in violation ? { bound: violation.bound } : {}),
+					},
 				});
 			}
 			return n;

--- a/src/core/parse/parse.test.ts
+++ b/src/core/parse/parse.test.ts
@@ -930,3 +930,101 @@ describe('includesBeforeSeparator()', () => {
 		expect(includesBeforeSeparator([], '--version')).toBe(false);
 	});
 });
+
+// === Numeric constraints (parse boundary)
+
+describe('numeric constraints — flags', () => {
+	function numberFlagSchema(constraints?: Parameters<typeof createSchema>[1]) {
+		return makeSchema({ flags: { n: createSchema('number', constraints) } });
+	}
+
+	it('rejects Infinity by default (finite defaults true)', () => {
+		const schema = numberFlagSchema();
+		expect(() => parse(schema, ['--n', 'Infinity'])).toThrow('must be a finite number');
+		try {
+			parse(schema, ['--n', 'Infinity']);
+		} catch (err) {
+			if (!(err instanceof ParseError)) throw err;
+			expect(err.code).toBe('INVALID_VALUE');
+		}
+	});
+
+	it('rejects -Infinity by default', () => {
+		expect(() => parse(numberFlagSchema(), ['--n=-Infinity'])).toThrow('must be a finite number');
+	});
+
+	it('still rejects NaN', () => {
+		expect(() => parse(numberFlagSchema(), ['--n', 'NaN'])).toThrow('Invalid number value');
+	});
+
+	it('{ finite: false } allows Infinity', () => {
+		const result = parse(numberFlagSchema({ numberConstraints: { finite: false } }), [
+			'--n',
+			'Infinity',
+		]);
+		expect(result.flags.n).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it('{ int: true } rejects 3.7 and accepts 3', () => {
+		const schema = numberFlagSchema({ numberConstraints: { int: true } });
+		expect(() => parse(schema, ['--n', '3.7'])).toThrow('must be an integer');
+		expect(parse(schema, ['--n', '3']).flags.n).toBe(3);
+	});
+
+	it('{ min: 0 } rejects -1 and accepts 0', () => {
+		const schema = numberFlagSchema({ numberConstraints: { min: 0 } });
+		// `--n=-1` inline form: a bare `-1` token would tokenize as a short flag.
+		expect(() => parse(schema, ['--n=-1'])).toThrow('must be >= 0');
+		expect(parse(schema, ['--n', '0']).flags.n).toBe(0);
+	});
+
+	it('{ max: 100 } rejects 101 and accepts 100', () => {
+		const schema = numberFlagSchema({ numberConstraints: { max: 100 } });
+		expect(() => parse(schema, ['--n', '101'])).toThrow('must be <= 100');
+		expect(parse(schema, ['--n', '100']).flags.n).toBe(100);
+	});
+
+	it('combined constraints enforce in order finite → int → min → max', () => {
+		const schema = numberFlagSchema({ numberConstraints: { int: true, min: 0, max: 10 } });
+		expect(() => parse(schema, ['--n', '5.5'])).toThrow('must be an integer');
+		expect(() => parse(schema, ['--n=-1'])).toThrow('must be >= 0');
+		expect(() => parse(schema, ['--n', '11'])).toThrow('must be <= 10');
+		expect(parse(schema, ['--n', '7']).flags.n).toBe(7);
+	});
+
+	it('valid values pass through unchanged', () => {
+		expect(parse(numberFlagSchema(), ['--n', '42.5']).flags.n).toBe(42.5);
+	});
+});
+
+describe('numeric constraints — args', () => {
+	function numberArgSchema(constraints?: Parameters<typeof createArgSchema>[1]) {
+		return makeSchema({
+			args: [{ name: 'count', schema: createArgSchema('number', constraints) }],
+		});
+	}
+
+	it('rejects Infinity by default', () => {
+		expect(() => parse(numberArgSchema(), ['Infinity'])).toThrow('must be a finite number');
+	});
+
+	it('{ int: true } rejects 3.7, accepts 3', () => {
+		const schema = numberArgSchema({ numberConstraints: { int: true } });
+		expect(() => parse(schema, ['3.7'])).toThrow('must be an integer');
+		expect(parse(schema, ['3']).args.count).toBe(3);
+	});
+
+	it('{ min: 0, max: 100 } bounds are inclusive', () => {
+		const schema = numberArgSchema({ numberConstraints: { min: 0, max: 100 } });
+		// `--` separator so `-1` is treated as a positional, not a short flag.
+		expect(() => parse(schema, ['--', '-1'])).toThrow('must be >= 0');
+		expect(() => parse(schema, ['101'])).toThrow('must be <= 100');
+		expect(parse(schema, ['0']).args.count).toBe(0);
+		expect(parse(schema, ['100']).args.count).toBe(100);
+	});
+
+	it('{ finite: false } allows Infinity', () => {
+		const schema = numberArgSchema({ numberConstraints: { finite: false } });
+		expect(parse(schema, ['Infinity']).args.count).toBe(Number.POSITIVE_INFINITY);
+	});
+});

--- a/src/core/resolve/coerce.ts
+++ b/src/core/resolve/coerce.ts
@@ -97,6 +97,7 @@ function finalizeNumber(
 					value: raw,
 					expected: 'number',
 					constraint: violation.kind,
+					...('bound' in violation ? { bound: violation.bound } : {}),
 				},
 				suggest:
 					source.kind === 'env'
@@ -419,6 +420,9 @@ function redactArgCoercionDetails(
 		...(schema.kind === 'number' || schema.kind === 'custom' ? { expected: schema.kind } : {}),
 		...(schema.kind === 'number' && typeof error.details?.constraint === 'string'
 			? { constraint: error.details.constraint }
+			: {}),
+		...(schema.kind === 'number' && typeof error.details?.bound === 'number'
+			? { bound: error.details.bound }
 			: {}),
 		...(schema.kind === 'enum' && Array.isArray(error.details?.allowed)
 			? {

--- a/src/core/resolve/coerce.ts
+++ b/src/core/resolve/coerce.ts
@@ -373,12 +373,16 @@ function redactArgCoercionMessage(
 ): string {
 	switch (schema.kind) {
 		case 'number': {
-			// Preserve the constraint reason suffix (e.g. `: must be >= 0`) while
-			// redacting the raw value. The suffix contains only schema-derived
-			// text (bounds, "integer"), never user input.
+			const base = `Invalid number value '<redacted>' ${argSourceLabel(source)} for argument <${argName}>`;
+			// Only a constraint violation carries a schema-derived reason suffix
+			// (e.g. `: must be >= 0`), which is safe to keep. Any other failure
+			// (e.g. TYPE_MISMATCH) embeds the raw value in `error.message`, so
+			// extracting a trailing suffix there could leak user input.
+			if (error.code !== 'CONSTRAINT_VIOLATED') {
+				return base;
+			}
 			const match = /: ([^:]+)$/.exec(error.message);
 			const suffix = match?.[1];
-			const base = `Invalid number value '<redacted>' ${argSourceLabel(source)} for argument <${argName}>`;
 			return suffix !== undefined ? `${base}: ${suffix}` : base;
 		}
 		case 'enum': {

--- a/src/core/resolve/coerce.ts
+++ b/src/core/resolve/coerce.ts
@@ -7,7 +7,11 @@
 
 import type { ValidationErrorCode } from '#internals/core/errors/index.ts';
 import { ValidationError } from '#internals/core/errors/index.ts';
-import type { ArgSchema, FlagSchema } from '#internals/core/schema/index.ts';
+import type { ArgSchema, FlagSchema, NumberConstraints } from '#internals/core/schema/index.ts';
+import {
+	describeNumberConstraintViolation,
+	validateNumberConstraints,
+} from '#internals/core/schema/index.ts';
 import type { ArgDiagnosticSource, FlagDiagnosticSource } from './contracts.ts';
 import type { SharedPropertySchema } from './property.ts';
 import { toSharedArgPropertySchema, toSharedFlagPropertySchema } from './property.ts';
@@ -58,6 +62,50 @@ function coercionError(
 			details: { flag: flagName, ...sourceDetails(source), value: raw, expected, ...extraDetails },
 			suggest,
 		}),
+	};
+}
+
+/**
+ * Apply numeric constraints to an already-parsed number. Shares the single
+ * {@link validateNumberConstraints} check used by the parse path, so the two
+ * boundaries cannot drift. On violation, returns a `CONSTRAINT_VIOLATED`
+ * failure; the human-readable reason is also surfaced in `details.constraint`
+ * (the violation kind) and the message suffix.
+ */
+function finalizeNumber(
+	flagName: string,
+	source: CoerceSource,
+	raw: unknown,
+	value: number,
+	constraints: NumberConstraints | undefined,
+): CoerceResult {
+	const violation = validateNumberConstraints(value, constraints);
+	if (violation === undefined) {
+		return { ok: true, value };
+	}
+
+	const reason = describeNumberConstraintViolation(violation);
+	return {
+		ok: false,
+		error: new ValidationError(
+			`Invalid number value '${String(raw)}' ${sourceLabel(source)} for flag --${flagName}: ${reason}`,
+			{
+				code: 'CONSTRAINT_VIOLATED',
+				details: {
+					flag: flagName,
+					...sourceDetails(source),
+					value: raw,
+					expected: 'number',
+					constraint: violation.kind,
+				},
+				suggest:
+					source.kind === 'env'
+						? `Set ${source.envVar} to a valid number`
+						: source.kind === 'config'
+							? `Set ${source.configPath} to a valid number in your config`
+							: `Enter a valid number for --${flagName}`,
+			},
+		),
 	};
 }
 
@@ -200,11 +248,13 @@ function coerceSharedPropertyValue(
 								: `Enter a valid number for --${flagName}`,
 					);
 				}
-				return { ok: true, value: raw };
+				return finalizeNumber(flagName, source, raw, raw, schema.numberConstraints);
 			}
 			if (typeof raw === 'string') {
 				const value = Number(raw);
-				if (!Number.isNaN(value)) return { ok: true, value };
+				if (!Number.isNaN(value)) {
+					return finalizeNumber(flagName, source, raw, value, schema.numberConstraints);
+				}
 			}
 			return coercionError(
 				flagName,
@@ -322,8 +372,15 @@ function redactArgCoercionMessage(
 	error: ValidationError,
 ): string {
 	switch (schema.kind) {
-		case 'number':
-			return `Invalid number value '<redacted>' ${argSourceLabel(source)} for argument <${argName}>`;
+		case 'number': {
+			// Preserve the constraint reason suffix (e.g. `: must be >= 0`) while
+			// redacting the raw value. The suffix contains only schema-derived
+			// text (bounds, "integer"), never user input.
+			const match = /: ([^:]+)$/.exec(error.message);
+			const suffix = match?.[1];
+			const base = `Invalid number value '<redacted>' ${argSourceLabel(source)} for argument <${argName}>`;
+			return suffix !== undefined ? `${base}: ${suffix}` : base;
+		}
 		case 'enum': {
 			const allowed = Array.isArray(error.details?.allowed)
 				? error.details.allowed.filter((value): value is string => typeof value === 'string')
@@ -356,6 +413,9 @@ function redactArgCoercionDetails(
 		arg: argName,
 		...argSourceDetails(source),
 		...(schema.kind === 'number' || schema.kind === 'custom' ? { expected: schema.kind } : {}),
+		...(schema.kind === 'number' && typeof error.details?.constraint === 'string'
+			? { constraint: error.details.constraint }
+			: {}),
 		...(schema.kind === 'enum' && Array.isArray(error.details?.allowed)
 			? {
 					allowed: error.details.allowed.filter(

--- a/src/core/resolve/property.ts
+++ b/src/core/resolve/property.ts
@@ -9,7 +9,7 @@
  * @internal
  */
 
-import type { ArgSchema, FlagSchema } from '#internals/core/schema/index.ts';
+import type { ArgSchema, FlagSchema, NumberConstraints } from '#internals/core/schema/index.ts';
 
 /** Flag/arg kinds that share a common coercion path. */
 const SHARED_PROPERTY_MODEL_KINDS = ['string', 'number', 'enum', 'custom'] as const;
@@ -20,7 +20,7 @@ type SharedPropertyKind = (typeof SHARED_PROPERTY_MODEL_KINDS)[number];
 /** Minimal coercion-relevant slice of a flag or arg schema, discriminated by kind. */
 type SharedPropertySchema =
 	| { readonly kind: 'string' }
-	| { readonly kind: 'number' }
+	| { readonly kind: 'number'; readonly numberConstraints: NumberConstraints | undefined }
 	| { readonly kind: 'enum'; readonly enumValues: readonly string[] | undefined }
 	| { readonly kind: 'custom'; readonly parseFn?: (raw: unknown) => unknown };
 
@@ -53,7 +53,7 @@ function toSharedFlagPropertySchema(schema: FlagSchema): SharedPropertySchema | 
 		case 'string':
 			return { kind: 'string' };
 		case 'number':
-			return { kind: 'number' };
+			return { kind: 'number', numberConstraints: schema.numberConstraints };
 		case 'enum':
 			return { kind: 'enum', enumValues: schema.enumValues };
 		case 'custom':
@@ -72,7 +72,7 @@ function toSharedArgPropertySchema(schema: ArgSchema): SharedPropertySchema {
 		case 'string':
 			return { kind: 'string' };
 		case 'number':
-			return { kind: 'number' };
+			return { kind: 'number', numberConstraints: schema.numberConstraints };
 		case 'enum':
 			return { kind: 'enum', enumValues: schema.enumValues };
 		case 'custom': {

--- a/src/core/resolve/resolve-arg-env.test.ts
+++ b/src/core/resolve/resolve-arg-env.test.ts
@@ -460,4 +460,31 @@ describe('resolve — arg env numeric constraints', () => {
 			'must be a finite number',
 		);
 	});
+
+	it('redacts a colon-delimited raw env value without leaking the trailing fragment', async () => {
+		// Non-numeric input → TYPE_MISMATCH (not a constraint violation). The raw
+		// value embeds `: `, which a naive suffix extraction would leak past the
+		// `<redacted>` placeholder. Redaction must drop it entirely.
+		const schema = makeSchema({
+			args: [
+				{
+					name: 'count',
+					schema: createArgSchema('number', {
+						envVar: 'COUNT',
+						numberConstraints: { min: 0, max: 100 },
+					}),
+				},
+			],
+		});
+		try {
+			await resolve(schema, makeParsed(), { env: { COUNT: 'nope: leaked-secret' } });
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect(isValidationError(err)).toBe(true);
+			if (isValidationError(err)) {
+				expect(err.message).toContain('<redacted>');
+				expect(err.message).not.toContain('leaked-secret');
+			}
+		}
+	});
 });

--- a/src/core/resolve/resolve-arg-env.test.ts
+++ b/src/core/resolve/resolve-arg-env.test.ts
@@ -447,7 +447,7 @@ describe('resolve — arg env numeric constraints', () => {
 				expect(err.message).toContain('<redacted>');
 				expect(err.message).not.toContain('150');
 				expect(err.message).toContain('must be <= 100');
-				expect(err.details).toMatchObject({ arg: 'count', constraint: 'max' });
+				expect(err.details).toMatchObject({ arg: 'count', constraint: 'max', bound: 100 });
 			}
 		}
 	});

--- a/src/core/resolve/resolve-arg-env.test.ts
+++ b/src/core/resolve/resolve-arg-env.test.ts
@@ -421,3 +421,43 @@ describe('resolve', () => {
 		});
 	});
 });
+
+// === Numeric constraints (arg env coerce path; raw value redacted, reason kept)
+
+describe('resolve — arg env numeric constraints', () => {
+	it('enforces constraints and redacts the raw value while keeping the reason', async () => {
+		const schema = makeSchema({
+			args: [
+				{
+					name: 'count',
+					schema: createArgSchema('number', {
+						envVar: 'COUNT',
+						numberConstraints: { int: true, min: 0, max: 100 },
+					}),
+				},
+			],
+		});
+		try {
+			await resolve(schema, makeParsed(), { env: { COUNT: '150' } });
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect(isValidationError(err)).toBe(true);
+			if (isValidationError(err)) {
+				expect(err.code).toBe('CONSTRAINT_VIOLATED');
+				expect(err.message).toContain('<redacted>');
+				expect(err.message).not.toContain('150');
+				expect(err.message).toContain('must be <= 100');
+				expect(err.details).toMatchObject({ arg: 'count', constraint: 'max' });
+			}
+		}
+	});
+
+	it('rejects Infinity from arg env by default', async () => {
+		const schema = makeSchema({
+			args: [{ name: 'count', schema: createArgSchema('number', { envVar: 'COUNT' }) }],
+		});
+		await expect(resolve(schema, makeParsed(), { env: { COUNT: 'Infinity' } })).rejects.toThrow(
+			'must be a finite number',
+		);
+	});
+});

--- a/src/core/resolve/resolve-config.test.ts
+++ b/src/core/resolve/resolve-config.test.ts
@@ -913,3 +913,56 @@ describe('resolve', () => {
 		});
 	});
 });
+
+// === Numeric constraints (config coerce path mirrors the parse path)
+
+describe('resolve — config numeric constraints', () => {
+	it('rejects out-of-range config number', async () => {
+		const schema = makeSchema({
+			flags: {
+				retries: createSchema('number', {
+					configPath: 'retries',
+					numberConstraints: { int: true, min: 0, max: 5 },
+				}),
+			},
+		});
+		try {
+			await resolve(schema, makeParsed(), { config: { retries: 10 } });
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect(isValidationError(err)).toBe(true);
+			if (isValidationError(err)) {
+				expect(err.code).toBe('CONSTRAINT_VIOLATED');
+				expect(err.message).toContain('must be <= 5');
+				expect(err.details).toMatchObject({ flag: 'retries', constraint: 'max' });
+			}
+		}
+	});
+
+	it('rejects non-integer config number when int required', async () => {
+		const schema = makeSchema({
+			flags: {
+				retries: createSchema('number', {
+					configPath: 'retries',
+					numberConstraints: { int: true },
+				}),
+			},
+		});
+		await expect(resolve(schema, makeParsed(), { config: { retries: 2.5 } })).rejects.toThrow(
+			'must be an integer',
+		);
+	});
+
+	it('accepts an in-range config number', async () => {
+		const schema = makeSchema({
+			flags: {
+				retries: createSchema('number', {
+					configPath: 'retries',
+					numberConstraints: { int: true, min: 0, max: 5 },
+				}),
+			},
+		});
+		const result = await resolve(schema, makeParsed(), { config: { retries: 3 } });
+		expect(result.flags).toEqual({ retries: 3 });
+	});
+});

--- a/src/core/resolve/resolve-env.test.ts
+++ b/src/core/resolve/resolve-env.test.ts
@@ -693,4 +693,21 @@ describe('resolve — env numeric constraints', () => {
 		const ok = await resolve(schema, makeParsed(), { env: { COUNT: '100' } });
 		expect(ok.flags).toEqual({ count: 100 });
 	});
+
+	it('includes the violated bound in env-path details (matches parse)', async () => {
+		const schema = makeSchema({
+			flags: {
+				count: createSchema('number', { envVar: 'COUNT', numberConstraints: { max: 100 } }),
+			},
+		});
+		try {
+			await resolve(schema, makeParsed(), { env: { COUNT: '101' } });
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect(isValidationError(err)).toBe(true);
+			if (isValidationError(err)) {
+				expect(err.details).toMatchObject({ flag: 'count', constraint: 'max', bound: 100 });
+			}
+		}
+	});
 });

--- a/src/core/resolve/resolve-env.test.ts
+++ b/src/core/resolve/resolve-env.test.ts
@@ -633,3 +633,64 @@ describe('resolve', () => {
 		});
 	});
 });
+
+// === Numeric constraints (env coerce path mirrors the parse path)
+
+describe('resolve — env numeric constraints', () => {
+	it('rejects Infinity by default (finite)', async () => {
+		const schema = makeSchema({
+			flags: { count: createSchema('number', { envVar: 'COUNT' }) },
+		});
+		try {
+			await resolve(schema, makeParsed(), { env: { COUNT: 'Infinity' } });
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect(isValidationError(err)).toBe(true);
+			if (isValidationError(err)) {
+				expect(err.code).toBe('CONSTRAINT_VIOLATED');
+				expect(err.message).toContain('must be a finite number');
+				expect(err.details).toMatchObject({ flag: 'count', constraint: 'finite' });
+			}
+		}
+	});
+
+	it('{ finite: false } allows Infinity from env', async () => {
+		const schema = makeSchema({
+			flags: {
+				count: createSchema('number', { envVar: 'COUNT', numberConstraints: { finite: false } }),
+			},
+		});
+		const result = await resolve(schema, makeParsed(), { env: { COUNT: 'Infinity' } });
+		expect(result.flags).toEqual({ count: Number.POSITIVE_INFINITY });
+	});
+
+	it('{ int: true } rejects non-integer env value', async () => {
+		const schema = makeSchema({
+			flags: {
+				count: createSchema('number', { envVar: 'COUNT', numberConstraints: { int: true } }),
+			},
+		});
+		await expect(resolve(schema, makeParsed(), { env: { COUNT: '3.7' } })).rejects.toThrow(
+			'must be an integer',
+		);
+	});
+
+	it('{ min: 0, max: 100 } enforces inclusive bounds from env', async () => {
+		const schema = makeSchema({
+			flags: {
+				count: createSchema('number', {
+					envVar: 'COUNT',
+					numberConstraints: { min: 0, max: 100 },
+				}),
+			},
+		});
+		await expect(resolve(schema, makeParsed(), { env: { COUNT: '-1' } })).rejects.toThrow(
+			'must be >= 0',
+		);
+		await expect(resolve(schema, makeParsed(), { env: { COUNT: '101' } })).rejects.toThrow(
+			'must be <= 100',
+		);
+		const ok = await resolve(schema, makeParsed(), { env: { COUNT: '100' } });
+		expect(ok.flags).toEqual({ count: 100 });
+	});
+});

--- a/src/core/schema/arg.test.ts
+++ b/src/core/schema/arg.test.ts
@@ -30,6 +30,50 @@ describe('arg.number() — creates and modifies number args', () => {
 		expect(a.schema.presence).toBe('required');
 		expect(a.schema.variadic).toBe(false);
 	});
+
+	it('has no constraints by default', () => {
+		expect(arg.number().schema.numberConstraints).toBeUndefined();
+	});
+
+	it('stores constraints from the options object', () => {
+		const a = arg.number({ min: 1, max: 9, int: true, finite: false });
+		expect(a.schema.numberConstraints).toEqual({ min: 1, max: 9, int: true, finite: false });
+	});
+
+	it('keeps the resolved value type as number regardless of constraints', () => {
+		const a = arg.number({ int: true });
+		expectTypeOf<InferArg<typeof a>>().toEqualTypeOf<number>();
+	});
+});
+
+describe('arg.number() chained constraint methods', () => {
+	it('.int()/.min()/.max()/.finite() build constraints', () => {
+		expect(arg.number().int().min(0).max(100).schema.numberConstraints).toEqual({
+			int: true,
+			min: 0,
+			max: 100,
+		});
+		expect(arg.number().finite(false).schema.numberConstraints).toEqual({ finite: false });
+	});
+
+	it('chained methods merge onto and override the options object', () => {
+		expect(arg.number({ min: 0 }).max(100).schema.numberConstraints).toEqual({ min: 0, max: 100 });
+		expect(arg.number({ min: 0 }).min(5).schema.numberConstraints).toEqual({ min: 5 });
+	});
+
+	it('preserves presence/variadic through the chain', () => {
+		const a = arg.number().optional().min(0);
+		expect(a.schema.presence).toBe('optional');
+		expectTypeOf<InferArg<typeof a>>().toEqualTypeOf<number | undefined>();
+	});
+
+	it('constraint methods are number-kind only at compile time', () => {
+		// @ts-expect-error — .min() is not available on string args
+		arg.string().min(0);
+		// @ts-expect-error — .int() is not available on enum args
+		arg.enum(['a', 'b']).int();
+		expect(true).toBe(true);
+	});
 });
 
 describe('arg.enum() — creates and modifies enum args', () => {

--- a/src/core/schema/arg.test.ts
+++ b/src/core/schema/arg.test.ts
@@ -92,6 +92,11 @@ describe('arg.number() rejects non-finite bounds at construction', () => {
 	it('still accepts finite bounds', () => {
 		expect(() => arg.number({ min: 0, max: 100 }).max(1000)).not.toThrow();
 	});
+
+	it('throws when min exceeds max', () => {
+		expect(() => arg.number({ min: 100, max: 0 })).toThrow(RangeError);
+		expect(() => arg.number({ max: 0 }).min(100)).toThrow(RangeError);
+	});
 });
 
 describe('arg.enum() — creates and modifies enum args', () => {

--- a/src/core/schema/arg.test.ts
+++ b/src/core/schema/arg.test.ts
@@ -76,6 +76,24 @@ describe('arg.number() chained constraint methods', () => {
 	});
 });
 
+describe('arg.number() rejects non-finite bounds at construction', () => {
+	it('throws for an infinite max in the options object', () => {
+		expect(() => arg.number({ max: Number.POSITIVE_INFINITY })).toThrow(RangeError);
+	});
+
+	it('throws for an infinite chained .min()', () => {
+		expect(() => arg.number().min(Number.NEGATIVE_INFINITY)).toThrow(RangeError);
+	});
+
+	it('throws for a NaN bound', () => {
+		expect(() => arg.number().max(Number.NaN)).toThrow(RangeError);
+	});
+
+	it('still accepts finite bounds', () => {
+		expect(() => arg.number({ min: 0, max: 100 }).max(1000)).not.toThrow();
+	});
+});
+
 describe('arg.enum() — creates and modifies enum args', () => {
 	it('creates an enum arg with required presence', () => {
 		const a = arg.enum(['us', 'eu', 'ap']);

--- a/src/core/schema/arg.ts
+++ b/src/core/schema/arg.ts
@@ -8,6 +8,8 @@
  * @module dreamcli/core/schema/arg
  */
 
+import type { NumberConstraints } from './number-constraints.ts';
+
 // --- Type-level configuration (phantom state tracked through the chain)
 
 /** All arg presence states as a runtime array. */
@@ -33,6 +35,8 @@ interface ArgConfig {
 	readonly presence: ArgPresence;
 	/** Whether this arg consumes remaining positionals. */
 	readonly variadic: boolean;
+	/** The runtime kind discriminator, mirroring {@link ArgKind}. */
+	readonly argKind: ArgKind;
 }
 
 // --- Type-level helpers
@@ -45,6 +49,7 @@ type WithArgPresence<C extends ArgConfig, P extends ArgPresence> = {
 	readonly valueType: C['valueType'];
 	readonly presence: P;
 	readonly variadic: C['variadic'];
+	readonly argKind: C['argKind'];
 };
 
 /**
@@ -55,6 +60,7 @@ type WithVariadic<C extends ArgConfig> = {
 	readonly valueType: C['valueType'];
 	readonly presence: C['presence'];
 	readonly variadic: true;
+	readonly argKind: C['argKind'];
 };
 
 /**
@@ -125,6 +131,13 @@ interface ArgSchema {
 	readonly envVar: string | undefined;
 	/** Allowed literal values when `kind === 'enum'`. */
 	readonly enumValues: readonly string[] | undefined;
+	/**
+	 * Numeric constraints when `kind === 'number'` (`undefined` otherwise).
+	 *
+	 * Enforced at the parse and resolution boundaries. `finite` defaults to
+	 * `true`, so `Infinity` is rejected even when no constraints object is set.
+	 */
+	readonly numberConstraints: NumberConstraints | undefined;
 	/** Custom parse function (only when `kind === 'custom'`). */
 	readonly parseFn: ArgParseFn<unknown> | undefined;
 	/**
@@ -174,6 +187,7 @@ function createArgSchema(kind: ArgKind, overrides?: Partial<ArgSchema>): ArgSche
 		description: undefined,
 		envVar: undefined,
 		enumValues: undefined,
+		numberConstraints: undefined,
 		parseFn: undefined,
 		deprecated: undefined,
 		...overrides,
@@ -478,6 +492,93 @@ class ArgBuilder<C extends ArgConfig> {
 			deprecated: message ?? true,
 		});
 	}
+
+	// -- Numeric constraint modifiers ----------------------------------------
+	//
+	// Compile-time guarded via a `this` parameter so they are only callable on
+	// number-kind builders. They merge onto the single `numberConstraints`
+	// representation, overriding any value set by `arg.number({ … })`.
+
+	/**
+	 * Require an integer value. Composes with other numeric constraints.
+	 *
+	 * @param value - Whether to require an integer.
+	 * @defaultValue `true`
+	 * @returns The builder (for chaining).
+	 *
+	 * @example
+	 * ```ts
+	 * arg.number().int()         // rejects 3.7, accepts 3
+	 * arg.number({ int: true }).int(false) // re-allows non-integers
+	 * ```
+	 */
+	int(this: ArgBuilder<C & { readonly argKind: 'number' }>, value = true): ArgBuilder<C> {
+		return new ArgBuilder({
+			...this.schema,
+			numberConstraints: { ...this.schema.numberConstraints, int: value },
+		});
+	}
+
+	/**
+	 * Set an inclusive lower bound. Composes with other numeric constraints;
+	 * a later call overrides an earlier `min` (including one from the options
+	 * object).
+	 *
+	 * @param value - Inclusive minimum.
+	 * @returns The builder (for chaining).
+	 *
+	 * @example
+	 * ```ts
+	 * arg.number().min(0)              // rejects -1, accepts 0
+	 * arg.number({ min: 0 }).min(5)    // effective min is 5
+	 * ```
+	 */
+	min(this: ArgBuilder<C & { readonly argKind: 'number' }>, value: number): ArgBuilder<C> {
+		return new ArgBuilder({
+			...this.schema,
+			numberConstraints: { ...this.schema.numberConstraints, min: value },
+		});
+	}
+
+	/**
+	 * Set an inclusive upper bound. Composes with other numeric constraints;
+	 * a later call overrides an earlier `max`.
+	 *
+	 * @param value - Inclusive maximum.
+	 * @returns The builder (for chaining).
+	 *
+	 * @example
+	 * ```ts
+	 * arg.number().max(100)            // rejects 101, accepts 100
+	 * ```
+	 */
+	max(this: ArgBuilder<C & { readonly argKind: 'number' }>, value: number): ArgBuilder<C> {
+		return new ArgBuilder({
+			...this.schema,
+			numberConstraints: { ...this.schema.numberConstraints, max: value },
+		});
+	}
+
+	/**
+	 * Require (or, with `false`, allow) a finite value. Finiteness is enforced
+	 * by default, so this is mainly used as `.finite(false)` to re-allow
+	 * `Infinity` / `-Infinity`.
+	 *
+	 * @param allow - Whether to require a finite value.
+	 * @defaultValue `true`
+	 * @returns The builder (for chaining).
+	 *
+	 * @example
+	 * ```ts
+	 * arg.number().finite(false) // accepts Infinity
+	 * ```
+	 */
+	finite(this: ArgBuilder<C & { readonly argKind: 'number' }>, allow = true): ArgBuilder<C> {
+		return new ArgBuilder({
+			...this.schema,
+			numberConstraints: { ...this.schema.numberConstraints, finite: allow },
+		});
+	}
 }
 
 // --- Factory namespace
@@ -544,6 +645,7 @@ interface ArgFactory {
 		readonly valueType: string;
 		readonly presence: 'required';
 		readonly variadic: false;
+		readonly argKind: 'string';
 	}>;
 
 	/**
@@ -566,12 +668,20 @@ interface ArgFactory {
 	 * // $ mycli serve          → 3000
 	 * ```
 	 *
+	 * Constraints are enforced at the parse and resolution boundaries and also
+	 * compose via chained methods (`.int()`, `.min()`, `.max()`, `.finite()`),
+	 * which override values set here. The resolved value type stays `number`.
+	 *
+	 * @param constraints - Optional numeric constraints. `finite` defaults to
+	 *   `true`, so `Infinity` / `-Infinity` are rejected unless `finite: false`.
+	 * @defaultValue `undefined` (finite-only, no bounds, non-integer allowed)
 	 * @returns A required number {@link ArgBuilder}.
 	 */
-	number(): ArgBuilder<{
+	number(constraints?: NumberConstraints): ArgBuilder<{
 		readonly valueType: number;
 		readonly presence: 'required';
 		readonly variadic: false;
+		readonly argKind: 'number';
 	}>;
 
 	/**
@@ -603,6 +713,7 @@ interface ArgFactory {
 		readonly valueType: T[number];
 		readonly presence: 'required';
 		readonly variadic: false;
+		readonly argKind: 'enum';
 	}>;
 
 	/**
@@ -634,6 +745,7 @@ interface ArgFactory {
 		readonly valueType: T;
 		readonly presence: 'required';
 		readonly variadic: false;
+		readonly argKind: 'custom';
 	}>;
 }
 
@@ -670,16 +782,23 @@ const arg: ArgFactory = {
 		readonly valueType: string;
 		readonly presence: 'required';
 		readonly variadic: false;
+		readonly argKind: 'string';
 	}> {
 		return new ArgBuilder(createArgSchema('string'));
 	},
 
-	number(): ArgBuilder<{
+	number(constraints?: NumberConstraints): ArgBuilder<{
 		readonly valueType: number;
 		readonly presence: 'required';
 		readonly variadic: false;
+		readonly argKind: 'number';
 	}> {
-		return new ArgBuilder(createArgSchema('number'));
+		return new ArgBuilder(
+			createArgSchema(
+				'number',
+				constraints !== undefined ? { numberConstraints: constraints } : {},
+			),
+		);
 	},
 
 	enum<const T extends readonly [string, ...string[]]>(
@@ -688,6 +807,7 @@ const arg: ArgFactory = {
 		readonly valueType: T[number];
 		readonly presence: 'required';
 		readonly variadic: false;
+		readonly argKind: 'enum';
 	}> {
 		return new ArgBuilder(createArgSchema('enum', { enumValues: values }));
 	},
@@ -696,6 +816,7 @@ const arg: ArgFactory = {
 		readonly valueType: T;
 		readonly presence: 'required';
 		readonly variadic: false;
+		readonly argKind: 'custom';
 	}> {
 		return new ArgBuilder(createArgSchema('custom', { parseFn: parseFn as ArgParseFn<unknown> }));
 	},

--- a/src/core/schema/arg.ts
+++ b/src/core/schema/arg.ts
@@ -8,7 +8,7 @@
  * @module dreamcli/core/schema/arg
  */
 
-import type { NumberConstraints } from './number-constraints.ts';
+import { assertNumberConstraints, type NumberConstraints } from './number-constraints.ts';
 
 // --- Type-level configuration (phantom state tracked through the chain)
 
@@ -534,10 +534,9 @@ class ArgBuilder<C extends ArgConfig> {
 	 * ```
 	 */
 	min(this: ArgBuilder<C & { readonly argKind: 'number' }>, value: number): ArgBuilder<C> {
-		return new ArgBuilder({
-			...this.schema,
-			numberConstraints: { ...this.schema.numberConstraints, min: value },
-		});
+		const numberConstraints = { ...this.schema.numberConstraints, min: value };
+		assertNumberConstraints(numberConstraints);
+		return new ArgBuilder({ ...this.schema, numberConstraints });
 	}
 
 	/**
@@ -553,10 +552,9 @@ class ArgBuilder<C extends ArgConfig> {
 	 * ```
 	 */
 	max(this: ArgBuilder<C & { readonly argKind: 'number' }>, value: number): ArgBuilder<C> {
-		return new ArgBuilder({
-			...this.schema,
-			numberConstraints: { ...this.schema.numberConstraints, max: value },
-		});
+		const numberConstraints = { ...this.schema.numberConstraints, max: value };
+		assertNumberConstraints(numberConstraints);
+		return new ArgBuilder({ ...this.schema, numberConstraints });
 	}
 
 	/**
@@ -793,6 +791,9 @@ const arg: ArgFactory = {
 		readonly variadic: false;
 		readonly argKind: 'number';
 	}> {
+		if (constraints !== undefined) {
+			assertNumberConstraints(constraints);
+		}
 		return new ArgBuilder(
 			createArgSchema(
 				'number',

--- a/src/core/schema/flag.test.ts
+++ b/src/core/schema/flag.test.ts
@@ -114,6 +114,18 @@ describe('flag.number() rejects non-finite bounds at construction', () => {
 	it('still accepts finite bounds', () => {
 		expect(() => flag.number({ min: 0, max: 100 }).min(-5).max(1000)).not.toThrow();
 	});
+
+	it('throws when min exceeds max (options object)', () => {
+		expect(() => flag.number({ min: 100, max: 0 })).toThrow(RangeError);
+	});
+
+	it('throws when a chained bound inverts the range', () => {
+		expect(() => flag.number({ max: 0 }).min(100)).toThrow(RangeError);
+	});
+
+	it('allows min equal to max (single permitted value)', () => {
+		expect(() => flag.number({ min: 5, max: 5 })).not.toThrow();
+	});
 });
 
 describe('flag.boolean()', () => {

--- a/src/core/schema/flag.test.ts
+++ b/src/core/schema/flag.test.ts
@@ -90,6 +90,32 @@ describe('flag.number() chained constraint methods', () => {
 	});
 });
 
+describe('flag.number() rejects non-finite bounds at construction', () => {
+	it('throws for an infinite max in the options object', () => {
+		expect(() => flag.number({ max: Number.POSITIVE_INFINITY })).toThrow(RangeError);
+	});
+
+	it('throws for an infinite min in the options object', () => {
+		expect(() => flag.number({ min: Number.NEGATIVE_INFINITY })).toThrow(RangeError);
+	});
+
+	it('throws for a NaN bound', () => {
+		expect(() => flag.number({ max: Number.NaN })).toThrow(RangeError);
+	});
+
+	it('throws for an infinite chained .max()', () => {
+		expect(() => flag.number().max(Number.POSITIVE_INFINITY)).toThrow(RangeError);
+	});
+
+	it('throws for an infinite chained .min()', () => {
+		expect(() => flag.number().min(Number.NEGATIVE_INFINITY)).toThrow(RangeError);
+	});
+
+	it('still accepts finite bounds', () => {
+		expect(() => flag.number({ min: 0, max: 100 }).min(-5).max(1000)).not.toThrow();
+	});
+});
+
 describe('flag.boolean()', () => {
 	it('creates a boolean flag defaulted to false', () => {
 		const f = flag.boolean();

--- a/src/core/schema/flag.test.ts
+++ b/src/core/schema/flag.test.ts
@@ -24,6 +24,70 @@ describe('flag.number()', () => {
 		expect(f.schema.kind).toBe('number');
 		expect(f.schema.presence).toBe('optional');
 	});
+
+	it('has no constraints by default', () => {
+		expect(flag.number().schema.numberConstraints).toBeUndefined();
+	});
+
+	it('stores constraints from the options object', () => {
+		const f = flag.number({ min: 0, max: 100, int: true, finite: false });
+		expect(f.schema.numberConstraints).toEqual({ min: 0, max: 100, int: true, finite: false });
+	});
+
+	it('keeps the resolved value type as number regardless of constraints', () => {
+		const f = flag.number({ int: true, min: 0 });
+		expectTypeOf<InferFlag<typeof f>>().toEqualTypeOf<number | undefined>();
+	});
+});
+
+describe('flag.number() chained constraint methods', () => {
+	it('.int() sets int true', () => {
+		expect(flag.number().int().schema.numberConstraints).toEqual({ int: true });
+	});
+
+	it('.int(false) sets int false', () => {
+		expect(flag.number().int(false).schema.numberConstraints).toEqual({ int: false });
+	});
+
+	it('.min()/.max() set inclusive bounds', () => {
+		expect(flag.number().min(0).max(100).schema.numberConstraints).toEqual({ min: 0, max: 100 });
+	});
+
+	it('.finite(false) opts back into Infinity', () => {
+		expect(flag.number().finite(false).schema.numberConstraints).toEqual({ finite: false });
+	});
+
+	it('chained methods merge onto the options object', () => {
+		const f = flag.number({ min: 0 }).max(100);
+		expect(f.schema.numberConstraints).toEqual({ min: 0, max: 100 });
+	});
+
+	it('a later chained method overrides an earlier value', () => {
+		const f = flag.number({ min: 0 }).min(5);
+		expect(f.schema.numberConstraints).toEqual({ min: 5 });
+	});
+
+	it('preserves presence through the chain', () => {
+		const f = flag.number().required().min(0);
+		expect(f.schema.presence).toBe('required');
+		expectTypeOf<InferFlag<typeof f>>().toEqualTypeOf<number>();
+	});
+
+	it('does not mutate the source builder (immutability)', () => {
+		const base = flag.number({ min: 0 });
+		base.max(100);
+		expect(base.schema.numberConstraints).toEqual({ min: 0 });
+	});
+
+	it('constraint methods are number-kind only at compile time', () => {
+		// @ts-expect-error — .min() is not available on string flags
+		flag.string().min(0);
+		// @ts-expect-error — .int() is not available on boolean flags
+		flag.boolean().int();
+		// @ts-expect-error — .finite() is not available on enum flags
+		flag.enum(['a', 'b']).finite();
+		expect(true).toBe(true);
+	});
 });
 
 describe('flag.boolean()', () => {

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -9,7 +9,7 @@
  * @module dreamcli/core/schema/flag
  */
 
-import type { NumberConstraints } from './number-constraints.ts';
+import { assertNumberConstraints, type NumberConstraints } from './number-constraints.ts';
 import type {
 	ConfirmPromptConfig,
 	InputPromptConfig,
@@ -612,10 +612,9 @@ class FlagBuilder<C extends FlagConfig> {
 	 * ```
 	 */
 	min(this: FlagBuilder<C & { readonly flagKind: 'number' }>, value: number): FlagBuilder<C> {
-		return new FlagBuilder({
-			...this.schema,
-			numberConstraints: { ...this.schema.numberConstraints, min: value },
-		});
+		const numberConstraints = { ...this.schema.numberConstraints, min: value };
+		assertNumberConstraints(numberConstraints);
+		return new FlagBuilder({ ...this.schema, numberConstraints });
 	}
 
 	/**
@@ -631,10 +630,9 @@ class FlagBuilder<C extends FlagConfig> {
 	 * ```
 	 */
 	max(this: FlagBuilder<C & { readonly flagKind: 'number' }>, value: number): FlagBuilder<C> {
-		return new FlagBuilder({
-			...this.schema,
-			numberConstraints: { ...this.schema.numberConstraints, max: value },
-		});
+		const numberConstraints = { ...this.schema.numberConstraints, max: value };
+		assertNumberConstraints(numberConstraints);
+		return new FlagBuilder({ ...this.schema, numberConstraints });
 	}
 
 	/**
@@ -822,6 +820,9 @@ const flag: FlagFactory = {
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'number';
 	}> {
+		if (constraints !== undefined) {
+			assertNumberConstraints(constraints);
+		}
 		return new FlagBuilder(
 			createSchema('number', constraints !== undefined ? { numberConstraints: constraints } : {}),
 		);

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -9,6 +9,7 @@
  * @module dreamcli/core/schema/flag
  */
 
+import type { NumberConstraints } from './number-constraints.ts';
 import type {
 	ConfirmPromptConfig,
 	InputPromptConfig,
@@ -165,6 +166,13 @@ interface FlagSchema {
 	readonly description: string | undefined;
 	/** Allowed literal values when `kind === 'enum'`. */
 	readonly enumValues: readonly string[] | undefined;
+	/**
+	 * Numeric constraints when `kind === 'number'` (`undefined` otherwise).
+	 *
+	 * Enforced at the parse and resolution boundaries. `finite` defaults to
+	 * `true`, so `Infinity` is rejected even when no constraints object is set.
+	 */
+	readonly numberConstraints: NumberConstraints | undefined;
 	/** Element schema when `kind === 'array'`. */
 	readonly elementSchema: FlagSchema | undefined;
 	/** Interactive prompt configuration for v0.3+ resolution. */
@@ -295,6 +303,7 @@ function createSchema(kind: FlagKind, overrides?: FlagSchemaOverrides): FlagSche
 		configPath: undefined,
 		description: undefined,
 		enumValues: undefined,
+		numberConstraints: undefined,
 		elementSchema: undefined,
 		prompt: undefined,
 		parseFn: undefined,
@@ -561,6 +570,93 @@ class FlagBuilder<C extends FlagConfig> {
 			propagate: true,
 		});
 	}
+
+	// -- Numeric constraint modifiers ----------------------------------------
+	//
+	// Compile-time guarded via a `this` parameter so they are only callable on
+	// number-kind builders. They merge onto the single `numberConstraints`
+	// representation, overriding any value set by `flag.number({ … })`.
+
+	/**
+	 * Require an integer value. Composes with other numeric constraints.
+	 *
+	 * @param value - Whether to require an integer.
+	 * @defaultValue `true`
+	 * @returns The builder (for chaining).
+	 *
+	 * @example
+	 * ```ts
+	 * flag.number().int()         // rejects 3.7, accepts 3
+	 * flag.number({ int: true }).int(false) // re-allows non-integers
+	 * ```
+	 */
+	int(this: FlagBuilder<C & { readonly flagKind: 'number' }>, value = true): FlagBuilder<C> {
+		return new FlagBuilder({
+			...this.schema,
+			numberConstraints: { ...this.schema.numberConstraints, int: value },
+		});
+	}
+
+	/**
+	 * Set an inclusive lower bound. Composes with other numeric constraints;
+	 * a later call overrides an earlier `min` (including one from the options
+	 * object).
+	 *
+	 * @param value - Inclusive minimum.
+	 * @returns The builder (for chaining).
+	 *
+	 * @example
+	 * ```ts
+	 * flag.number().min(0)              // rejects -1, accepts 0
+	 * flag.number({ min: 0 }).min(5)    // effective min is 5
+	 * ```
+	 */
+	min(this: FlagBuilder<C & { readonly flagKind: 'number' }>, value: number): FlagBuilder<C> {
+		return new FlagBuilder({
+			...this.schema,
+			numberConstraints: { ...this.schema.numberConstraints, min: value },
+		});
+	}
+
+	/**
+	 * Set an inclusive upper bound. Composes with other numeric constraints;
+	 * a later call overrides an earlier `max`.
+	 *
+	 * @param value - Inclusive maximum.
+	 * @returns The builder (for chaining).
+	 *
+	 * @example
+	 * ```ts
+	 * flag.number().max(100)            // rejects 101, accepts 100
+	 * ```
+	 */
+	max(this: FlagBuilder<C & { readonly flagKind: 'number' }>, value: number): FlagBuilder<C> {
+		return new FlagBuilder({
+			...this.schema,
+			numberConstraints: { ...this.schema.numberConstraints, max: value },
+		});
+	}
+
+	/**
+	 * Require (or, with `false`, allow) a finite value. Finiteness is enforced
+	 * by default, so this is mainly used as `.finite(false)` to re-allow
+	 * `Infinity` / `-Infinity`.
+	 *
+	 * @param allow - Whether to require a finite value.
+	 * @defaultValue `true`
+	 * @returns The builder (for chaining).
+	 *
+	 * @example
+	 * ```ts
+	 * flag.number().finite(false) // accepts Infinity
+	 * ```
+	 */
+	finite(this: FlagBuilder<C & { readonly flagKind: 'number' }>, allow = true): FlagBuilder<C> {
+		return new FlagBuilder({
+			...this.schema,
+			numberConstraints: { ...this.schema.numberConstraints, finite: allow },
+		});
+	}
 }
 
 // --- Factory namespace
@@ -583,11 +679,28 @@ interface FlagFactory {
 	}>;
 
 	/**
-	 * Number-valued flag.
+	 * Number-valued flag, with optional numeric constraints.
 	 *
+	 * Constraints are enforced at the parse and resolution boundaries. The
+	 * resolved value type stays `number` — constraints are runtime + schema, not
+	 * type-level. Bounds are inclusive.
+	 *
+	 * Constraints also compose via chained methods (`.int()`, `.min()`,
+	 * `.max()`, `.finite()`), which override values set here.
+	 *
+	 * @param constraints - Optional numeric constraints. `finite` defaults to
+	 *   `true`, so `Infinity` / `-Infinity` are rejected unless `finite: false`.
+	 * @defaultValue `undefined` (finite-only, no bounds, non-integer allowed)
 	 * @returns A {@link FlagBuilder} for `number` values.
+	 *
+	 * @example
+	 * ```ts
+	 * flag.number()                       // finite numbers only
+	 * flag.number({ int: true, min: 0 })  // non-negative integers
+	 * flag.number({ finite: false })      // also accepts Infinity
+	 * ```
 	 */
-	number(): FlagBuilder<{
+	number(constraints?: NumberConstraints): FlagBuilder<{
 		readonly valueType: number;
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
@@ -703,13 +816,15 @@ const flag: FlagFactory = {
 		return new FlagBuilder(createSchema('string'));
 	},
 
-	number(): FlagBuilder<{
+	number(constraints?: NumberConstraints): FlagBuilder<{
 		readonly valueType: number;
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'number';
 	}> {
-		return new FlagBuilder(createSchema('number'));
+		return new FlagBuilder(
+			createSchema('number', constraints !== undefined ? { numberConstraints: constraints } : {}),
+		);
 	},
 
 	boolean(): FlagBuilder<{

--- a/src/core/schema/index.ts
+++ b/src/core/schema/index.ts
@@ -88,4 +88,9 @@ export type {
 	MiddlewareParams,
 } from './middleware.ts';
 export { middleware } from './middleware.ts';
+export type { NumberConstraints, NumberConstraintViolation } from './number-constraints.ts';
+export {
+	describeNumberConstraintViolation,
+	validateNumberConstraints,
+} from './number-constraints.ts';
 export type { RunOptions, RunResult } from './run.ts';

--- a/src/core/schema/number-constraints.ts
+++ b/src/core/schema/number-constraints.ts
@@ -114,11 +114,13 @@ function describeNumberConstraintViolation(violation: NumberConstraintViolation)
  *
  * `min` / `max` must be finite — an infinite or `NaN` bound is meaningless (omit
  * the field for "no bound") and would serialize to `null` in the emitted JSON
- * Schema. Throws so the misconfiguration surfaces where the flag/arg is
- * declared, not at parse time.
+ * Schema. An inverted range (`min > max`) is also rejected, since it makes the
+ * flag/arg permanently unsatisfiable. Throws so the misconfiguration surfaces
+ * where the flag/arg is declared, not at parse time.
  *
  * @param constraints - The constraints to validate.
- * @throws RangeError if `min` or `max` is non-finite (`Infinity` / `-Infinity` / `NaN`).
+ * @throws RangeError if `min` or `max` is non-finite (`Infinity` / `-Infinity` /
+ *   `NaN`), or if `min` exceeds `max`.
  */
 function assertNumberConstraints(constraints: NumberConstraints): void {
 	if (constraints.min !== undefined && !Number.isFinite(constraints.min)) {
@@ -129,6 +131,15 @@ function assertNumberConstraints(constraints: NumberConstraints): void {
 	if (constraints.max !== undefined && !Number.isFinite(constraints.max)) {
 		throw new RangeError(
 			`number constraint 'max' must be a finite number (got ${constraints.max}); omit it for no upper bound`,
+		);
+	}
+	if (
+		constraints.min !== undefined &&
+		constraints.max !== undefined &&
+		constraints.min > constraints.max
+	) {
+		throw new RangeError(
+			`number constraint 'min' (${constraints.min}) must not exceed 'max' (${constraints.max})`,
 		);
 	}
 }

--- a/src/core/schema/number-constraints.ts
+++ b/src/core/schema/number-constraints.ts
@@ -59,9 +59,9 @@ const DEFAULT_FINITE = true;
  *
  * The single source of truth for numeric-constraint checks, shared by the
  * parse and coerce paths. Checks run in a fixed order — **finite → int → min →
- * max** — and the first failure is returned. `NaN` is treated as non-finite, so
- * it fails the finite check (callers typically reject `NaN` earlier with a
- * dedicated message).
+ * max** — and the first failure is returned. `NaN` is always rejected as a
+ * `finite` violation, regardless of the `finite` option (a non-finite value can
+ * otherwise slip past `min`/`max`, since `NaN < x` and `NaN > x` are both false).
  *
  * @param value - The numeric value to validate.
  * @param constraints - Constraints to enforce, or `undefined` for defaults.
@@ -71,6 +71,9 @@ function validateNumberConstraints(
 	value: number,
 	constraints: NumberConstraints | undefined,
 ): NumberConstraintViolation | undefined {
+	if (Number.isNaN(value)) {
+		return { kind: 'finite' };
+	}
 	const finite = constraints?.finite ?? DEFAULT_FINITE;
 	if (finite && !Number.isFinite(value)) {
 		return { kind: 'finite' };

--- a/src/core/schema/number-constraints.ts
+++ b/src/core/schema/number-constraints.ts
@@ -109,5 +109,34 @@ function describeNumberConstraintViolation(violation: NumberConstraintViolation)
 	}
 }
 
+/**
+ * Assert that a constraints object is well-formed at schema-construction time.
+ *
+ * `min` / `max` must be finite — an infinite or `NaN` bound is meaningless (omit
+ * the field for "no bound") and would serialize to `null` in the emitted JSON
+ * Schema. Throws so the misconfiguration surfaces where the flag/arg is
+ * declared, not at parse time.
+ *
+ * @param constraints - The constraints to validate.
+ * @throws RangeError if `min` or `max` is non-finite (`Infinity` / `-Infinity` / `NaN`).
+ */
+function assertNumberConstraints(constraints: NumberConstraints): void {
+	if (constraints.min !== undefined && !Number.isFinite(constraints.min)) {
+		throw new RangeError(
+			`number constraint 'min' must be a finite number (got ${constraints.min}); omit it for no lower bound`,
+		);
+	}
+	if (constraints.max !== undefined && !Number.isFinite(constraints.max)) {
+		throw new RangeError(
+			`number constraint 'max' must be a finite number (got ${constraints.max}); omit it for no upper bound`,
+		);
+	}
+}
+
 export type { NumberConstraints, NumberConstraintViolation };
-export { DEFAULT_FINITE, describeNumberConstraintViolation, validateNumberConstraints };
+export {
+	assertNumberConstraints,
+	DEFAULT_FINITE,
+	describeNumberConstraintViolation,
+	validateNumberConstraints,
+};

--- a/src/core/schema/number-constraints.ts
+++ b/src/core/schema/number-constraints.ts
@@ -1,0 +1,110 @@
+/**
+ * Numeric constraints for number-valued flags and args.
+ *
+ * A single, shared representation and validator so the parse path
+ * (`core/parse`) and the resolver coercion path (`core/resolve/coerce`) cannot
+ * drift: both import {@link validateNumberConstraints} and apply the checks in
+ * the same order (finite → int → min → max).
+ *
+ * @module dreamcli/core/schema/number-constraints
+ */
+
+/**
+ * Runtime numeric constraints attached to a number flag/arg schema.
+ *
+ * Bounds are **inclusive**. All fields are optional; an absent field means "no
+ * constraint" except for {@link NumberConstraints.finite | finite}, which
+ * defaults to `true` (so `Infinity` / `-Infinity` are rejected unless opted
+ * back in).
+ */
+interface NumberConstraints {
+	/**
+	 * Inclusive lower bound. Values below this are rejected.
+	 * @defaultValue `undefined` (no lower bound)
+	 */
+	readonly min?: number;
+	/**
+	 * Inclusive upper bound. Values above this are rejected.
+	 * @defaultValue `undefined` (no upper bound)
+	 */
+	readonly max?: number;
+	/**
+	 * Require an integer value. Non-integers (e.g. `3.7`) are rejected.
+	 * @defaultValue `false`
+	 */
+	readonly int?: boolean;
+	/**
+	 * Require a finite value. When `true`, `Infinity` / `-Infinity` are rejected.
+	 * @defaultValue `true`
+	 */
+	readonly finite?: boolean;
+}
+
+/**
+ * A failed numeric constraint, discriminated by which rule was violated.
+ *
+ * `min` / `max` carry the offending bound so callers can render it.
+ */
+type NumberConstraintViolation =
+	| { readonly kind: 'finite' }
+	| { readonly kind: 'int' }
+	| { readonly kind: 'min'; readonly bound: number }
+	| { readonly kind: 'max'; readonly bound: number };
+
+/** Default for {@link NumberConstraints.finite} — reject `Infinity` unless opted out. */
+const DEFAULT_FINITE = true;
+
+/**
+ * Validate a numeric value against constraints.
+ *
+ * The single source of truth for numeric-constraint checks, shared by the
+ * parse and coerce paths. Checks run in a fixed order — **finite → int → min →
+ * max** — and the first failure is returned. `NaN` is treated as non-finite, so
+ * it fails the finite check (callers typically reject `NaN` earlier with a
+ * dedicated message).
+ *
+ * @param value - The numeric value to validate.
+ * @param constraints - Constraints to enforce, or `undefined` for defaults.
+ * @returns The first {@link NumberConstraintViolation}, or `undefined` if valid.
+ */
+function validateNumberConstraints(
+	value: number,
+	constraints: NumberConstraints | undefined,
+): NumberConstraintViolation | undefined {
+	const finite = constraints?.finite ?? DEFAULT_FINITE;
+	if (finite && !Number.isFinite(value)) {
+		return { kind: 'finite' };
+	}
+	if (constraints?.int === true && !Number.isInteger(value)) {
+		return { kind: 'int' };
+	}
+	if (constraints?.min !== undefined && value < constraints.min) {
+		return { kind: 'min', bound: constraints.min };
+	}
+	if (constraints?.max !== undefined && value > constraints.max) {
+		return { kind: 'max', bound: constraints.max };
+	}
+	return undefined;
+}
+
+/**
+ * Render a terse, human-readable reason for a constraint violation.
+ *
+ * @param violation - The violation to describe.
+ * @returns A message suffix such as `must be an integer` or `must be >= 0`.
+ */
+function describeNumberConstraintViolation(violation: NumberConstraintViolation): string {
+	switch (violation.kind) {
+		case 'finite':
+			return 'must be a finite number';
+		case 'int':
+			return 'must be an integer';
+		case 'min':
+			return `must be >= ${violation.bound}`;
+		case 'max':
+			return `must be <= ${violation.bound}`;
+	}
+}
+
+export type { NumberConstraints, NumberConstraintViolation };
+export { DEFAULT_FINITE, describeNumberConstraintViolation, validateNumberConstraints };

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,8 @@ export type {
 	MiddlewareHandler,
 	MiddlewareParams,
 	MultiselectPromptConfig,
+	NumberConstraints,
+	NumberConstraintViolation,
 	Out,
 	ProgressHandle,
 	ProgressOptions,


### PR DESCRIPTION
## What

Adds optional **numeric constraints** to the `number` factories, schema-integrated end to end.

### API

Two composable forms, writing to a single `numberConstraints` representation on the flag/arg schema:

```ts
// options object
flag.number({ min: 0, max: 100, int: true, finite: true });
arg.number({ min: 1 });

// chained methods (compose; a later call overrides an earlier value,
// including one set in the options object)
flag.number().int().min(0).max(100);
flag.number({ min: 0 }).max(100);        // -> { min: 0, max: 100 }
flag.number({ min: 0 }).min(5);          // -> { min: 5 }
flag.number().finite(false);             // re-allow Infinity
```

- Options arg is optional — `flag.number()` / `arg.number()` keep working.
- Bounds are **inclusive**; `int` defaults `false`; `min`/`max` default unbounded.
- Chained `.int()` / `.min()` / `.max()` / `.finite()` are **compile-time guarded** to number-kind builders via a `this`-parameter constraint (`this: FlagBuilder<C & { flagKind: 'number' }>` / `ArgBuilder<C & { argKind: 'number' }>`), so they don't appear on string/boolean/enum builders. `arg`'s config gained an `argKind` discriminant to mirror `flag`'s `flagKind`.
- Resolved TS value type stays `number` (constraints are runtime + schema, not type-level). No `any`, `as`, `!`, or lint suppression introduced.

### Behavior change (finite defaults true)

`finite` defaults to **`true`**, so `flag.number()` / `arg.number()` now **reject `Infinity` / `-Infinity`**, which previously slipped through (`Number("Infinity")` is not `NaN`). Opt back in with `{ finite: false }` / `.finite(false)`. `NaN` is still rejected as before. Classified under **Changed** in the changelog.

## Integration (single source of truth)

- **Schema storage**: `numberConstraints?: NumberConstraints` on `FlagSchema` / `ArgSchema`, set only for number kind via the existing immutable `createSchema` / `createArgSchema` pattern.
- **One shared validator**: `validateNumberConstraints(value, constraints)` (new `core/schema/number-constraints.ts`) is called from BOTH the parse path (`parse/index.ts`, flag + arg number cases) and the coerce path (`resolve/coerce.ts`, env/config/prompt) — they can't drift. Order: **finite → int → min → max**.
- **Errors**: parse throws `ParseError` `INVALID_VALUE` (exit 2), e.g. ``Invalid number value '3.7' for flag --times: must be an integer`` / `must be >= 0` / `must be <= 100` / `must be a finite number`. Coerce returns a `ValidationError` (`CONSTRAINT_VIOLATED`) following that file's shape; the arg env/stdin redaction path keeps the constraint reason while redacting the raw value.
- **JSON Schema** (`json-schema/index.ts`): number emits `type: 'integer'` when `int` else `'number'`, plus `minimum` / `maximum` when set, consistently for flags and args. (No field for `finite` — JSON has no Infinity.)

## Tests

TDD across `flag.test.ts`, `arg.test.ts`, `parse.test.ts`, `json-schema.test.ts`, `resolve-env.test.ts`, `resolve-config.test.ts`, `resolve-arg-env.test.ts`: object + chained forms, merge/override, compile-time `@ts-expect-error` guards, Infinity/NaN rejection, `finite:false` opt-in, int/min/max accept+reject, combined ordering, identical enforcement on the env/config coerce path, and JSON-Schema `minimum`/`maximum`/`type:integer`.

## Gates

`typecheck`, `lint`, `format:check` clean; full `test` suite green (2496 tests).