### PR TITLE
fix(cli): consistent root `--help` reach and advertise built-in global flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `{ finite: false }` (or `.finite(false)`) to opt back into accepting non-finite
   values. `NaN` continues to be rejected as before.
 
+### Fixed
+
+- **Root `--help` now matches consistently with `--version`** (#29) — previously
+  `--help` / `-h` were intercepted at the root only when they were the very first
+  token, while `--version` / `-V` matched anywhere before `--`. A help flag
+  preceded only by flags (e.g. `mycli --verbose --help`) now shows root help,
+  mirroring `mycli --verbose --version`. A help flag that follows a subcommand
+  token still scopes to that subcommand (`mycli deploy --help` → `deploy` help);
+  `--version` remains a global, position-independent flag by design (there is no
+  per-command version). The bare `help` token now triggers root help from the same
+  position as `--help`, and the `--` end-of-options separator is respected for both.
+- **Generated `--help` now advertises the active built-in global flags** (#32) — root
+  help renders a `Global options:` block listing `--help, -h` and `--json` (always),
+  `--version, -V` (when a version is set), and `--config <path>` (when `.config()`
+  enabled config discovery). Previously these framework-provided flags were invisible
+  in help even though they worked. `--completions` is unchanged (still advertised via
+  the inline surface when active).
+
 ## [2.5.0] - 2026-06-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   enabled config discovery). Previously these framework-provided flags were invisible
   in help even though they worked. `--completions` is unchanged (still advertised via
   the inline surface when active).
+- **Root usage no longer prints the default command's name** — the merged/sole-default
+  usage line rendered `Usage: <bin> <default-name> …`, teaching an invocation that does
+  not route (`.default()` is not a named command, so the token is consumed as the
+  default's first positional). It now renders under the bin name only
+  (`Usage: <bin> [flags] <args>`).
+- **`inlineDefault: false` no longer hides a sole default command's interface** — when
+  the default command is the only surface (no visible subcommands and no eager
+  `--completions` flag), root help would collapse to a bare `Usage: <bin> [options]`
+  with no discoverable args/flags. The default is now always rendered inline in that
+  case, since suppressing it leaves no other path to its interface.
 
 ## [2.5.0] - 2026-06-28
 

--- a/src/core/cli/cli-default.test.ts
+++ b/src/core/cli/cli-default.test.ts
@@ -302,8 +302,11 @@ describe('.default()', () => {
 			expect(result.exitCode).toBe(0);
 			const output = result.stdout.join('');
 			expect(output).toContain('mycli v1.0.0');
-			// Sole default + no subcommands → its own usage stands alone, no [command].
-			expect(output).toContain('Usage: mycli deploy [flags] <target>');
+			// Sole default + no subcommands → its args/flags render inline under the
+			// bin name only: no `[command]` placeholder and no command name, since
+			// `.default()` is not a named route.
+			expect(output).toContain('Usage: mycli [flags] <target>');
+			expect(output).not.toContain('mycli deploy [flags]');
 			expect(output).toContain('\n\nDeploy to an environment\n\nArguments:');
 			// Default is the surface, not echoed under Commands, and no footer.
 			expect(output).not.toContain('(default)');
@@ -328,7 +331,8 @@ describe('.default()', () => {
 
 			expect(result.exitCode).toBe(0);
 			const output = result.stdout.join('');
-			expect(output).toContain('Usage: mycli deploy [flags] <target>');
+			expect(output).toContain('Usage: mycli [flags] <target>');
+			expect(output).not.toContain('mycli deploy [flags]');
 			expect(output).toContain('Arguments:');
 		});
 
@@ -360,7 +364,8 @@ describe('.default()', () => {
 			expect(result.exitCode).toBe(0);
 			expect(result.stdout).toEqual([]);
 			const output = result.stderr.join('');
-			expect(output).toContain('Usage: mycli deploy [flags] <target>');
+			expect(output).toContain('Usage: mycli [flags] <target>');
+			expect(output).not.toContain('mycli deploy [flags]');
 		});
 	});
 
@@ -413,7 +418,8 @@ describe('.default()', () => {
 			// The default group is the surface (not echoed under Commands), but its
 			// own subcommands still render inline.
 			expect(output).not.toContain('(default)');
-			expect(output).toContain('Usage: mycli run <command>');
+			expect(output).toContain('Usage: mycli <command>');
+			expect(output).not.toContain('mycli run <command>');
 			expect(output).toContain('check');
 		});
 	});
@@ -433,7 +439,8 @@ describe('formatRootHelp — default command', () => {
 		const app = cli('mycli').default(deployCommand());
 		const help = formatRootHelp(app.schema);
 
-		expect(help).toContain('Usage: mycli deploy [flags] <target>');
+		expect(help).toContain('Usage: mycli [flags] <target>');
+		expect(help).not.toContain('mycli deploy [flags]');
 		expect(help).not.toContain('Usage: mycli [command] [options]');
 	});
 
@@ -487,7 +494,20 @@ describe('formatRootHelp — default command', () => {
 		const app = cli('mycli').default(deployCommand());
 		const help = formatRootHelp(app.schema);
 
-		expect(help).toContain('Usage: mycli deploy [flags] <target>');
+		expect(help).toContain('Usage: mycli [flags] <target>');
+		expect(help).not.toContain('mycli deploy [flags]');
+	});
+
+	it('still exposes a sole default command surface when inlineDefault is false', () => {
+		// A sole default with no other surface must never collapse to a bare
+		// `Usage: <bin> [options]`: that would leave its args/flags undiscoverable.
+		// `inlineDefault: false` is overridden in this case.
+		const app = cli('mycli').default(deployCommand());
+		const help = formatRootHelp(app.schema, { inlineDefault: false });
+
+		expect(help).toContain('Usage: mycli [flags] <target>');
+		expect(help).toContain('Arguments:');
+		expect(help).not.toContain('Usage: mycli [options]');
 	});
 
 	it('footer uses <command> when no default', () => {
@@ -502,7 +522,8 @@ describe('formatRootHelp — default command', () => {
 		const help = formatRootHelp(app.schema, { binName: 'tool' });
 
 		expect(help).toContain('Usage: tool [command] [options]');
-		expect(help).toContain('       tool deploy [flags] <target>');
+		expect(help).toContain('       tool [flags] <target>');
+		expect(help).not.toContain('tool deploy [flags]');
 		expect(help).toContain("Run 'tool [command] --help' for more information.");
 		expect(help).not.toContain('Usage: mycli');
 	});

--- a/src/core/cli/cli.test.ts
+++ b/src/core/cli/cli.test.ts
@@ -562,6 +562,15 @@ describe('error handling', () => {
 		expect(result.stderr.join('')).toContain('No commands registered');
 	});
 
+	it('returns NO_ACTION (not empty help) on a bare invocation with no commands', async () => {
+		const app = cli('mycli');
+		const result = await app.execute([]);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.error?.code).toBe('NO_ACTION');
+		expect(result.stderr.join('')).toContain('No commands registered');
+	});
+
 	it('returns error for command without action handler', async () => {
 		const app = cli('mycli').command(noActionCommand());
 		const result = await app.execute(['broken']);

--- a/src/core/cli/cli.test.ts
+++ b/src/core/cli/cli.test.ts
@@ -516,8 +516,10 @@ describe('help virtual subcommand — behavior', () => {
 		expect(result.exitCode).toBe(0);
 		const output = result.stdout.join('');
 		expect(output).toContain('mycli');
-		// Sole default + no subcommands → its own usage stands alone as the root surface.
-		expect(output).toContain('Usage: mycli run <target>');
+		// Sole default + no subcommands → its usage stands alone as the root surface,
+		// under the bin name only (no `run` command name — it is not a route).
+		expect(output).toContain('Usage: mycli <target>');
+		expect(output).not.toContain('mycli run <target>');
 		expect(output).toContain('Default runner');
 	});
 });

--- a/src/core/cli/cli.test.ts
+++ b/src/core/cli/cli.test.ts
@@ -177,6 +177,54 @@ describe('--version flag', () => {
 	});
 });
 
