### PR TITLE
feat(prompt): default values for confirm/input prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `type: "integer"` when `int` is set. `min` / `max` must be finite — a
   non-finite bound (`Infinity` / `-Infinity` / `NaN`) throws at construction. The
   resolved TypeScript value type stays `number`.
+- **Prompt-level defaults for `confirm` and `input` prompts** — `confirm`
+  prompts accept `default?: boolean` (drives the `(Y/n)` vs `(y/N)` hint and the
+  empty-line result, so a confirm can default to **No**), and `input` prompts
+  accept `default?: string` (shown in the hint as `(default: <value>)` and used
+  when the user presses Enter, skipping `validate`). Precedence among defaults is
+  prompt-level `default` > flag `.default()`. Unset `confirm` default stays
+  backward compatible (`true`).
 
 ### Changed
 
@@ -62,6 +69,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   passed straight through to handlers (`Number("Infinity")` is not `NaN`). Pass
   `{ finite: false }` (or `.finite(false)`) to opt back into accepting non-finite
   values. `NaN` continues to be rejected as before.
+
+### Fixed
+
+- **Empty `input`-prompt answer no longer clobbers a flag's `.default()`** — a
+  flag declared with both `.default(...)` and an `input` prompt previously
+  resolved to `""` when the user submitted an empty line, because empty input was
+  treated as a real answer that short-circuited the default fallback. An empty or
+  blank `input` answer with no prompt-level `default` is now treated as "no
+  answer", so resolution falls through to the flag's `.default()` (or, for a
+  required flag, the standard missing-flag error).
 
 ## [2.5.0] - 2026-06-28
 

--- a/docs/guide/prompts.md
+++ b/docs/guide/prompts.md
@@ -28,6 +28,37 @@ after prompts are skipped or unanswered.
 For the exact non-interactive rules, cancellation fallthrough, and full
 precedence chain, see [CLI Semantics](/guide/semantics).
 
+## Prompt Defaults
+
+`confirm` and `input` prompts accept a `default` that is used when the user
+submits an empty line (presses Enter):
+
+```ts twoslash
+import { flag } from '@kjanat/dreamcli';
+
+// Enter → false; hint renders as `(y/N)` for a safe destructive default.
+flag.boolean().prompt({
+  kind: 'confirm',
+  message: 'Delete everything?',
+  default: false,
+});
+
+// Enter → 'Anonymous'; hint renders as `Name (default: Anonymous):`.
+flag.string().default('Anonymous').prompt({
+  kind: 'input',
+  message: 'Name',
+  default: 'Anonymous',
+});
+```
+
+A `confirm` default of `true` (or unset) shows `(Y/n)`; `false` shows `(y/N)`.
+
+For `input`, an empty submission resolves to the prompt-level `default` when set
+(skipping `validate`). When **no** prompt-level `default` is set, an empty
+submission is treated as "no answer" and resolution falls through to the flag's
+`.default()` — so pressing Enter never clobbers a configured default with `""`.
+Precedence among defaults is **prompt-level `default` > flag `.default()`**.
+
 ## Prompt Types
 
 | Kind          | Input            | Output     |

