### PR TITLE
fix(testkit): honor CLI-level `--json` in argv and run prompt validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   with no discoverable args/flags. The default is now always rendered inline in that
   case, since suppressing it leaves no other path to its interface.
 
+### Fixed
+
+- **`runCommand()` now honors a CLI-level `--json` passed in `argv`** — the testkit
+  gained the same root-flag layer as the real CLI: a `--json` before the `--`
+  separator enables JSON mode and is stripped before parsing, instead of failing
+  with `Unknown flag --json` (exit 2). A literal `--json` after `--` still reaches
+  the command unchanged. The existing `{ jsonMode: true }` option keeps working —
+  either source enables JSON mode. Copying a real `mycli --json …` invocation into a
+  test now works verbatim.
+- **`createTestPrompter()` now runs an `input` prompt's `validate`** — a queued
+  string answer to an `input` prompt is validated exactly as the terminal prompter
+  does; an answer that fails validation is rejected as a cancellation rather than
+  injected verbatim as the resolved value, so prompt validation is integration-testable
+  through `runCommand(cmd, argv, { answers })`. Non-string answers stay verbatim so
+  downstream coercion paths remain testable.
+
 ## [2.5.0] - 2026-06-28
 
 ### Added

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -125,6 +125,27 @@ function includesBeforeSeparator(argv: readonly string[], token: string): boolea
 	return false;
 }
 