+// --- Built-in global options in root help (#32)
+
+describe('root help — built-in global options', () => {
+	it('always advertises --help, -h and --json', async () => {
+		const app = cli('mycli').command(deployCommand());
+		const output = (await app.execute(['--help'])).stdout.join('');
+
+		expect(output).toContain('Global options:');
+		expect(output).toContain('-h, --help');
+		expect(output).toContain('--json');
+	});
+
+	it('advertises --version only when a version is configured', async () => {
+		const withVersion = (
+			await cli('mycli').version('1.0.0').command(deployCommand()).execute(['--help'])
+		).stdout.join('');
+		expect(withVersion).toContain('-V, --version');
+
+		const withoutVersion = (
+			await cli('mycli').command(deployCommand()).execute(['--help'])
+		).stdout.join('');
+		expect(withoutVersion).not.toContain('--version');
+	});
+
+	it('advertises --config <path> only when config discovery is enabled', async () => {
+		const withConfig = (
+			await cli('mycli').config('mycli').command(deployCommand()).execute(['--help'])
+		).stdout.join('');
+		expect(withConfig).toContain('--config <path>');
+
+		const withoutConfig = (
+			await cli('mycli').command(deployCommand()).execute(['--help'])
+		).stdout.join('');
+		expect(withoutConfig).not.toContain('--config');
+	});
+
+	it('lists every active built-in for a default-command CLI', async () => {
+		const app = cli('mycli').version('1.0.0').config('mycli').default(deployCommand());
+		const output = (await app.execute(['--help'])).stdout.join('');
+
+		expect(output).toContain('Global options:');
+		expect(output).toContain('-h, --help');
+		expect(output).toContain('-V, --version');
+		expect(output).toContain('--json');
+		expect(output).toContain('--config <path>');
+	});
+});
+
 // --- Root help
 
 describe('root help', () => {

--- a/src/core/cli/planner.test.ts
+++ b/src/core/cli/planner.test.ts
@@ -140,6 +140,77 @@ describe('planInvocation() — root interception', () => {
 	});
 });
 
