### PR TITLE
feat: compile-time array-element narrowing + JSON help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **`flag.array()` rejects non-element builders at compile time** — the
+  element position now requires a builder carrying only value-shape settings
+  (kind, constraints, enum values, `parseFn`). Flag-level modifiers
+  (`.alias()`, `.env()`, `.default()`, `.prompt()`, `.describe()`, …) were
+  silently ignored on elements before; passing them is now a type error, as
+  is `flag.path()` / `flag.count()` / `flag.keyValue()` / nested arrays.
+  Type-level only — no runtime behavior change.
+
 ## [3.0.0-rc.8] - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **JSON help** — `--help` with `--json` emits the CLI's definition document
+  (the `generateSchema()` shape, `$schema`-tagged) on stdout instead of help
+  text, for root help, `help <command>`, and `<command> --help` alike. New
+  `generateCommandSchema(schema)` export produces the per-command document.
+
 ### Changed
+
+- **`generateSchema()` emits the default command's full definition** — the
+  `defaultCommand` field was a name-only string reference while the default
+  command's flags/args appeared nowhere in the document (it never lists in
+  `commands`). It is now the complete serialized command.
 
 - **`flag.array()` rejects non-element builders at compile time** — the
   element position now requires a builder carrying only value-shape settings

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -159,6 +159,21 @@ flagTypes.array;
 
 Array flags resolve to `[]` when unset — they never resolve to `undefined`.
 
+The element builder describes the *value shape only*: kinds and their value
+constraints (`flag.number({ int: true, min: 0 })`, `.nonEmpty()`,
+`.pattern()`, enum values, custom `parseFn`). Flag-level settings —
+`.alias()`, `.env()`, `.default()`, `.prompt()`, `.describe()`, and friends —
+belong on the array itself and are a **compile error** in element position,
+since an element schema would silently ignore them:
+
+```ts
+flag.array(flag.number({ min: 1 })).env('PORTS').describe('Ports'); // ✓
+// flag.array(flag.number().env('PORTS'))  ✗ compile error — env the array, not the element
+```
+
+`flag.path()`, `flag.count()`, `flag.keyValue()`, and nested `flag.array()`
+are not element-eligible either.
+
 #### Separators and deduplication
 
 By default each occurrence of an array flag contributes exactly one element

--- a/docs/guide/help.md
+++ b/docs/guide/help.md
@@ -87,6 +87,22 @@ and `dim`. A styled span can cross a soft-wrap boundary — colors carry
 invisibly across the continuation indent, but `underline`, `inverse`, and
 background styles would visibly paint it.
 
+## JSON Help
+
+With `--json`, help emits the CLI's **definition document** instead of text —
+the same machine-readable shape produced by `generateSchema()`, so
+`mycli --help --json | jq '.commands[].name'` just works:
+
+```sh
+$ mycli --help --json          # root: { $schema, name, version, defaultCommand?, commands }
+$ mycli deploy --help --json   # command: { name, description, flags, args, commands }
+```
+
+The root document includes the default command's *full* definition under
+`defaultCommand` (flags and args included), and carries a `$schema` pointer to
+the definition meta-schema for validation and editor tooling. Nothing is
+written to stderr — the JSON is the help.
+
 ## Programmatic Rendering
 
 `formatHelp()` renders a command's help as a plain string — useful for custom

--- a/src/core/cli/cli-default.test.ts
+++ b/src/core/cli/cli-default.test.ts
@@ -358,14 +358,21 @@ describe('.default()', () => {
 			expect(result.stdout.join('')).toContain('"ok":true');
 		});
 
-		it('merged root help still respects jsonMode', async () => {
+		it('root help in jsonMode emits the definition including the default command', async () => {
 			const result = await cli('mycli').default(deployCommand()).execute(['--help', '--json']);
 
 			expect(result.exitCode).toBe(0);
-			expect(result.stdout).toEqual([]);
-			const output = result.stderr.join('');
-			expect(output).toContain('Usage: mycli [flags] <target>');
-			expect(output).not.toContain('mycli deploy [flags]');
+			expect(result.stderr).toEqual([]);
+			const doc: unknown = JSON.parse(result.stdout.join(''));
+			// The default command's full definition (flags and all) is present —
+			// it lives only in `defaultCommand`, never in `commands`.
+			expect(doc).toMatchObject({
+				name: 'mycli',
+				defaultCommand: {
+					name: 'deploy',
+					flags: { force: { kind: 'boolean' } },
+				},
+			});
 		});
 	});
 