+/**
+ * Remove every occurrence of `token` that appears before the `--` end-of-options
+ * separator, leaving post-separator literals untouched.
+ *
+ * The strip counterpart to {@linkcode includesBeforeSeparator}: root-level flags
+ * (`--json`) are stripped before dispatch/parse so the command schema never sees
+ * them, but a literal after `--` (`-- --json`) must reach the command unchanged.
+ *
+ * @param argv - Raw argument strings.
+ * @param token - Exact flag token to strip (e.g. `--json`).
+ * @returns A new argv with pre-separator occurrences of `token` removed, or the
+ *   original reference when `token` does not occur before the separator.
+ */
+function stripBeforeSeparator(argv: readonly string[], token: string): readonly string[] {
+	const separatorIndex = argv.indexOf('--');
+	const head = separatorIndex === -1 ? argv : argv.slice(0, separatorIndex);
+	if (!head.includes(token)) return argv;
+	const filteredHead = head.filter((arg) => arg !== token);
+	return separatorIndex === -1 ? filteredHead : [...filteredHead, ...argv.slice(separatorIndex)];
+}
+
 // --- Parse result
 
 /**
@@ -711,4 +732,11 @@ function levenshtein(a: string, b: string): number {
 // --- Exports
 
 export type { ParseResult, Token };
-export { buildFlagLookup, flagExpectsValue, includesBeforeSeparator, parse, tokenize };
+export {
+	buildFlagLookup,
+	flagExpectsValue,
+	includesBeforeSeparator,
+	parse,
+	stripBeforeSeparator,
+	tokenize,
+};

--- a/src/core/prompt/AGENTS.md
+++ b/src/core/prompt/AGENTS.md
@@ -15,12 +15,12 @@ resolve layer.
 
 ## WHERE TO LOOK
 
-| Task                          | Location                               | Notes                                                    |
-| ----------------------------- | -------------------------------------- | -------------------------------------------------------- |
-| Change engine contract        | `PromptEngine`, `ResolvedPromptConfig` | select and multiselect choices are guaranteed non-empty  |
-| Change test prompts           | `createTestPrompter()`                 | queue-driven, supports malformed values and cancellation |
-| Change terminal prompts       | `createTerminalPrompter()`             | line-based read/write seam, no raw mode                  |
-| Change cancellation semantics | `PROMPT_CANCEL`                        | shared sentinel for test flows                           |
+| Task                          | Location                               | Notes                                                                             |
+| ----------------------------- | -------------------------------------- | --------------------------------------------------------------------------------- |
+| Change engine contract        | `PromptEngine`, `ResolvedPromptConfig` | select and multiselect choices are guaranteed non-empty                           |
+| Change test prompts           | `createTestPrompter()`                 | queue-driven; runs `input` `validate`, supports malformed values and cancellation |
+| Change terminal prompts       | `createTerminalPrompter()`             | line-based read/write seam, no raw mode                                           |
+| Change cancellation semantics | `PROMPT_CANCEL`                        | shared sentinel for test flows                                                    |
 
 ## CONVENTIONS
 
@@ -29,6 +29,8 @@ resolve layer.
 - Choice merging happens before the engine sees config; engines should not infer enum choices
   themselves
 - `TestAnswer` stays `unknown` so downstream validation paths can be tested
+- The test prompter mirrors the terminal `input` contract: a string answer is run through
+  `config.validate`, and a failing answer is rejected as a cancellation (not accepted verbatim)
 
 ## ANTI-PATTERNS
 

--- a/src/core/prompt/index.ts
+++ b/src/core/prompt/index.ts
@@ -148,9 +148,11 @@ const PROMPT_CANCEL: unique symbol = Symbol.for('dreamcli.prompt.cancel') as typ
  * A queued answer consumed by {@link createTestPrompter}.
  *
  * The test prompter returns these values exactly as provided; it does not
- * coerce or validate them. The normal resolution pipeline performs any later
- * type coercion, so tests can supply values in the same shapes real prompts
- * would yield:
+ * coerce them. The one exception mirrors the terminal prompter: a string answer
+ * to an `input` prompt is run through the prompt's `validate` function, and a
+ * failing answer is rejected as a cancellation (see {@link createTestPrompter}).
+ * The normal resolution pipeline performs any later type coercion, so tests can
+ * supply values in the same shapes real prompts would yield:
  *
  * - `string` for `input` and `select`
  * - `boolean` for `confirm`
@@ -186,6 +188,12 @@ interface TestPrompterOptions {
  * Pass `PROMPT_CANCEL` as an answer to simulate the user cancelling
  * that prompt.
  *
+ * For `input` prompts that declare a `validate` function, a string answer is
+ * validated just as the terminal prompter does. An answer that fails validation
+ * is rejected as a cancellation (`{ answered: false }`) — mirroring the terminal
+ * prompter exhausting its retries — so prompt validation is integration-testable
+ * via {@linkcode runCommand} rather than silently accepted as the resolved value.
+ *
  * @param answers - Ordered queue of answers. Use `PROMPT_CANCEL` for
  *   cancellation.
  * @param options - Controls behavior when the queue is exhausted.
@@ -206,7 +214,7 @@ function createTestPrompter(
 ): PromptEngine {
 	let index = 0;
 	return {
-		promptOne(): Promise<PromptResult> {
+		promptOne(config): Promise<PromptResult> {
 			if (index >= answers.length) {
 				if (options?.onExhausted === 'cancel') {
 					return Promise.resolve({ answered: false });
@@ -221,6 +229,20 @@ function createTestPrompter(
 			index += 1;
 			if (answer === PROMPT_CANCEL) {
 				return Promise.resolve({ answered: false });
+			}
+			// Mirror the terminal prompter's `input` contract: run `config.validate`
+			// against the queued answer so prompt validation is integration-testable
+			// (#36). A failing answer is rejected the way the terminal prompter
+			// rejects after exhausting its retries — as a cancellation — so the
+			// resolution pipeline surfaces it (required-flag error / default
+			// fallback) instead of injecting the invalid value verbatim. Only
+			// `input` prompts carry a validator and only string answers are the
+			// shape the terminal prompter would ever validate; non-string answers
+			// stay verbatim so downstream coercion paths remain testable.
+			if (config.kind === 'input' && config.validate !== undefined && typeof answer === 'string') {
+				if (config.validate(answer) !== true) {
+					return Promise.resolve({ answered: false });
+				}
 			}
 			return Promise.resolve({ answered: true, value: answer });
 		},

--- a/src/core/testkit/index.ts
+++ b/src/core/testkit/index.ts
@@ -17,6 +17,7 @@
 import { buildRunResult, executeCommand } from '#internals/core/execution/index.ts';
 import type { CapturedOutput } from '#internals/core/output/index.ts';
 import { createCaptureOutput } from '#internals/core/output/index.ts';
+import { includesBeforeSeparator, stripBeforeSeparator } from '#internals/core/parse/index.ts';
 import type { CommandMeta, Out, RunnableCommand } from '#internals/core/schema/command.ts';
 import type { RunOptions, RunResult } from '#internals/core/schema/run.ts';
 
@@ -30,16 +31,20 @@ import type { RunOptions, RunResult } from '#internals/core/schema/run.ts';
  * Run a command builder against the given argv with injected options.
  *
  * This is the testkit wrapper around the shared executor:
- * 1. Create or reuse capture output
- * 2. Build standalone schema/meta defaults when CLI dispatch did not
- * 3. Delegate parse -> resolve -> execute to the shared executor
- * 4. Return the structured result with captured buffers
+ * 1. Apply the CLI root-flag layer (detect/strip `--json`) so copied real argv works
+ * 2. Create or reuse capture output
+ * 3. Build standalone schema/meta defaults when CLI dispatch did not
+ * 4. Delegate parse -> resolve -> execute to the shared executor
+ * 5. Return the structured result with captured buffers
  *
  * Errors are normalized by the shared executor into structured {@linkcode RunResult}s
  * with appropriate exit codes. The function never throws.
  *
  * @param cmd - The command builder (must have an action handler)
- * @param argv - Raw argv strings (NOT including the command name itself)
+ * @param argv - Raw argv strings (NOT including the command name itself). A
+ *   CLI-level `--json` before the `--` separator is honored and stripped here,
+ *   just like the real CLI root — so `['--json']` enables JSON mode rather than
+ *   failing as an unknown flag. Equivalent to passing `{ jsonMode: true }`.
  * @param options - Injectable runtime state
  * @returns Structured run result with exit code and captured output
  */