--- a/src/core/prompt/index.ts
+++ b/src/core/prompt/index.ts
@@ -283,10 +283,11 @@ const MAX_RETRIES = 10;
 /**
  * Confirm prompt: yes/no question.
  *
- * Displays `(Y/n)` because empty input defaults to yes.
- * Accepts: y, yes, n, no, empty (uses default). Case-insensitive.
+ * The hint reflects {@link ConfirmPromptConfig.default}: `(Y/n)` when the
+ * default is `true` (or unset), `(y/N)` when `false`. An empty submission
+ * resolves to that default. Accepts: y, yes, n, no, empty. Case-insensitive.
  *
- * @param config - {@link ConfirmPromptConfig} with the question message
+ * @param config - {@link ConfirmPromptConfig} with the question message and optional default
  * @param read - {@link ReadFn} for reading a line of user input
  * @param write - {@link WriteFn} for rendering prompt text
  * @returns Resolved {@link PromptResult} — `true`/`false` value, or cancelled on EOF
@@ -296,7 +297,7 @@ async function promptConfirm(
 	read: ReadFn,
 	write: WriteFn,
 ): Promise<PromptResult> {
-	const defaultValue = true;
+	const defaultValue = config.default ?? true;
 	let retries = 0;
 
 	while (retries < MAX_RETRIES) {
@@ -328,13 +329,17 @@ async function promptConfirm(
 /**
  * Input prompt: free-text string entry.
  *
- * Displays the message, reads a line, and optionally validates via
- * `config.validate`. Loops on invalid input up to `MAX_RETRIES`.
+ * Displays the message and a hint listing the placeholder and/or
+ * {@link InputPromptConfig.default | default}, reads a line, and optionally
+ * validates via {@link InputPromptConfig.validate | validate}. When a default
+ * is configured, an empty submission resolves to it without running validation;
+ * otherwise an empty submission is returned verbatim (and treated as "no answer"
+ * by the resolver). Loops on invalid input up to `MAX_RETRIES`.
  *
- * @param config - {@link InputPromptConfig} with message, optional placeholder and validator
+ * @param config - {@link InputPromptConfig} with message, optional placeholder, default, and validator
  * @param read - {@link ReadFn} for reading a line of user input
  * @param write - {@link WriteFn} for rendering prompt text and validation errors
- * @returns Resolved {@link PromptResult} — trimmed string value, or cancelled on EOF/exhausted retries
+ * @returns Resolved {@link PromptResult} — trimmed string value (or default), or cancelled on EOF/exhausted retries
  */
 async function promptInput(
 	config: InputPromptConfig,
@@ -343,14 +348,22 @@ async function promptInput(
 ): Promise<PromptResult> {
 	let retries = 0;
 
+	const hints: string[] = [];
+	if (config.placeholder !== undefined) hints.push(config.placeholder);
+	if (config.default !== undefined) hints.push(`default: ${config.default}`);
+	const hint = hints.length > 0 ? ` (${hints.join(', ')})` : '';
+
 	while (retries < MAX_RETRIES) {
-		const placeholder = config.placeholder !== undefined ? ` (${config.placeholder})` : '';
-		write(`${config.message}${placeholder}: `);
+		write(`${config.message}${hint}: `);
 
 		const line = await read();
 		if (line === null) return { answered: false };
 
 		const trimmed = line.trim();
+
+		if (trimmed === '' && config.default !== undefined) {
+			return { answered: true, value: config.default };
+		}
 
 		if (config.validate !== undefined) {
 			const result = config.validate(trimmed);

--- a/src/core/prompt/index.ts
+++ b/src/core/prompt/index.ts
@@ -361,8 +361,13 @@ async function promptInput(
 
 		const trimmed = line.trim();
 
-		if (trimmed === '' && config.default !== undefined) {
-			return { answered: true, value: config.default };
+		// An empty submission is the absence of a value, not a value to validate:
+		// resolve to the configured default, else return blank so the resolver can
+		// treat it as "no answer" and fall through to the flag's own default.
+		if (trimmed === '') {
+			return config.default !== undefined
+				? { answered: true, value: config.default }
+				: { answered: true, value: '' };
 		}
 
 		if (config.validate !== undefined) {

--- a/src/core/prompt/prompt.test.ts
+++ b/src/core/prompt/prompt.test.ts
@@ -376,6 +376,26 @@ describe('createTerminalPrompter', () => {
 			expect(validateCalls).toBe(0);
 		});
 
+		it('returns blank without validating when input is empty and no default is set', async () => {
+			// A required-style validator must not trap empty input: an empty answer is
+			// "no answer", returned verbatim so the resolver can fall through to the
+			// flag's own default instead of looping on validation.
+			let validateCalls = 0;
+			const { write, lines } = captureWrite();
+			const prompter = createTerminalPrompter(mockRead(['']), write);
+			const result = await prompter.promptOne({
+				kind: 'input',
+				message: 'Name',
+				validate: (v) => {
+					validateCalls += 1;
+					return v === '' ? 'Required' : true;
+				},
+			});
+			expect(result).toEqual({ answered: true, value: '' });
+			expect(validateCalls).toBe(0);
+			expect(lines.some((l) => l.includes('Required'))).toBe(false);
+		});
+
 		it('shows both placeholder and default in the hint', async () => {
 			const { write, lines } = captureWrite();
 			const prompter = createTerminalPrompter(mockRead(['x']), write);

--- a/src/core/prompt/prompt.test.ts
+++ b/src/core/prompt/prompt.test.ts
@@ -222,6 +222,40 @@ describe('createTerminalPrompter', () => {
 			expect(result).toEqual({ answered: false });
 			expect(lines.some((line) => line.includes('Too many invalid attempts'))).toBe(true);
 		});
+
+		it('defaults to true with (Y/n) hint when default is omitted', async () => {
+			const { write, lines } = captureWrite();
+			const prompter = createTerminalPrompter(mockRead(['']), write);
+			const result = await prompter.promptOne({ kind: 'confirm', message: 'q' });
+			expect(result).toEqual({ answered: true, value: true });
+			expect(lines[0]).toContain('(Y/n)');
+		});
+
+		it('shows (y/N) hint and empty resolves to false when default is false', async () => {
+			const { write, lines } = captureWrite();
+			const prompter = createTerminalPrompter(mockRead(['']), write);
+			const result = await prompter.promptOne({
+				kind: 'confirm',
+				message: 'Delete everything?',
+				default: false,
+			});
+			expect(result).toEqual({ answered: true, value: false });
+			expect(lines[0]).toContain('(y/N)');
+		});
+
+		it('shows (Y/n) hint when default is explicitly true', async () => {
+			const { write, lines } = captureWrite();
+			const prompter = createTerminalPrompter(mockRead(['']), write);
+			const result = await prompter.promptOne({ kind: 'confirm', message: 'q', default: true });
+			expect(result).toEqual({ answered: true, value: true });
+			expect(lines[0]).toContain('(Y/n)');
+		});
+
+		it('explicit y still overrides default: false', async () => {
+			const prompter = createTerminalPrompter(mockRead(['y']), captureWrite().write);
+			const result = await prompter.promptOne({ kind: 'confirm', message: 'q', default: false });
+			expect(result).toEqual({ answered: true, value: true });
+		});
 	});
 
 	// --- input
@@ -302,6 +336,70 @@ describe('createTerminalPrompter', () => {
 			});
 			expect(result).toEqual({ answered: false });
 			expect(lines.some((l) => l.includes('Too many invalid attempts'))).toBe(true);
+		});
+
+		it('resolves empty input to the configured default', async () => {
+			const { write, lines } = captureWrite();
+			const prompter = createTerminalPrompter(mockRead(['']), write);
+			const result = await prompter.promptOne({
+				kind: 'input',
+				message: 'Name',
+				default: 'Anonymous',
+			});
+			expect(result).toEqual({ answered: true, value: 'Anonymous' });
+			expect(lines[0]).toContain('default: Anonymous');
+		});
+
+		it('prefers typed input over the configured default', async () => {
+			const prompter = createTerminalPrompter(mockRead(['Alice']), captureWrite().write);
+			const result = await prompter.promptOne({
+				kind: 'input',
+				message: 'Name',
+				default: 'Anonymous',
+			});
+			expect(result).toEqual({ answered: true, value: 'Alice' });
+		});
+
+		it('does not run validate against the default on empty input', async () => {
+			let validateCalls = 0;
+			const prompter = createTerminalPrompter(mockRead(['']), captureWrite().write);
+			const result = await prompter.promptOne({
+				kind: 'input',
+				message: 'Name',
+				default: 'Anonymous',
+				validate: (v) => {
+					validateCalls += 1;
+					return v === '' ? 'Required' : true;
+				},
+			});
+			expect(result).toEqual({ answered: true, value: 'Anonymous' });
+			expect(validateCalls).toBe(0);
+		});
+
+		it('shows both placeholder and default in the hint', async () => {
+			const { write, lines } = captureWrite();
+			const prompter = createTerminalPrompter(mockRead(['x']), write);
+			await prompter.promptOne({
+				kind: 'input',
+				message: 'Name',
+				placeholder: 'your name',
+				default: 'Anonymous',
+			});
+			expect(lines[0]).toContain('your name');
+			expect(lines[0]).toContain('default: Anonymous');
+		});
+
+		it('still validates typed (non-empty) input when a default is set', async () => {
+			const { write, lines } = captureWrite();
+			const prompter = createTerminalPrompter(mockRead(['ab', 'abc']), write);
+			const result = await prompter.promptOne({
+				kind: 'input',
+				message: 'Code',
+				default: 'fallback',
+				validate: (v) => (v.length >= 3 ? true : 'Must be at least 3 chars'),
+			});
+			expect(result).toEqual({ answered: true, value: 'abc' });
+			expect(lines.some((l) => l.includes('Must be at least 3 chars'))).toBe(true);
 		});
 	});
 

--- a/src/core/resolve/flags.ts
+++ b/src/core/resolve/flags.ts
@@ -227,6 +227,20 @@ async function resolvePromptValueWithConfig(
 		return { ok: false, error: undefined };
 	}
 
+	// An empty/blank `input` answer with no prompt-level default is not a real
+	// answer — fall through (ok: false) so resolution reaches the flag's
+	// `.default()`. When a prompt-level default exists, the prompt engine has
+	// already applied it (so the value is the default, not blank), giving it
+	// precedence over the flag default.
+	if (
+		promptConfig.kind === 'input' &&
+		promptConfig.default === undefined &&
+		typeof result.value === 'string' &&
+		result.value.trim() === ''
+	) {
+		return { ok: false, error: undefined };
+	}
+
 	return coerceValue(flagName, { kind: 'prompt' }, result.value, schema);
 }
 

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -9,7 +9,12 @@
 import { describe, expect, it } from 'vitest';
 import { ValidationError } from '#internals/core/errors/index.ts';
 import type { ParseResult } from '#internals/core/parse/index.ts';
-import { createTestPrompter, PROMPT_CANCEL } from '#internals/core/prompt/index.ts';
+import {
+	createTerminalPrompter,
+	createTestPrompter,
+	PROMPT_CANCEL,
+	type ReadFn,
+} from '#internals/core/prompt/index.ts';
 import { FLAG_KINDS } from '#internals/core/schema/flag.ts';
 import type { CommandSchema } from '#internals/core/schema/index.ts';
 import { createSchema } from '#internals/core/schema/index.ts';
@@ -41,6 +46,17 @@ function makeParsed(overrides?: Partial<ParseResult>): ParseResult {
 		flags: {},
 		args: {},
 		...overrides,
+	};
+}
+
+/** A ReadFn that yields queued lines, then EOF (`null`). */
+function mockRead(lines: readonly (string | null)[]): ReadFn {
+	let index = 0;
+	return () => {
+		if (index >= lines.length) return Promise.resolve(null);
+		const line = lines[index];
+		index += 1;
+		return Promise.resolve(line ?? null);
 	};
 }
 
@@ -303,6 +319,105 @@ describe('resolve', () => {
 
 			const result = await resolve(schema, parsed, { prompter });
 			expect(result.flags).toEqual({ name: undefined });
+		});
+	});
+
+	// --- empty input + prompt/flag defaults (issues #34 / #35)
+
+	describe('empty input defaults', () => {
+		it('empty input with no prompt-default falls through to flag .default() (#35)', async () => {
+			const schema = makeSchema({
+				flags: {
+					name: createSchema('string', {
+						defaultValue: 'Anonymous',
+						prompt: { kind: 'input', message: 'Name' },
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			// Real terminal prompter; user presses Enter (empty line).
+			const prompter = createTerminalPrompter(mockRead(['']), () => {});
+
+			const result = await resolve(schema, parsed, { prompter });
+			expect(result.flags).toEqual({ name: 'Anonymous' });
+		});
+
+		it('empty test-prompter answer with no prompt-default falls through to flag .default()', async () => {
+			const schema = makeSchema({
+				flags: {
+					name: createSchema('string', {
+						defaultValue: 'Anonymous',
+						prompt: { kind: 'input', message: 'Name' },
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter(['']);
+
+			const result = await resolve(schema, parsed, { prompter });
+			expect(result.flags).toEqual({ name: 'Anonymous' });
+		});
+
+		it('blank (whitespace) input with no prompt-default falls through to flag .default()', async () => {
+			const schema = makeSchema({
+				flags: {
+					name: createSchema('string', {
+						defaultValue: 'Anonymous',
+						prompt: { kind: 'input', message: 'Name' },
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter(['   ']);
+
+			const result = await resolve(schema, parsed, { prompter });
+			expect(result.flags).toEqual({ name: 'Anonymous' });
+		});
+
+		it('empty input resolves to prompt-level default, overriding flag .default() (#34)', async () => {
+			const schema = makeSchema({
+				flags: {
+					name: createSchema('string', {
+						defaultValue: 'flag-default',
+						prompt: { kind: 'input', message: 'Name', default: 'prompt-default' },
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTerminalPrompter(mockRead(['']), () => {});
+
+			const result = await resolve(schema, parsed, { prompter });
+			expect(result.flags).toEqual({ name: 'prompt-default' });
+		});
+
+		it('empty input with no prompt-default and no flag default → optional flag undefined', async () => {
+			const schema = makeSchema({
+				flags: {
+					name: createSchema('string', {
+						prompt: { kind: 'input', message: 'Name' },
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTestPrompter(['']);
+
+			const result = await resolve(schema, parsed, { prompter });
+			expect(result.flags).toEqual({ name: undefined });
+		});
+
+		it('confirm prompt with default:false resolves empty Enter to false', async () => {
+			const schema = makeSchema({
+				flags: {
+					force: createSchema('boolean', {
+						prompt: { kind: 'confirm', message: 'Delete?', default: false },
+					}),
+				},
+			});
+			const parsed = makeParsed();
+			const prompter = createTerminalPrompter(mockRead(['']), () => {});
+
+			const result = await resolve(schema, parsed, { prompter });
+			expect(result.flags).toEqual({ force: false });
 		});
 	});
 

--- a/src/core/schema/prompt.ts
+++ b/src/core/schema/prompt.ts
@@ -36,6 +36,12 @@ interface PromptConfigBase {
 interface ConfirmPromptConfig extends PromptConfigBase {
 	/** Discriminator identifying this as a yes/no confirmation prompt. */
 	readonly kind: 'confirm';
+	/**
+	 * Value used when the user submits an empty line (presses Enter). Also
+	 * drives the displayed hint: `true` → `(Y/n)`, `false` → `(y/N)`.
+	 * @defaultValue `true`
+	 */
+	readonly default?: boolean;
 }
 
 /** Free-text input prompt — maps to `string` and `number` flags. Part of {@link PromptConfig}. */
@@ -44,6 +50,15 @@ interface InputPromptConfig extends PromptConfigBase {
 	readonly kind: 'input';
 	/** Placeholder text shown before user types (informational only). */
 	readonly placeholder?: string;
+	/**
+	 * Value used when the user submits an empty line (presses Enter), shown in
+	 * the hint as `(default: <value>)`. When set, an empty submission resolves
+	 * to this value without running {@link InputPromptConfig.validate | validate}.
+	 * When omitted, an empty submission is treated as "no answer" so resolution
+	 * falls through to the flag's `.default()`.
+	 * @defaultValue `undefined`
+	 */
+	readonly default?: string;
 	/**
 	 * Inline validation function. Return `true` if valid, or a string
 	 * error message if invalid. Called before coercion to flag kind.


### PR DESCRIPTION
## Summary

Closes the prompt-default cluster: prompts gain a `default`, and an empty input answer no longer clobbers a flag's `.default()`.

### #34 — prompt configs have no default value (feature)

- `ConfirmPromptConfig` gains `default?: boolean`; `InputPromptConfig` gains `default?: string`.
- `promptConfirm` derives its default from `config.default ?? true` (backward compatible), drives the `(Y/n)` vs `(y/N)` hint from it, and resolves an empty line to it — so a confirm can finally default to **No**.
- `promptInput` shows the default in the hint as `(default: <value>)` and resolves an empty submission to it (skipping `validate`).

### #35 — empty input answer overrides a flag's `.default()` with `""` (bug)

Previously an empty `input` answer was `{ answered: true, value: '' }`, which short-circuited the `schema.defaultValue` fallback, so `.default('Anonymous')` was never consulted. Now, in `resolve/flags.ts`, an empty/blank `input` answer **with no prompt-level default** is treated as "no answer" (`{ ok: false }`) and resolution falls through to the flag's `.default()` (or the standard missing-flag error for required flags).

### Precedence

Resolution chain stays CLI → env → config → prompt → default. Among defaults: **prompt-level `default` > flag `.default()`** — when a prompt-level default exists, the prompt engine applies it (the value is the default, not blank), so it wins.

## Tests

TDD: failing tests written first, then implementation.

- `prompt.test.ts`: confirm `(y/N)` + empty→false via `default:false`; input default applied on empty Enter; default shown in hint; `validate` not run against the default; typed input still validated.
- `resolve-prompt.test.ts`: empty input with no prompt-default falls through to flag `.default()` (the exact #35 repro, via the real terminal prompter); prompt-level default overrides flag default; empty + no defaults → optional `undefined`; confirm `default:false` resolves empty to `false`.

Full suite green (2563 tests); `typecheck`, `lint`, `format:check`, `meta-descriptions:check`, and `docs:build` all pass.

## Docs

`docs/guide/prompts.md` gains a "Prompt Defaults" section (twoslash-checked).

Closes #34
Closes #35