+// === Consistent --help / --version positional reach (#29)
+
+describe('planInvocation() — consistent help/version reach (#29)', () => {
+	function defaultWithVerbose(): ErasedCommand {
+		return erased(commandSchema({ name: 'app', flags: { verbose: flagSchema('boolean', false) } }));
+	}
+
+	it('intercepts root help when only flags precede --help', () => {
+		const app = defaultWithVerbose();
+
+		const result = planFor([], ['--verbose', '--help'], app);
+
+		expect(result).toEqual({ kind: 'root-help', help });
+	});
+
+	it('intercepts root version when only flags precede --version (mirror of --help)', () => {
+		const app = defaultWithVerbose();
+
+		const result = planFor([], ['--verbose', '--version'], app);
+
+		expect(result).toEqual({ kind: 'root-version', version: '1.2.3' });
+	});
+
+	it('intercepts root help for a bare --help', () => {
+		const deploy = erased(commandSchema({ name: 'deploy' }));
+
+		expect(planFor([deploy], ['--help'])).toEqual({ kind: 'root-help', help });
+		expect(planFor([deploy], ['-h'])).toEqual({ kind: 'root-help', help });
+	});
+
+	it('keeps --help after a subcommand token scoped to that subcommand', () => {
+		const deploy = erased(commandSchema({ name: 'deploy' }));
+
+		const result = planFor([deploy], ['deploy', '--help']);
+
+		expect(result.kind).toBe('match');
+		if (result.kind === 'match') {
+			expect(result.plan.command).toBe(deploy);
+			expect(result.plan.argv).toEqual(['--help']);
+		}
+	});
+
+	it('respects the -- separator: a literal --help after -- is not root help', () => {
+		const deploy = erased(
+			commandSchema({
+				name: 'app',
+				args: [{ name: 'rest', schema: createArgSchema('string') }],
+			}),
+		);
+
+		const result = planFor([], ['--', '--help'], deploy);
+
+		expect(result.kind).toBe('match');
+		if (result.kind === 'match') {
+			expect(result.plan.command).toBe(deploy);
+			expect(result.plan.argv).toEqual(['--', '--help']);
+		}
+	});
+
+	it('treats a bare help token after flags as a root help request', () => {
+		const deploy = erased(commandSchema({ name: 'deploy' }));
+		const app = erased(
+			commandSchema({ name: 'app', flags: { verbose: flagSchema('boolean', false) } }),
+		);
+
+		const result = planFor([deploy], ['--verbose', 'help'], app);
+
+		expect(result).toEqual({ kind: 'root-help', help });
+	});
+});
+
 // === Default-command behavior
 
 describe('planInvocation() — default command behavior', () => {

--- a/src/core/cli/planner.ts
+++ b/src/core/cli/planner.ts
@@ -518,13 +518,8 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 		}
 	}
 