@@ -48,6 +53,16 @@ async function runCommand(
 	argv: readonly string[],
 	options?: RunOptions,
 ): Promise<RunResult> {
+	// Root-flag layer mirroring `CLIBuilder.execute()`: `--json` is owned by the
+	// CLI root, not the command schema, so it would otherwise reach `parse()` as
+	// an unknown flag (#33). Detect it before the `--` separator (a literal
+	// `--json` positional after `--` survives), enable JSON mode, and strip it so
+	// the command schema never sees it. The explicit `options.jsonMode` keeps
+	// working — either source enables JSON mode.
+	const hasJsonFlag = includesBeforeSeparator(argv, '--json');
+	const jsonMode = hasJsonFlag || options?.jsonMode === true;
+	const effectiveArgv = hasJsonFlag ? stripBeforeSeparator(argv, '--json') : argv;
+
 	let out: Out;
 	let captured: CapturedOutput;
 	if (options?.out !== undefined) {
@@ -56,7 +71,7 @@ async function runCommand(
 	} else {
 		const captureOptions = {
 			...(options?.verbosity !== undefined ? { verbosity: options.verbosity } : {}),
-			...(options?.jsonMode !== undefined ? { jsonMode: options.jsonMode } : {}),
+			...(jsonMode ? { jsonMode } : {}),
 			...(options?.isTTY !== undefined ? { isTTY: options.isTTY } : {}),
 		};
 		[out, captured] = createCaptureOutput(
@@ -74,13 +89,22 @@ async function runCommand(
 		command: schema.name,
 	};
 
+	// Thread the effective JSON mode into the executor so its error path renders
+	// structured JSON, matching dispatch where the planner sets `options.jsonMode`.
+	const effectiveOptions: RunOptions | undefined =
+		options !== undefined
+			? { ...options, ...(jsonMode ? { jsonMode } : {}) }
+			: jsonMode
+				? { jsonMode }
+				: undefined;
+
 	const result = await executeCommand({
 		command: cmd,
-		argv,
+		argv: effectiveArgv,
 		out,
 		schema,
 		meta,
-		...(options !== undefined ? { options } : {}),
+		...(effectiveOptions !== undefined ? { options: effectiveOptions } : {}),
 	});
 
 	return buildRunResult(result, captured);

--- a/src/core/testkit/testkit-json.test.ts
+++ b/src/core/testkit/testkit-json.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { arg } from '#internals/core/schema/arg.ts';
 import { CLIError } from '#internals/core/errors/index.ts';
 import { command } from '#internals/core/schema/command.ts';
 import { flag } from '#internals/core/schema/flag.ts';
@@ -87,6 +88,100 @@ describe('runCommand', () => {
 			const json = await runCommand(cmd, [], { jsonMode: true });
 			expect(json.stdout).toEqual(['{"status":"ok","verbose":false}\n']);
 			expect(json.stderr).toEqual([]);
+		});
+	});
+
+	// --- CLI-level --json in argv (#33)
+
+	describe('argv --json flag', () => {
+		it('enables JSON mode when --json is passed in argv', async () => {
+			const cmd = statusCommand();
+
+			const result = await runCommand(cmd, ['--json']);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toEqual(['{"status":"ok","verbose":false}\n']);
+			expect(result.stderr).toEqual([]);
+		});
+
+		it('does not reject --json as an unknown flag', async () => {
+			const cmd = statusCommand();
+
+			const result = await runCommand(cmd, ['--json', '--verbose']);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toEqual(['{"status":"ok","verbose":true}\n']);
+		});
+
+		it('redirects log() to stderr when --json is in argv', async () => {
+			const cmd = mixedOutputCommand();
+
+			const result = await runCommand(cmd, ['--json']);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toEqual([
+				'{"step":1,"data":"processing"}\n',
+				'{"step":2,"data":"complete"}\n',
+			]);
+			expect(result.stderr).toEqual(['Starting...\n', 'Almost done\n']);
+		});
+
+		it('argv --json and { jsonMode: true } option both enable JSON mode', async () => {
+			const cmd = statusCommand();
+
+			const result = await runCommand(cmd, ['--json'], { jsonMode: true });
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toEqual(['{"status":"ok","verbose":false}\n']);
+		});
+
+		it('renders a thrown CLIError as JSON when --json is in argv', async () => {
+			const cmd = command('boom').action(() => {
+				throw new CLIError('Something went wrong', { code: 'CUSTOM_ERROR', exitCode: 3 });
+			});
+
+			const result = await runCommand(cmd, ['--json']);
+
+			expect(result.exitCode).toBe(3);
+			expect(result.stdout.length).toBe(1);
+			const parsed = JSON.parse(result.stdout[0] ?? '');
+			expect(parsed.error.code).toBe('CUSTOM_ERROR');
+		});
+
+		it('treats a literal --json after the -- separator as a positional, not JSON mode', async () => {
+			const cmd = command('echo')
+				.arg('value', arg.string())
+				.action(({ args, out }) => {
+					out.log(`value=${args.value}`);
+				});
+
+			const result = await runCommand(cmd, ['--', '--json']);
+
+			// Post-separator literal reaches the command unchanged; JSON mode off.
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toEqual(['value=--json\n']);
+		});
+
+		it('reserves root --json even when the command declares its own json flag', async () => {
+			// `--json` is a reserved root-level output flag: the planner and
+			// `.execute()` strip it before the command schema parses, so a command's
+			// own `--json` never reaches parse in the real CLI. runCommand mirrors
+			// that exactly — guarding on the command schema would make the harness
+			// diverge from real dispatch, defeating the point of #33.
+			const cmd = command('emit')
+				.flag('json', flag.boolean().describe('command-level json flag'))
+				.action(({ flags, out }) => {
+					out.log('progress');
+					out.json({ commandJsonFlag: flags.json });
+				});
+
+			const result = await runCommand(cmd, ['--json']);
+
+			expect(result.exitCode).toBe(0);
+			// --json reserved for output mode (json() → stdout, log() → stderr), and the
+			// command's own `json` flag never saw it — it stayed at its default.
+			expect(result.stdout).toEqual(['{"commandJsonFlag":false}\n']);
+			expect(result.stderr).toEqual(['progress\n']);
 		});
 	});
 

--- a/src/core/testkit/testkit-prompt.test.ts
+++ b/src/core/testkit/testkit-prompt.test.ts
@@ -253,6 +253,69 @@ describe('runCommand', () => {
 		});
 	});
 