--- a/src/core/cli/cli-default.test.ts
+++ b/src/core/cli/cli-default.test.ts
@@ -371,6 +371,7 @@ describe('.default()', () => {
 				defaultCommand: {
 					name: 'deploy',
 					flags: { force: { kind: 'boolean' } },
+					args: [{ name: 'target', kind: 'string' }],
 				},
 			});
 		});

--- a/src/core/cli/cli-json.test.ts
+++ b/src/core/cli/cli-json.test.ts
@@ -199,23 +199,50 @@ describe('CLIBuilder --json with root flags', () => {
 		expect(result.stderr).toContainEqual('1.2.3\n');
 	});
 
-	it('--help still works with --json present', async () => {
+	it('--help with --json emits the definition document on stdout', async () => {
 		const app = cli('test').version('1.0.0').command(dataCommand());
 		const result = await app.execute(['--help', '--json']);
 
 		expect(result.exitCode).toBe(0);
-		// Help text goes to stderr in JSON mode
-		expect(result.stderr.length).toBeGreaterThan(0);
-		expect(result.stdout).toEqual([]);
+		const doc: unknown = JSON.parse(result.stdout.join(''));
+		expect(doc).toMatchObject({
+			name: 'test',
+			version: '1.0.0',
+			commands: [{ name: 'data' }],
+		});
+		// Machine-readable output only — no help text anywhere.
+		expect(result.stderr).toEqual([]);
 	});
 
-	it('`help --json <command>` preserves json mode', async () => {
+	it('`help --json <command>` emits the command definition on stdout', async () => {
 		const app = cli('test').version('1.0.0').command(dataCommand());
 		const result = await app.execute(['help', '--json', 'data']);
 
 		expect(result.exitCode).toBe(0);
-		// Help text goes to stderr in JSON mode (stdout reserved for data)
-		expect(result.stderr.length).toBeGreaterThan(0);
-		expect(result.stdout).toEqual([]);
+		const doc: unknown = JSON.parse(result.stdout.join(''));
+		expect(doc).toMatchObject({ name: 'data' });
+		expect(result.stderr).toEqual([]);
+	});
+
+	it('`<command> --help --json` emits the command definition on stdout', async () => {
+		const app = cli('test').version('1.0.0').command(dataCommand());
+		const result = await app.execute(['data', '--help', '--json']);
+
+		expect(result.exitCode).toBe(0);
+		const doc: unknown = JSON.parse(result.stdout.join(''));
+		expect(doc).toMatchObject({ name: 'data' });
+		expect(result.stderr).toEqual([]);
+	});
+
+	it('json help output round-trips through JSON.parse regardless of flag order', async () => {
+		const app = cli('test').version('1.0.0').command(dataCommand());
+		for (const argv of [
+			['--json', '--help'],
+			['--help', '--json'],
+		]) {
+			const result = await app.execute(argv);
+			expect(result.exitCode).toBe(0);
+			expect(() => JSON.parse(result.stdout.join(''))).not.toThrow();
+		}
 	});
 });

--- a/src/core/cli/cli-json.test.ts
+++ b/src/core/cli/cli-json.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { CLIError } from '#internals/core/errors/index.ts';
+import { createCaptureOutput } from '#internals/core/output/index.ts';
 import { command } from '#internals/core/schema/command.ts';
 import { flag } from '#internals/core/schema/flag.ts';
 import { cli } from './index.ts';
@@ -208,7 +209,13 @@ describe('CLIBuilder --json with root flags', () => {
 		expect(doc).toMatchObject({
 			name: 'test',
 			version: '1.0.0',
-			commands: [{ name: 'data' }],
+			commands: [
+				{
+					name: 'data',
+					description: 'Get data',
+					flags: { limit: { kind: 'number', presence: 'defaulted', defaultValue: 10 } },
+				},
+			],
 		});
 		// Machine-readable output only — no help text anywhere.
 		expect(result.stderr).toEqual([]);
@@ -220,7 +227,10 @@ describe('CLIBuilder --json with root flags', () => {
 
 		expect(result.exitCode).toBe(0);
 		const doc: unknown = JSON.parse(result.stdout.join(''));
-		expect(doc).toMatchObject({ name: 'data' });
+		expect(doc).toMatchObject({
+			name: 'data',
+			flags: { limit: { kind: 'number', defaultValue: 10 } },
+		});
 		expect(result.stderr).toEqual([]);
 	});
 
@@ -230,8 +240,23 @@ describe('CLIBuilder --json with root flags', () => {
 
 		expect(result.exitCode).toBe(0);
 		const doc: unknown = JSON.parse(result.stdout.join(''));
-		expect(doc).toMatchObject({ name: 'data' });
+		expect(doc).toMatchObject({
+			name: 'data',
+			flags: { limit: { kind: 'number', defaultValue: 10 } },
+		});
 		expect(result.stderr).toEqual([]);
+	});
+
+	it('command help emits JSON with a caller-supplied out channel', async () => {
+		// An injected `out` predates the resolved JSON mode — the help branch
+		// must honor `options.jsonMode` / root `--json`, not just the channel flag.
+		const [out, captured] = createCaptureOutput();
+		const app = cli('test').version('1.0.0').command(dataCommand());
+		const result = await app.execute(['data', '--help', '--json'], { out, captured });
+
+		expect(result.exitCode).toBe(0);
+		const doc: unknown = JSON.parse(captured.stdout.join(''));
+		expect(doc).toMatchObject({ name: 'data', flags: { limit: { kind: 'number' } } });
 	});
 
 	it('json help output round-trips through JSON.parse regardless of flag order', async () => {
@@ -242,7 +267,10 @@ describe('CLIBuilder --json with root flags', () => {
 		]) {
 			const result = await app.execute(argv);
 			expect(result.exitCode).toBe(0);
-			expect(() => JSON.parse(result.stdout.join(''))).not.toThrow();
+			const doc: unknown = JSON.parse(result.stdout.join(''));
+			expect(doc).toMatchObject({
+				commands: [{ name: 'data', flags: { limit: { kind: 'number' } } }],
+			});
 		}
 	});
 });

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -22,6 +22,7 @@ import { CLIError } from '#internals/core/errors/index.ts';
 import { buildRunResult, executeCommand } from '#internals/core/execution/index.ts';
 import type { HelpOptions, HelpThemeFactory } from '#internals/core/help/index.ts';
 import { formatHelp } from '#internals/core/help/index.ts';
+import { generateCommandSchema, generateSchema } from '#internals/core/json-schema/index.ts';
 import type { CapturedOutput } from '#internals/core/output/index.ts';
 import {
 	clearRequestedExitCode,
@@ -1201,8 +1202,12 @@ class CLIBuilder {
 			}
 
 			case 'root-help': {
-				const helpText = formatRootHelp(resolveHelpLinksSchema(this.schema), planned.help);
-				out.log(helpText);
+				if (jsonMode) {
+					out.json(generateSchema(this.schema));
+				} else {
+					const helpText = formatRootHelp(resolveHelpLinksSchema(this.schema), planned.help);
+					out.log(helpText);
+				}
 				return buildRunResult({ exitCode: 0, error: undefined }, captured);
 			}
 
@@ -1219,8 +1224,12 @@ class CLIBuilder {
 			}
 
 			case 'needs-subcommand': {
-				const helpText = formatHelp(planned.command.schema, planned.help);
-				out.log(helpText);
+				if (jsonMode) {
+					out.json(generateCommandSchema(planned.command.schema));
+				} else {
+					const helpText = formatHelp(planned.command.schema, planned.help);
+					out.log(helpText);
+				}
 				return buildRunResult({ exitCode: 0, error: undefined }, captured);
 			}
 

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -73,7 +73,10 @@ async function executeCommand(request: CommandExecutionRequest): Promise<Command
 
 	try {
 		if (includesBeforeSeparator(argv, '--help') || includesBeforeSeparator(argv, '-h')) {
-			if (out.jsonMode) {
+			// `options.jsonMode` carries the resolved JSON mode from the CLI/testkit
+			// layer (root `--json` is stripped from argv pre-dispatch) — an injected
+			// `out` may predate it, so the channel flag alone is not authoritative.
+			if (out.jsonMode || options?.jsonMode === true) {
 				out.json(generateCommandSchema(schema));
 				return { exitCode: 0, error: undefined };
 			}

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -15,6 +15,7 @@ import type {
 } from '#internals/core/cli/plugin.ts';
 import { CLIError } from '#internals/core/errors/index.ts';
 import { formatHelp } from '#internals/core/help/index.ts';
+import { generateCommandSchema } from '#internals/core/json-schema/index.ts';
 import type { CapturedOutput } from '#internals/core/output/index.ts';
 import { clearRequestedExitCode, getRequestedExitCode } from '#internals/core/output/index.ts';
 import { includesBeforeSeparator, parse } from '#internals/core/parse/index.ts';
@@ -72,6 +73,10 @@ async function executeCommand(request: CommandExecutionRequest): Promise<Command
 
 	try {
 		if (includesBeforeSeparator(argv, '--help') || includesBeforeSeparator(argv, '-h')) {
+			if (out.jsonMode) {
+				out.json(generateCommandSchema(schema));
+				return { exitCode: 0, error: undefined };
+			}
 			// Standalone `cmd.run()` / testkit paths reach here without the CLI
 			// builder's help merge — default the palette from the output channel.
 			const helpText = formatHelp(

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -139,7 +139,10 @@ function generateSchema(schema: CLISchema, options?: JsonSchemaOptions): Record<
 		schema.defaultCommand !== undefined &&
 		(opts.includeHidden || !schema.defaultCommand.schema.hidden)
 	) {
-		result.defaultCommand = schema.defaultCommand.schema.name;
+		// Full definition, not just the name — the default command lives only in
+		// `defaultCommand` (never in `commands`), so a name-only reference would
+		// drop its flags/args from the document entirely.
+		result.defaultCommand = serializeCommand(schema.defaultCommand.schema, opts);
 	}
 
 	result.commands = schema.commands
@@ -150,6 +153,25 @@ function generateSchema(schema: CLISchema, options?: JsonSchemaOptions): Record<
 }
 
 // --- Command serialization
+
+/**
+ * Generate the definition metadata document for a single command.
+ *
+ * The per-command counterpart of {@link generateSchema}: the same
+ * JSON-serializable shape as one entry of its `commands` array (flags, args,
+ * subcommands, examples). Powers `--help` in `--json` mode and is useful for
+ * embedding one command's definition into custom tooling.
+ *
+ * @param schema - The command schema to serialize.
+ * @param options - Generation options.
+ * @returns A plain object suitable for `JSON.stringify()`.
+ */
+function generateCommandSchema(
+	schema: CommandSchema,
+	options?: JsonSchemaOptions,
+): Record<string, unknown> {
+	return serializeCommand(schema, resolveOptions(options));
+}
 
 /**
  * Serialize a single {@link CommandSchema} into a plain object.
@@ -879,7 +901,7 @@ const definitionMetaSchema: Record<string, unknown> = withDefinitionMetaSchemaDe
 		name: string;
 		version?: string;
 		description?: string;
-		defaultCommand?: string;
+		defaultCommand?: @command;
 		commands: @command[]
 	}`),
 		$defs: {
@@ -950,4 +972,4 @@ const definitionMetaSchema: Record<string, unknown> = withDefinitionMetaSchemaDe
 // === Exports
 
 export type { JsonSchemaOptions };
-export { definitionMetaSchema, generateInputSchema, generateSchema };
+export { definitionMetaSchema, generateCommandSchema, generateInputSchema, generateSchema };

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -132,7 +132,7 @@ describe('generateSchema — definition metadata', () => {
 		expect(result).toHaveProperty('description', 'A CLI tool');
 	});
 
-	it('includes defaultCommand as name reference', () => {
+	it('includes the defaultCommand as a full command definition', () => {
 		const deploy = commandDef({ name: 'deploy' });
 		const result = generateSchema(
 			minimalCLI({
@@ -140,7 +140,8 @@ describe('generateSchema — definition metadata', () => {
 				defaultCommand: erased(deploy),
 			}),
 		);
-		expect(result).toHaveProperty('defaultCommand', 'deploy');
+		expect(result).toHaveProperty('defaultCommand');
+		expect(result.defaultCommand).toMatchObject({ name: 'deploy', flags: {}, args: [] });
 	});
 
 	it('omits hidden defaultCommand when includeHidden is false', () => {

--- a/src/core/schema/flag-element-eligibility.test.ts
+++ b/src/core/schema/flag-element-eligibility.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Type-level tests for `flag.array()` element eligibility.
+ *
+ * Flag-level modifiers (`.alias()`, `.env()`, `.default()`, …) produce
+ * settings an element schema never reads; the phantom `elementEligible`
+ * marker makes passing such builders to `flag.array()` a compile error
+ * instead of silently dropping them.
+ *
+ * @module dreamcli/core/schema/flag-element-eligibility.test
+ */
+
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { parse } from '#internals/core/parse/index.ts';
+import { command } from './command.ts';
+import { flag, type InferFlag } from './flag.ts';
+
+describe('flag.array() element eligibility', () => {
+	it('accepts pristine element builders of every element-meaningful kind', () => {
+		flag.array(flag.string());
+		flag.array(flag.number());
+		flag.array(flag.boolean());
+		flag.array(flag.enum(['us', 'eu', 'ap']));
+		flag.array(flag.custom((raw) => String(raw)));
+		flag.array(flag.url());
+		flag.array(flag.date());
+		flag.array(flag.duration());
+		flag.array(flag.bytes());
+	});
+
+	it('accepts element builders with value constraints (still element-meaningful)', () => {
+		flag.array(flag.number({ int: true, min: 0 }));
+		flag.array(flag.number().int().min(0).max(10));
+		flag.array(flag.string({ nonEmpty: true }));
+		flag.array(
+			flag
+				.string()
+				.nonEmpty()
+				.minLength(2)
+				.maxLength(8)
+				.pattern(/^[a-z]+$/),
+		);
+	});
+
+	it('rejects builders carrying flag-level settings elements would ignore', () => {
+		// @ts-expect-error — element aliases are never read
+		flag.array(flag.string().alias('s'));
+		// @ts-expect-error — element env bindings are never read
+		flag.array(flag.string().env('TAGS'));
+		// @ts-expect-error — element config paths are never read
+		flag.array(flag.string().config('deploy.tags'));
+		// @ts-expect-error — element defaults are never read (default the array)
+		flag.array(flag.string().default('x'));
+		// @ts-expect-error — element requiredness is never read (require the array)
+		flag.array(flag.string().required());
+		// @ts-expect-error — element descriptions are never read (describe the array)
+		flag.array(flag.string().describe('a tag'));
+		// @ts-expect-error — element prompts are never read
+		flag.array(flag.string().prompt({ kind: 'input', message: '?' }));
+		// @ts-expect-error — element deprecation is never read
+		flag.array(flag.string().deprecated('use --new'));
+		// @ts-expect-error — element propagation is never read
+		flag.array(flag.string().propagate());
+		// @ts-expect-error — element negation is never read
+		flag.array(flag.boolean().negatable());
+		// @ts-expect-error — element duplicate policy is never read
+		flag.array(flag.string().duplicates('error'));
+	});
+
+	it('rejects kinds that are not element-meaningful', () => {
+		// @ts-expect-error — nested arrays are unsupported
+		flag.array(flag.array(flag.string()));
+		// @ts-expect-error — count accumulates occurrences, not values
+		flag.array(flag.count());
+		// @ts-expect-error — keyValue accumulates into a record, not an array
+		flag.array(flag.keyValue());
+		// @ts-expect-error — pathChecks are validated on the flag, never on elements
+		flag.array(flag.path());
+	});
+
+	it('flag-level modifiers still chain freely on the array itself', () => {
+		const tags = flag
+			.array(flag.enum(['api', 'web', 'git']))
+			.separator(',')
+			.unique()
+			.default(['api'])
+			.env('TAGS')
+			.alias('t')
+			.describe('Services to check');
+		expectTypeOf<InferFlag<typeof tags>>().toEqualTypeOf<('api' | 'web' | 'git')[]>();
+	});
+
+	it('element constraints keep working end-to-end', () => {
+		const schema = command('run')
+			.flag('ports', flag.array(flag.number({ int: true, min: 1 })).separator(','))
+			.action(() => {}).schema;
+		expect(parse(schema, ['--ports', '80,443']).flags['ports']).toEqual([80, 443]);
+		expect(() => parse(schema, ['--ports', '80,0'])).toThrow(/Invalid number value '0'/);
+	});
+});

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -66,6 +66,16 @@ interface FlagConfig {
 	readonly optionalFallback: OptionalFallback;
 	/** The runtime kind discriminator, mirroring {@link FlagKind}. */
 	readonly flagKind: FlagKind;
+	/**
+	 * Whether this builder may still be passed to `flag.array()` as the
+	 * element schema.
+	 *
+	 * Factories producing element-meaningful kinds start `true`. Flag-level
+	 * modifiers (`.alias()`, `.env()`, `.prompt()`, `.default()`, …) flip it
+	 * to `false` — those settings describe the *flag*, are never read from an
+	 * element schema, and would otherwise be silently ignored.
+	 */
+	readonly elementEligible: boolean;
 }
 
 // --- Type-level helpers
@@ -79,6 +89,19 @@ type WithPresence<C extends FlagConfig, P extends FlagPresence> = {
 	readonly presence: P;
 	readonly optionalFallback: C['optionalFallback'];
 	readonly flagKind: C['flagKind'];
+	readonly elementEligible: false;
+};
+
+/**
+ * Advanced type helper: marks a builder as no longer usable as an array
+ * element (returned by flag-level modifiers whose settings elements ignore).
+ */
+type WithoutElementEligibility<C extends FlagConfig> = {
+	readonly valueType: C['valueType'];
+	readonly presence: C['presence'];
+	readonly optionalFallback: C['optionalFallback'];
+	readonly flagKind: C['flagKind'];
+	readonly elementEligible: false;
 };
 
 /**
@@ -577,7 +600,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * // $ mycli build --verbose  → verbose = true
 	 * ```
 	 */
-	alias(name: string, options?: { hidden?: boolean }): FlagBuilder<C> {
+	alias(name: string, options?: { hidden?: boolean }): FlagBuilder<WithoutElementEligibility<C>> {
 		return new FlagBuilder({
 			...this.schema,
 			aliases: [
@@ -604,7 +627,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * // $ mycli request --api-key sk-456 → apiKey = 'sk-456' (CLI wins)
 	 * ```
 	 */
-	env(varName: string): FlagBuilder<C> {
+	env(varName: string): FlagBuilder<WithoutElementEligibility<C>> {
 		return new FlagBuilder({
 			...this.schema,
 			envVar: varName,
@@ -627,7 +650,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * // #   → CLI flag wins
 	 * ```
 	 */
-	config(path: string): FlagBuilder<C> {
+	config(path: string): FlagBuilder<WithoutElementEligibility<C>> {
 		return new FlagBuilder({
 			...this.schema,
 			configPath: path,
@@ -640,7 +663,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * @param description - Text displayed next to the flag in `--help`.
 	 * @returns The builder (for chaining).
 	 */
-	describe(description: string): FlagBuilder<C> {
+	describe(description: string): FlagBuilder<WithoutElementEligibility<C>> {
 		return new FlagBuilder({
 			...this.schema,
 			description,
@@ -666,7 +689,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * // $ mycli init --name foo   → skips prompt, uses CLI value
 	 * ```
 	 */
-	prompt(config: AllowedPromptConfig<C>): FlagBuilder<C> {
+	prompt(config: AllowedPromptConfig<C>): FlagBuilder<WithoutElementEligibility<C>> {
 		return new FlagBuilder({
 			...this.schema,
 			prompt: config,
@@ -692,7 +715,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * // ⚠ --dest is deprecated: Use --target instead
 	 * ```
 	 */
-	deprecated(message?: string): FlagBuilder<C> {
+	deprecated(message?: string): FlagBuilder<WithoutElementEligibility<C>> {
 		return new FlagBuilder({
 			...this.schema,
 			deprecated: message ?? true,
@@ -720,7 +743,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * // #   → same, inherited from parent
 	 * ```
 	 */
-	propagate(): FlagBuilder<C> {
+	propagate(): FlagBuilder<WithoutElementEligibility<C>> {
 		return new FlagBuilder({
 			...this.schema,
 			propagate: true,
@@ -961,7 +984,7 @@ class FlagBuilder<C extends FlagConfig> {
 	negatable(
 		this: FlagBuilder<C & { readonly flagKind: 'boolean' }>,
 		options?: { alias?: string; hidden?: boolean },
-	): FlagBuilder<C> {
+	): FlagBuilder<WithoutElementEligibility<C>> {
 		return new FlagBuilder({
 			...this.schema,
 			negation: { alias: options?.alias, hidden: options?.hidden ?? false },
@@ -993,7 +1016,7 @@ class FlagBuilder<C extends FlagConfig> {
 			C & { readonly flagKind: 'boolean' | 'string' | 'number' | 'enum' | 'custom' }
 		>,
 		policy: DuplicatePolicy,
-	): FlagBuilder<C> {
+	): FlagBuilder<WithoutElementEligibility<C>> {
 		return new FlagBuilder({ ...this.schema, duplicates: policy });
 	}
 }
@@ -1029,6 +1052,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'string';
+		readonly elementEligible: true;
 	}>;
 
 	/**
@@ -1058,6 +1082,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'number';
+		readonly elementEligible: true;
 	}>;
 
 	/**
@@ -1071,6 +1096,7 @@ interface FlagFactory {
 		readonly presence: 'defaulted';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'boolean';
+		readonly elementEligible: true;
 	}>;
 
 	/**
@@ -1095,6 +1121,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'enum';
+		readonly elementEligible: true;
 	}>;
 
 	/**
@@ -1109,13 +1136,14 @@ interface FlagFactory {
 	 * @param element - {@link FlagBuilder} describing the element type.
 	 * @returns A {@link FlagBuilder} for arrays of the element type.
 	 */
-	array<E extends FlagConfig>(
+	array<E extends FlagConfig & { readonly elementEligible: true }>(
 		element: FlagBuilder<E>,
 	): FlagBuilder<{
 		readonly valueType: E['valueType'][];
 		readonly presence: 'optional';
 		readonly optionalFallback: 'empty-array';
 		readonly flagKind: 'array';
+		readonly elementEligible: false;
 	}>;
 
 	/**
@@ -1152,6 +1180,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}>;
 
 	/**
@@ -1172,6 +1201,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}>;
 
 	/**
@@ -1195,6 +1225,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'string';
+		readonly elementEligible: false;
 	}>;
 
 	/**
@@ -1221,6 +1252,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}>;
 
 	/**
@@ -1240,6 +1272,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}>;
 
 	/**
@@ -1259,6 +1292,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}>;
 
 	/**
@@ -1282,6 +1316,7 @@ interface FlagFactory {
 		readonly presence: 'defaulted';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'count';
+		readonly elementEligible: false;
 	}>;
 
 	/**
@@ -1306,6 +1341,7 @@ interface FlagFactory {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'empty-object';
 		readonly flagKind: 'keyValue';
+		readonly elementEligible: false;
 	}>;
 }
 
@@ -1319,6 +1355,7 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'string';
+		readonly elementEligible: true;
 	}> {
 		if (constraints !== undefined) {
 			assertStringConstraints(constraints);
@@ -1333,6 +1370,7 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'number';
+		readonly elementEligible: true;
 	}> {
 		if (constraints !== undefined) {
 			assertNumberConstraints(constraints);
@@ -1347,6 +1385,7 @@ const flag: FlagFactory = {
 		readonly presence: 'defaulted';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'boolean';
+		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(
 			createSchema('boolean', {
@@ -1363,17 +1402,19 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'enum';
+		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(createSchema('enum', { enumValues: values }));
 	},
 
-	array<E extends FlagConfig>(
+	array<E extends FlagConfig & { readonly elementEligible: true }>(
 		element: FlagBuilder<E>,
 	): FlagBuilder<{
 		readonly valueType: E['valueType'][];
 		readonly presence: 'optional';
 		readonly optionalFallback: 'empty-array';
 		readonly flagKind: 'array';
+		readonly elementEligible: false;
 	}> {
 		return new FlagBuilder(createSchema('array', { elementSchema: element.schema }));
 	},
@@ -1383,6 +1424,7 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(createSchema('custom', { parseFn: parseFn as FlagParseFn<unknown> }));
 	},
@@ -1392,6 +1434,7 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(
 			createSchema('custom', {
@@ -1406,6 +1449,7 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'string';
+		readonly elementEligible: false;
 	}> {
 		const pathChecks =
 			options?.mustExist === true || options?.type !== undefined
@@ -1419,6 +1463,7 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(
 			createSchema('custom', {
@@ -1433,6 +1478,7 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(
 			createSchema('custom', { parseFn: parseDurationValue, valueHint: 'duration' }),
@@ -1444,6 +1490,7 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'custom';
+		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(createSchema('custom', { parseFn: parseBytesValue, valueHint: 'size' }));
 	},
@@ -1453,6 +1500,7 @@ const flag: FlagFactory = {
 		readonly presence: 'defaulted';
 		readonly optionalFallback: 'undefined';
 		readonly flagKind: 'count';
+		readonly elementEligible: false;
 	}> {
 		return new FlagBuilder(
 			createSchema('count', {
@@ -1467,6 +1515,7 @@ const flag: FlagFactory = {
 		readonly presence: 'optional';
 		readonly optionalFallback: 'empty-object';
 		readonly flagKind: 'keyValue';
+		readonly elementEligible: false;
 	}> {
 		return new FlagBuilder(createSchema('keyValue', { valueHint: 'key=value' }));
 	},

--- a/src/core/schema/prompt.test.ts
+++ b/src/core/schema/prompt.test.ts
@@ -414,6 +414,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'defaulted';
 			readonly optionalFallback: 'undefined';
 			readonly flagKind: 'boolean';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<AllowedPromptConfig<BoolConfig>>().toEqualTypeOf<ConfirmPromptConfig>();
 	});
@@ -424,6 +425,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
 			readonly flagKind: 'number';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<AllowedPromptConfig<NumConfig>>().toEqualTypeOf<InputPromptConfig>();
 	});
@@ -434,6 +436,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
 			readonly flagKind: 'string';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<AllowedPromptConfig<StrConfig>>().toEqualTypeOf<
 			InputPromptConfig | SelectPromptConfig
@@ -446,6 +449,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
 			readonly flagKind: 'enum';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<AllowedPromptConfig<EnumConfig>>().toEqualTypeOf<
 			SelectPromptConfig | InputPromptConfig
@@ -458,6 +462,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'optional';
 			readonly optionalFallback: 'empty-array';
 			readonly flagKind: 'array';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<AllowedPromptConfig<ArrConfig>>().toEqualTypeOf<MultiselectPromptConfig>();
 	});
@@ -468,6 +473,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
 			readonly flagKind: 'custom';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<AllowedPromptConfig<CustomConfig>>().toEqualTypeOf<PromptConfig>();
 	});
@@ -478,6 +484,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
 			readonly flagKind: 'enum';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<MultiselectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<EnumConfig>>();
 	});
@@ -488,6 +495,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'defaulted';
 			readonly optionalFallback: 'undefined';
 			readonly flagKind: 'boolean';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<MultiselectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<BoolConfig>>();
 	});
@@ -498,6 +506,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'optional';
 			readonly optionalFallback: 'undefined';
 			readonly flagKind: 'string';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<ConfirmPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<StrConfig>>();
 	});
@@ -508,6 +517,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'defaulted';
 			readonly optionalFallback: 'undefined';
 			readonly flagKind: 'boolean';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<InputPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<BoolConfig>>();
 	});
@@ -518,6 +528,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly presence: 'optional';
 			readonly optionalFallback: 'empty-array';
 			readonly flagKind: 'array';
+			readonly elementEligible: false;
 		};
 		expectTypeOf<SelectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<ArrConfig>>();
 	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ export { formatHelp, osc8, visibleWidth } from './core/help/index.ts';
 export type { JsonSchemaOptions } from './core/json-schema/index.ts';
 export {
 	definitionMetaSchema,
+	generateCommandSchema,
 	generateInputSchema,
 	generateSchema,
 } from './core/json-schema/index.ts';


### PR DESCRIPTION
Two changes for the next rc, both green through full local CI (2,876 tests, typecheck, lint zero findings, docs build).

## `flag.array()` rejects non-element builders (type-level, breaking)

The element position accepted any `FlagBuilder` while reading only its value shape — `flag.array(flag.string().env('TAGS'))` compiled and the `env` binding silently vanished. A phantom `elementEligible` marker in `FlagConfig` now makes that unrepresentable:

- factories with element-meaningful kinds (`string`, `number`, `boolean`, `enum`, `custom`, `url`, `date`, `duration`, `bytes`) start eligible
- value-constraint modifiers (`.min()`, `.pattern()`, `.nonEmpty()`, …) preserve eligibility
- flag-level modifiers (`.alias()`, `.env()`, `.config()`, `.default()`, `.required()`, `.prompt()`, `.describe()`, `.deprecated()`, `.propagate()`, `.negatable()`, `.duplicates()`) flip it off
- `flag.path()` (pathChecks are flag-level), `flag.count()`, `flag.keyValue()`, and nested arrays are ineligible outright

No runtime change. Breaking only for code whose element-level settings were already being ignored — the compile error *is* the fix. 11 `@ts-expect-error` assertions pin the rejections; eligibility-preserving chains are asserted with `expectTypeOf`.

## `--help --json` emits the definition document

Previously JSON mode routed help *text* to stderr with empty stdout — nothing consumable. Now:

- root `--help --json` → the `generateSchema()` document (`$schema`-tagged) on stdout
- `help <cmd> --json` / `<cmd> --help --json` → the per-command definition (new `generateCommandSchema()` export)
- `mycli --help --json | jq '.commands[].name'` works; stderr stays empty

Supporting fix: `generateSchema()` emitted `defaultCommand` as a name-only string while the default command's flags/args appeared nowhere in the document (defaults never list under `commands`). It's now the full serialized command, and the meta-schema `defaultCommand` field $refs the command def.

Three existing tests documenting the old help-to-stderr contract were rewritten to the new one.