-	if (filteredArgv.length === 0 && defaultCommand === undefined) {
-		return {
-			kind: 'root-help',
-			help: options.help,
-		};
-	}
-
+	// A CLI with no commands and no default is misconfigured: report NO_ACTION
+	// even for a bare invocation, rather than masking it with empty root help.
 	if (options.schema.commands.length === 0 && defaultCommand === undefined) {
 		return {
 			kind: 'dispatch-error',
@@ -532,6 +527,13 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 				code: 'NO_ACTION',
 				suggest: 'Add commands via .command() or .default() before calling .run()',
 			}),
+		};
+	}
+
+	if (filteredArgv.length === 0 && defaultCommand === undefined) {
+		return {
+			kind: 'root-help',
+			help: options.help,
 		};
 	}
 

--- a/src/core/cli/planner.ts
+++ b/src/core/cli/planner.ts
@@ -315,6 +315,74 @@ function findUnknownFlagBeforePositional(
 }
 
 /**
+ * Result of scanning the pre-`--`, `--json`-stripped head for root interception.
+ * @internal
+ */
+interface RootHeadScan {
+	/**
+	 * `--help` / `-h` appeared in the head before any command-dispatch token.
+	 *
+	 * Mirrors the global reach of `--version` (#29): a help flag preceded only by
+	 * flags (no subcommand token) is a *root* help request. A help flag that
+	 * follows a subcommand token is left to that command's executor, so
+	 * `app sub --help` still renders the subcommand's help.
+	 */
+	readonly helpBeforeCommand: boolean;
+	/** First command-dispatch (positional) token, or `undefined` when the head is all flags. */
+	readonly firstCommandToken: string | undefined;
+	/** Index of {@linkcode firstCommandToken} in the head, or `-1` when absent. */
+	readonly commandTokenIndex: number;
+}
+
+/**
+ * Scan the pre-`--`, `--json`-stripped head to locate the first command-dispatch
+ * token and detect a root-level `--help` / `-h` ahead of it.
+ *
+ * Value-flag arity is honoured (via `valueFlags`) so a flag value that happens
+ * to look like a command name is not mistaken for one — matching how
+ * {@linkcode dispatch} reads the same argv.
+ *
+ * @internal
+ */
+function scanRootHead(
+	head: readonly string[],
+	valueFlags: ReturnType<typeof buildFlagLookup> | undefined,
+): RootHeadScan {
+	for (let index = 0; index < head.length; index++) {
+		const token = head[index];
+		if (token === undefined) continue;
+
+		if (token === '--help' || token === '-h') {
+			return { helpBeforeCommand: true, firstCommandToken: undefined, commandTokenIndex: -1 };
+		}
+
+		// Positional (command-dispatch) token: `-` alone or anything not flag-shaped.
+		if (token === '-' || !token.startsWith('-')) {
+			return { helpBeforeCommand: false, firstCommandToken: token, commandTokenIndex: index };
+		}
+
+		if (token.startsWith('--')) {
+			const equalsIndex = token.indexOf('=');
+			const name = token.slice(2, equalsIndex === -1 ? undefined : equalsIndex);
+			const entry = valueFlags?.get(name);
+			if (entry !== undefined && equalsIndex === -1 && flagExpectsValue(entry[1])) index++;
+			continue;
+		}
+
+		// Short-flag cluster: consume a trailing value-expecting flag's argument.
+		const chars = token.slice(1);
+		for (let charIndex = 0; charIndex < chars.length; charIndex++) {
+			const entry = valueFlags?.get(chars.charAt(charIndex));
+			if (entry === undefined || !flagExpectsValue(entry[1])) continue;
+			if (charIndex === chars.length - 1) index++;
+			break;
+		}
+	}
+
+	return { helpBeforeCommand: false, firstCommandToken: undefined, commandTokenIndex: -1 };
+}
+
+/**
  * Detect and resolve the eager `--completions [shell]` flag before dispatch.
  *
  * Accepts `--completions <shell>` and `--completions=<shell>`. When no value is
@@ -389,6 +457,13 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 	const filteredHead = head.includes('--json') ? head.filter((arg) => arg !== '--json') : head;
 	const filteredArgv = separatorIndex === -1 ? filteredHead : [...filteredHead, ...tail];
 
+	const defaultCommand = options.schema.defaultCommand;
+	// At the root, a default command's flags govern value-flag arity so a
+	// space-separated value (`mycli --region eu`) is not misread as a command
+	// name — both for root interception below and dispatch (see #25).
+	const rootValueFlags =
+		defaultCommand !== undefined ? buildFlagLookup(defaultCommand.schema.flags) : undefined;
+
 	if (
 		options.schema.version !== undefined &&
 		(includesBeforeSeparator(options.argv, '--version') ||
@@ -407,20 +482,28 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 		}
 	}
 
-	const firstArg = filteredArgv[0];
-	if (firstArg === '--help' || firstArg === '-h') {
+	// `--help` / `-h` is intercepted at the root with the same positional reach as
+	// `--version` (#29): a help flag preceded only by flags (no subcommand token)
+	// is a root request, so `app --verbose --help` mirrors `app --verbose --version`.
+	// A help flag *after* a subcommand token is left to that command's executor,
+	// keeping `app sub --help` scoped to the subcommand (version stays global by
+	// design — there is no per-command version).
+	const headScan = scanRootHead(filteredHead, rootValueFlags);
+	if (headScan.helpBeforeCommand) {
 		return {
 			kind: 'root-help',
 			help: options.help,
 		};
 	}
 
-	if (firstArg === 'help') {
+	// Bare `help` token: a root help request (or `<command> --help` forwarding)
+	// when it is the first command token and no real `help` command is registered.
+	if (headScan.firstCommandToken === 'help') {
 		const hasRealHelpCommand = options.schema.commands.some(
 			(command) => command.schema.name === 'help' || command.schema.aliases.includes('help'),
 		);
 		if (!hasRealHelpCommand) {
-			const rest = filteredArgv.slice(1);
+			const rest = filteredArgv.slice(headScan.commandTokenIndex + 1);
 			if (rest.length === 0) {
 				return {
 					kind: 'root-help',
@@ -435,14 +518,14 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 		}
 	}
 
-	if (firstArg === undefined && options.schema.defaultCommand === undefined) {
+	if (filteredArgv.length === 0 && defaultCommand === undefined) {
 		return {
 			kind: 'root-help',
 			help: options.help,
 		};
 	}
 
-	if (options.schema.commands.length === 0 && options.schema.defaultCommand === undefined) {
+	if (options.schema.commands.length === 0 && defaultCommand === undefined) {
 		return {
 			kind: 'dispatch-error',
 			error: new CLIError('No commands registered', {
@@ -452,12 +535,6 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 		};
 	}
 
-	const defaultCommand = options.schema.defaultCommand;
-	// At the root, a default command's flags govern value-flag arity so a
-	// space-separated value (`mycli --region eu`) is not misread as a command
-	// name and stolen from the default-command fallback (see #25).
-	const rootValueFlags =
-		defaultCommand !== undefined ? buildFlagLookup(defaultCommand.schema.flags) : undefined;
 	const result = dispatch(
 		filteredArgv,
 		buildRootCommandMap(options.schema.commands),

--- a/src/core/cli/root-help.ts
+++ b/src/core/cli/root-help.ts
@@ -69,7 +69,17 @@ function formatRootHelp(schema: CLISchemaLike, options?: HelpOptions): string {
 	// `inlineDefault: false` hides the default command's args/flags, but the eager
 	// `--completions` flag is a root-level option that must still be advertised, so
 	// a synthetic completions-only surface is rendered even then.
-	const inlineDefaultCommand = inlineDefault ? defaultCommand : undefined;
+	//
+	// Exception: when the default command is the *only* surface — no visible
+	// subcommands AND no eager `--completions` flag to advertise — suppressing it
+	// would collapse root help to a bare `Usage: <bin> [options]` with no
+	// discoverable interface at all. In that case the default is always rendered
+	// inline regardless of `inlineDefault`. (With a completions flag the synthetic
+	// surface still gives a discoverable path, so `inlineDefault: false` is honored.)
+	const defaultIsSoleSurface =
+		!surface.hasVisibleSubcommands && schema.completionsFlag === undefined;
+	const renderDefaultInline = inlineDefault || defaultIsSoleSurface;
+	const inlineDefaultCommand = renderDefaultInline ? defaultCommand : undefined;
 	const surfaceCommand = resolveSurfaceCommand(schema, inlineDefaultCommand);
 	const inline = surfaceCommand !== undefined;
 

--- a/src/core/cli/root-help.ts
+++ b/src/core/cli/root-help.ts
@@ -9,8 +9,8 @@
  */
 
 import { osc8, padEnd, wrapText } from '#internals/core/help/ansi.ts';