+	// --- prompt validate (#36)
+
+	describe('prompt validate', () => {
+		/** Input-prompt flag whose validate requires an `@`. */
+		function emailCommand() {
+			return command('signup')
+				.flag(
+					'email',
+					flag
+						.string()
+						.required()
+						.prompt({
+							kind: 'input',
+							message: 'Email?',
+							validate: (value) => value.includes('@') || 'must be an email',
+						}),
+				)
+				.action(({ flags, out }) => {
+					out.log(`email=${flags.email}`);
+				});
+		}
+
+		it('accepts a queued answer that passes validate', async () => {
+			const result = await runCommand(emailCommand(), [], { answers: ['a@b.com'] });
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toEqual(['email=a@b.com\n']);
+		});
+
+		it('rejects a queued answer that fails validate (not accepted verbatim)', async () => {
+			const result = await runCommand(emailCommand(), [], { answers: ['not-an-email'] });
+
+			// Mirrors the terminal prompter: failed validation behaves like a
+			// cancellation, so resolution surfaces the required-flag error rather
+			// than injecting the invalid value.
+			expect(result.exitCode).toBe(2);
+			expect(result.error?.code).toBe('REQUIRED_FLAG');
+		});
+
+		it('falls back to default when a queued answer fails validate', async () => {
+			const cmd = command('signup')
+				.flag(
+					'email',
+					flag
+						.string()
+						.default('default@example.com')
+						.prompt({
+							kind: 'input',
+							message: 'Email?',
+							validate: (value) => value.includes('@') || 'must be an email',
+						}),
+				)
+				.action(({ flags, out }) => {
+					out.log(`email=${flags.email}`);
+				});
+
+			const result = await runCommand(cmd, [], { answers: ['nope'] });
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toEqual(['email=default@example.com\n']);
+		});
+	});
+
 	// --- answers with interactive resolver
 
 	describe('answers with interactive resolver', () => {


### PR DESCRIPTION
Fixes two testkit gaps where `runCommand` diverges from the real CLI root.

## #33 — `runCommand` rejects CLI-level `--json` in argv

`runCommand` executed commands in isolation with no root-flag layer, so a
`--json` in `argv` was parsed against the command's own schema and rejected as
`Unknown flag --json` (exit 2). JSON mode was only reachable via the separate
`{ jsonMode: true }` option, so copying a real `mycli --json …` invocation into
a test failed verbatim.

`runCommand` now mirrors `CLIBuilder.execute()`:

- detect `--json` before the `--` separator (`includesBeforeSeparator`),
- enable JSON mode, and
- strip it before `parse` so the command schema never sees it.

A literal `--json` after `--` still reaches the command unchanged (#28 parity).
The existing `{ jsonMode: true }` option keeps working — either source enables
JSON mode. The separator-aware strip is extracted as `stripBeforeSeparator`
(sibling of `includesBeforeSeparator`) and the planner now reuses it instead of
inlining the same logic.

## #36 — `createTestPrompter` bypasses prompt `validate`

`createTestPrompter`'s `promptOne` dropped the prompt `config`, so an `input`
prompt's `validate` was dead code from the testkit's perspective: an invalid
scripted answer was injected verbatim as the resolved value, and prompt
validation could not be integration-tested.

`promptOne` now receives `config` and runs `config.validate` on string answers
to `input` prompts, mirroring the terminal prompter. A failing answer is
rejected as a cancellation (`{ answered: false }`) — exactly as the terminal
prompter behaves when it exhausts its retries — so the resolution pipeline
surfaces it as a required-flag error or default fallback instead of accepting
the invalid value. Non-string answers stay verbatim so downstream coercion
paths remain testable.

## Tests / docs

- `testkit-json.test.ts`: argv `--json` enables JSON mode, isn't rejected as
  unknown, redirects `log()` to stderr, composes with the option, renders
  errors as JSON, and a post-`--` literal `--json` reaches the command.
- `testkit-prompt.test.ts`: a queued answer passing `validate` resolves; one
  failing `validate` is rejected (required → exit 2) or falls back to default.
- Updated `createTestPrompter`/`TestAnswer` TSDoc and `prompt/AGENTS.md` for the
  new validate contract.

Full suite green: 2557 tests across 76 files; typecheck, lint, and format all
pass.

Closes #33
Closes #36