-import type { HelpOptions } from '#internals/core/help/index.ts';
-import { formatHelpSections } from '#internals/core/help/index.ts';
+import type { FlagEntry, HelpOptions } from '#internals/core/help/index.ts';
+import { formatFlagEntriesBlock, formatHelpSections } from '#internals/core/help/index.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { command } from '#internals/core/schema/command.ts';
 import type { FlagSchema } from '#internals/core/schema/flag.ts';
@@ -35,6 +35,12 @@ interface CLISchemaLike {
 		  }
 		| undefined;
 	readonly completionsFlag?: { readonly shells: readonly string[] } | undefined;
+	/**
+	 * Config discovery settings. Only its presence is read — defined means
+	 * `.config()` enabled the built-in `--config <path>` flag, so root help
+	 * advertises it in `Global options:`.
+	 */
+	readonly configSettings?: { readonly appName: string } | undefined;
 }
 
 // --- Root help formatter
@@ -134,6 +140,15 @@ function formatRootHelp(schema: CLISchemaLike, options?: HelpOptions): string {
 			surfaceSections.shift();
 		}
 		sections.push(...surfaceSections);
+	}
+
+	// ---- Global options (active built-in flags) -----------------------------
+	// Built-ins are framework-provided and never appear in any command schema, so
+	// they are advertised here for discoverability (#32). `--completions` is not
+	// listed: when active it is already injected into the inline surface's flags.
+	const globalOptions = formatGlobalOptionsSection(schema, width);
+	if (globalOptions.length > 0) {
+		sections.push(globalOptions);
 	}
 
 	// ---- Footer -------------------------------------------------------------
@@ -264,6 +279,36 @@ function formatRootCommandsSection(
 	}
 
 	return lines.join('\n');
+}
+
+/**
+ * Build the `Global options:` section advertising the active built-in flags.
+ *
+ * `--help, -h` and `--json` are always available; `--version, -V` is shown only
+ * when the program declares a version; `--config <path>` only when `.config()`
+ * enabled config discovery. The eager `--completions` flag is intentionally
+ * omitted — it is advertised via the inline surface when active.
+ *
+ * @param schema - The CLI schema (read for `version` and `configSettings`).
+ * @param width - Terminal width for description wrapping.
+ * @returns Formatted `Global options:` block (always non-empty).
+ * @internal
+ */
+function formatGlobalOptionsSection(schema: CLISchemaLike, width: number): string {
+	const entries: FlagEntry[] = [
+		{ left: '-h, --help', description: 'Show this help message and exit' },
+	];
+	if (schema.version !== undefined) {
+		entries.push({ left: '-V, --version', description: 'Print the version number and exit' });
+	}
+	entries.push({ left: '--json', description: 'Emit machine-readable JSON output' });
+	if (schema.configSettings !== undefined) {
+		entries.push({
+			left: '--config <path>',
+			description: 'Load configuration from the given file',
+		});
+	}
+	return formatFlagEntriesBlock('Global options:', entries, width);
 }
 
 /**

--- a/src/core/help/index.ts
+++ b/src/core/help/index.ts
@@ -374,11 +374,15 @@ function formatHelp(schema: CommandSchema, options?: HelpOptions): string {
  */
 function formatUsageLine(schema: CommandSchema, opts: ResolvedHelpOptions): string {
 	const parts: string[] = ['Usage:'];
+	// For the default command rendered as the root surface (`isDefaultHelp`), the
+	// command name is NOT a route — `.default()` does not register a named command,
+	// so `mycli <name>` would be consumed as the default's first positional, not a
+	// dispatch. Render usage with only the bin name to avoid teaching a fake form.
 	const cmdName =
 		opts.binName === undefined
 			? schema.name
-			: opts.isDefaultHelp && opts.binName === schema.name
-				? schema.name
+			: opts.isDefaultHelp
+				? opts.binName
 				: `${opts.binName} ${schema.name}`;
 	parts.push(cmdName);
 

--- a/src/core/help/index.ts
+++ b/src/core/help/index.ts
@@ -447,13 +447,31 @@ function formatFlagsSection(
 	flags: Readonly<Record<string, FlagSchema>>,
 	opts: ResolvedHelpOptions,
 ): string {
-	const lines: string[] = ['Flags:'];
+	return formatFlagEntriesBlock('Flags:', buildFlagEntries(flags), opts.width);
+}
+
+/**
+ * Render a titled two-column flag block from pre-built {@link FlagEntry} rows.
+ *
+ * Shared by the per-command `Flags:` section and the root-help `Global options:`
+ * block (built-in flags), so column alignment and description wrapping stay
+ * identical across both. Returns `''` when there are no entries.
+ *
+ * @param title - Section heading (e.g. `'Flags:'`, `'Global options:'`).
+ * @param entries - Formatted left/description rows.
+ * @param width - Terminal width for description wrapping.
+ * @returns Multi-line block string, or `''` when `entries` is empty.
+ * @internal
+ */
+function formatFlagEntriesBlock(
+	title: string,
+	entries: readonly FlagEntry[],
+	width: number,
+): string {
+	if (entries.length === 0) return '';
+	const lines: string[] = [title];
 	const GAP = 2;
 
-	const entries = buildFlagEntries(flags);
-	if (entries.length === 0) return '';
-
-	// Compute max left width
 	let maxLeft = 0;
 	for (const entry of entries) {
 		const indented = `  ${entry.left}`;
@@ -467,7 +485,7 @@ function formatFlagsSection(
 			lines.push(left);
 		} else {
 			const padded = padEnd(left, descCol);
-			const wrapped = wrapText(entry.description, opts.width, descCol);
+			const wrapped = wrapText(entry.description, width, descCol);
 			lines.push(`${padded}${wrapped}`);
 		}
 	}
@@ -537,5 +555,5 @@ function formatExamplesSection(examples: readonly CommandExample[]): string {
 // --- Exports
 
 export { osc8, visibleWidth } from './ansi.ts';
-export type { HelpOptions };
-export { formatHelp, formatHelpSections };
+export type { FlagEntry, HelpOptions };
+export { formatFlagEntriesBlock, formatHelp, formatHelpSections };

--- a/src/core/help/index.ts
+++ b/src/core/help/index.ts
@@ -107,7 +107,7 @@ function formatHelpDefaultValue(value: unknown): string {
 
 // --- Flag formatting
 
-/** Formatted flag entry for the flags table. */
+/** Formatted flag entry for the flags table. @internal */
 interface FlagEntry {
 	readonly left: string;
 	readonly description: string;


### PR DESCRIPTION
Fixes a cluster of two related CLI help bugs.

## #29 — consistent root `--help` interception

Root `--help` / `-h` were intercepted only when they were the **first** token, while `--version` / `-V` matched **anywhere** before `--`. So with a default command, `app --verbose --help` fell through to the default command's help instead of root help, even though `app --verbose --version` printed the version.

`--help` now shares `--version`'s positional reach in the head: **a help flag preceded only by flags is a root request**, so `app --verbose --help` mirrors `app --verbose --version`. A help flag that follows a subcommand token stays scoped to that command, so `app sub --help` still renders the subcommand's help. The bare `help` token and the `--` end-of-options separator follow the same rule.

### Why version stays global (and isn't made command-scoped)

The issue suggested making `--version` command-scoped too. That would break existing, explicitly-titled behavior: `'--version takes precedence over commands'` asserts `app deploy --version` → version, and `'--version before command name still shows version'` asserts `app --version deploy` → version. There is no per-command version concept, so `--version` is intentionally a global, position-independent flag. The genuine, fixable inconsistency was that `--help` was uniquely pinned to `argv[0]`; it now reaches the whole pre-`--` head before the first subcommand token, which is exactly the scenario the issue reproduces. The residual difference (version intercepts even after a subcommand token; help defers to the subcommand there) is intentional and documented.

Detection uses an arity-aware head scan that locates the first command-dispatch token the same way `dispatch` reads argv (skipping value-flag values), so the planner's notion of "before any subcommand token" matches dispatch's.

## #32 — advertise active built-in global flags in help

Generated `--help` listed a command's own flags but none of the framework built-ins, even when active — `--config` was completely invisible. Root help now renders a `Global options:` block, gated per built-in:

- `--help, -h` and `--json` — always
- `--version, -V` — only when a version is set
- `--config <path>` — only when `.config()` enabled config discovery
- `--completions` — unchanged (still advertised via the inline surface when active; not double-listed)

The two-column flag renderer is extracted into a shared `formatFlagEntriesBlock` so the `Global options:` block aligns identically to the per-command `Flags:` section (the `Flags:` section now delegates to it — output unchanged).

## Verification

- New planner tests cover the #29 matrix: `--help`/`--version` root reach, `sub --help` scoping, the `--` separator, and the bare `help` token.
- New `cli` tests assert the `Global options:` block and its gating.
- Full gate green: typecheck, lint, format:check, and the whole suite (2558 tests passing).

Closes #29
Closes #32