### PR TITLE
fix(help): honor NO_HYPERLINKS in root-help header (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0-rc.12] - 2026-07-20
+
 ### Added
 
+- **`out.isHyperlinkSupported`** — resolved OSC 8 hyperlink gate on the output
+  channel. Honors `NO_HYPERLINKS`/`FORCE_HYPERLINKS` and the
+  `--no-hyperlinks`/`--hyperlinks` flags, falling back to `isTTY`. Consumers
+  rendering their own `out.color.link(...)` output can gate on it to keep OSC 8
+  escapes out of piped or opted-out contexts.
 - **Standard Schema v1 validation** — `flag.custom(schema)` and
   `arg.custom(schema)` accept any conforming validator (including callable,
   sync, and async schemas) with inferred output types and no runtime
@@ -36,6 +43,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Internal schema DSL** — the private template-literal parser, validator, and
   JSON Schema converter were replaced by direct definition-schema objects,
   removing roughly 1,500 lines without changing the generated schema.
+
+### Fixed
+
+- **`NO_HYPERLINKS` ignored in the help header** — root-help header hyperlinks
+  gated on raw TTY status, so `NO_HYPERLINKS=1` (and `--no-hyperlinks`) still
+  emitted OSC 8 links in the header. The gate now consults
+  `out.isHyperlinkSupported`, which respects the standard hyperlink overrides.
 
 ## [3.0.0-rc.11] - 2026-07-15
 
@@ -1250,7 +1264,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MIT License.
 - Markdownlint configuration.
 
-[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.11...HEAD
+[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.12...HEAD
+[3.0.0-rc.12]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.11...v3.0.0-rc.12
 [3.0.0-rc.11]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.10...v3.0.0-rc.11
 [3.0.0-rc.10]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.9...v3.0.0-rc.10
 [3.0.0-rc.9]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.8...v3.0.0-rc.9

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.11",
+	"version": "3.0.0-rc.12",
 	"license": "MIT",
 	"tasks": {
 		"check": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.11",
+	"version": "3.0.0-rc.12",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
 		"dreamcli",

--- a/src/core/cli/cli-links.test.ts
+++ b/src/core/cli/cli-links.test.ts
@@ -181,6 +181,14 @@ describe('root help — explicit links', () => {
 
 			expect(result.stdout.join('')).not.toContain(ESC);
 		});
+
+		it('--hyperlinks in argv emits header links without a TTY', async () => {
+			const app = cli('mytool').version('1.0.0').links({ name: REPO }).command(deployCommand());
+
+			const result = await app.execute(['--help', '--hyperlinks']);
+
+			expect(result.stdout.join('')).toContain(osc8(REPO, 'mytool'));
+		});
 	});
 
 	it('links only the name when no version URL is configured', async () => {

--- a/src/core/cli/cli-links.test.ts
+++ b/src/core/cli/cli-links.test.ts
@@ -5,7 +5,7 @@
  * package.json metadata (repository/homepage, discovery and pre-loaded
  * data), and that escapes never leak outside the header line.
  */
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { osc8 } from '#internals/core/help/index.ts';
 import { command } from '#internals/core/schema/command.ts';
 import { createTestAdapter, ExitError } from '#internals/runtime/index.ts';
@@ -155,26 +155,31 @@ describe('root help — explicit links', () => {
 	});
 
 	describe('environment overrides', () => {
-		afterEach(() => {
-			vi.unstubAllEnvs();
-		});
-
 		it('NO_HYPERLINKS suppresses header links on a TTY', async () => {
-			vi.stubEnv('NO_HYPERLINKS', '1');
 			const app = cli('mytool').version('1.0.0').links({ name: REPO }).command(deployCommand());
 
-			const result = await app.execute(['--help'], { isTTY: true });
+			const result = await app.execute(['--help'], {
+				isTTY: true,
+				env: { NO_HYPERLINKS: '1' },
+			});
 
 			expect(result.stdout.join('')).not.toContain(ESC);
 		});
 
 		it('FORCE_HYPERLINKS emits header links without a TTY', async () => {
-			vi.stubEnv('FORCE_HYPERLINKS', '1');
 			const app = cli('mytool').version('1.0.0').links({ name: REPO }).command(deployCommand());
 
-			const result = await app.execute(['--help']);
+			const result = await app.execute(['--help'], { env: { FORCE_HYPERLINKS: '1' } });
 
 			expect(result.stdout.join('')).toContain(osc8(REPO, 'mytool'));
+		});
+
+		it('--no-hyperlinks in argv suppresses header links on a TTY', async () => {
+			const app = cli('mytool').version('1.0.0').links({ name: REPO }).command(deployCommand());
+
+			const result = await app.execute(['--help', '--no-hyperlinks'], { isTTY: true });
+
+			expect(result.stdout.join('')).not.toContain(ESC);
 		});
 	});
 

--- a/src/core/cli/cli-links.test.ts
+++ b/src/core/cli/cli-links.test.ts
@@ -5,7 +5,7 @@
  * package.json metadata (repository/homepage, discovery and pre-loaded
  * data), and that escapes never leak outside the header line.
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { osc8 } from '#internals/core/help/index.ts';
 import { command } from '#internals/core/schema/command.ts';
 import { createTestAdapter, ExitError } from '#internals/runtime/index.ts';
@@ -152,6 +152,30 @@ describe('root help — explicit links', () => {
 		const result = await app.execute(['--help'], { isTTY: true, help: { hyperlinks: false } });
 
 		expect(result.stdout.join('')).not.toContain(ESC);
+	});
+
+	describe('environment overrides', () => {
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
+
+		it('NO_HYPERLINKS suppresses header links on a TTY', async () => {
+			vi.stubEnv('NO_HYPERLINKS', '1');
+			const app = cli('mytool').version('1.0.0').links({ name: REPO }).command(deployCommand());
+
+			const result = await app.execute(['--help'], { isTTY: true });
+
+			expect(result.stdout.join('')).not.toContain(ESC);
+		});
+
+		it('FORCE_HYPERLINKS emits header links without a TTY', async () => {
+			vi.stubEnv('FORCE_HYPERLINKS', '1');
+			const app = cli('mytool').version('1.0.0').links({ name: REPO }).command(deployCommand());
+
+			const result = await app.execute(['--help']);
+
+			expect(result.stdout.join('')).toContain(osc8(REPO, 'mytool'));
+		});
 	});
 
 	it('links only the name when no version URL is configured', async () => {

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -1136,13 +1136,15 @@ class CLIBuilder {
 
 		// Resolve help options — builder-level `.help()` config under runtime
 		// `options.help` (runtime wins), then default binName to the CLI program
-		// name, hyperlinks to TTY detection, and colors to the output channel's
-		// gated palette (escapes never leak into piped output).
+		// name, hyperlinks to the channel's resolved support (NO_HYPERLINKS/
+		// FORCE_HYPERLINKS honored, else TTY), and colors to the output
+		// channel's gated palette (escapes never leak into piped output).
 		const helpOptions: HelpOptions = {
 			...this.schema.helpConfig,
 			...options?.help,
 			binName: options?.help?.binName ?? this.schema.name,
-			hyperlinks: options?.help?.hyperlinks ?? this.schema.helpConfig?.hyperlinks ?? out.isTTY,
+			hyperlinks:
+				options?.help?.hyperlinks ?? this.schema.helpConfig?.hyperlinks ?? out.isHyperlinkSupported,
 			colors: options?.help?.colors ?? out.color,
 		};
 

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -28,6 +28,7 @@ import {
 	clearRequestedExitCode,
 	createCaptureOutput,
 	createOutput,
+	resolveHyperlinkOverride,
 } from '#internals/core/output/index.ts';
 import type { ParseOptions } from '#internals/core/parse/index.ts';
 import { includesBeforeSeparator } from '#internals/core/parse/index.ts';
@@ -465,6 +466,17 @@ interface CLIRunOptions extends Omit<RunOptions, 'meta' | 'mergedSchema'> {
 }
 
 // --- Command run options builder
+
+/**
+ * Conditional-spread wrapper for the output channel's `hyperlinks` option:
+ * omit the key entirely when there is no override so `exactOptionalPropertyTypes`
+ * stays happy and the channel falls back to `isTTY`.
+ *
+ * @internal
+ */
+function hyperlinksOption(override: boolean | undefined): { hyperlinks?: boolean } {
+	return override !== undefined ? { hyperlinks: override } : {};
+}
 
 /**
  * Build {@linkcode RunOptions} from {@linkcode CLIRunOptions}, conditionally spreading each
@@ -1121,6 +1133,7 @@ class CLIBuilder {
 			...(options?.verbosity !== undefined ? { verbosity: options.verbosity } : {}),
 			...(jsonMode ? { jsonMode } : {}),
 			...(options?.isTTY !== undefined ? { isTTY: options.isTTY } : {}),
+			...hyperlinksOption(resolveHyperlinkOverride(options?.env ?? {}, argv)),
 		};
 		let out: Out;
 		let captured: CapturedOutput;
@@ -1324,6 +1337,7 @@ class CLIBuilder {
 				...(preflight.inputs.verbosity !== 'normal'
 					? { verbosity: preflight.inputs.verbosity }
 					: {}),
+				...hyperlinksOption(resolveHyperlinkOverride(adapter.env, adapter.argv)),
 			}),
 		};
 		const result = await effectiveBuilder.execute(preflight.filteredArgv, executeOptions);

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -181,8 +181,10 @@ function resolveHyperlinkOverride(
 	env: Readonly<Record<string, string | undefined>>,
 	argv: readonly string[],
 ): boolean | undefined {
-	if (env.NO_HYPERLINKS || argv.includes('--no-hyperlinks')) return false;
-	if (env.FORCE_HYPERLINKS || argv.includes('--hyperlinks')) return true;
+	const separator = argv.indexOf('--');
+	const flags = separator === -1 ? argv : argv.slice(0, separator);
+	if (env.NO_HYPERLINKS || flags.includes('--no-hyperlinks')) return false;
+	if (env.FORCE_HYPERLINKS || flags.includes('--hyperlinks')) return true;
 	return undefined;
 }
 

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -113,17 +113,14 @@ interface OutputOptions {
 	readonly color?: boolean;
 
 	/**
-	 * Explicitly enable or disable OSC 8 hyperlink support on
-	 * `out.isHyperlinkSupported`.
+	 * Resolved OSC 8 hyperlink support for `out.isHyperlinkSupported`.
 	 *
-	 * When set, this wins over the auto-gate. When omitted, the gate honors
-	 * `NO_HYPERLINKS`/`--no-hyperlinks` (force off) and
-	 * `FORCE_HYPERLINKS`/`--hyperlinks` (force on), then falls back to
-	 * `isTTY`.
+	 * When set, this wins over the `isTTY` fallback. Callers pass the
+	 * `NO_HYPERLINKS`/`FORCE_HYPERLINKS` (and `--no-hyperlinks`/`--hyperlinks`)
+	 * decision here via {@linkcode resolveHyperlinkOverride}, keeping `process`
+	 * access out of the output layer.
 	 *
-	 * @defaultValue auto — `NO_HYPERLINKS`/`FORCE_HYPERLINKS` (and the
-	 *   `--no-hyperlinks`/`--hyperlinks` argv flags) override, otherwise
-	 *   `isTTY`.
+	 * @defaultValue `isTTY`
 	 */
 	readonly hyperlinks?: boolean;
 }
@@ -175,12 +172,15 @@ function clearRequestedExitCode(out: Out): void {
  * Forced hyperlink decision from `NO_HYPERLINKS`/`FORCE_HYPERLINKS` and the
  * `--no-hyperlinks`/`--hyperlinks` argv flags; `undefined` when unset.
  *
+ * Pure over its inputs — callers pass the adapter's `env`/`argv` so the
+ * output layer never touches `process` directly.
+ *
  * @see https://no-hyperlinks.org/
  */
-function hyperlinkOverride(): boolean | undefined {
-	const proc = globalThis.process;
-	const env = proc?.env ?? {};
-	const argv = proc?.argv ?? [];
+function resolveHyperlinkOverride(
+	env: Readonly<Record<string, string | undefined>>,
+	argv: readonly string[],
+): boolean | undefined {
 	if (env.NO_HYPERLINKS || argv.includes('--no-hyperlinks')) return false;
 	if (env.FORCE_HYPERLINKS || argv.includes('--hyperlinks')) return true;
 	return undefined;
@@ -199,9 +199,9 @@ function resolveOptions(options?: OutputOptions): ResolvedOutputOptions {
 		// Explicit `color` wins; otherwise gate on TTY, JSON mode, and
 		// environment support (NO_COLOR/FORCE_COLOR/--no-color/--color/CI).
 		color: options?.color ?? (isTTY && !jsonMode && isColorSupported),
-		// Explicit `hyperlinks` wins; otherwise NO_HYPERLINKS/FORCE_HYPERLINKS
-		// (and the matching argv flags) override, then fall back to TTY.
-		isHyperlinkSupported: options?.hyperlinks ?? hyperlinkOverride() ?? isTTY,
+		// Explicit `hyperlinks` (the caller-resolved env/argv override) wins;
+		// otherwise fall back to TTY.
+		isHyperlinkSupported: options?.hyperlinks ?? isTTY,
 	};
 }
 
@@ -770,6 +770,7 @@ export {
 	noopProgressHandle,
 	noopSpinnerHandle,
 	OutputChannel,
+	resolveHyperlinkOverride,
 	StaticProgressHandle,
 	StaticSpinnerHandle,
 	setRequestedExitCode,

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -111,6 +111,21 @@ interface OutputOptions {
 	 *   `FORCE_COLOR`, `--no-color`, `--color`, `CI` are respected).
 	 */
 	readonly color?: boolean;
+
+	/**
+	 * Explicitly enable or disable OSC 8 hyperlink support on
+	 * `out.isHyperlinkSupported`.
+	 *
+	 * When set, this wins over the auto-gate. When omitted, the gate honors
+	 * `NO_HYPERLINKS`/`--no-hyperlinks` (force off) and
+	 * `FORCE_HYPERLINKS`/`--hyperlinks` (force on), then falls back to
+	 * `isTTY`.
+	 *
+	 * @defaultValue auto — `NO_HYPERLINKS`/`FORCE_HYPERLINKS` (and the
+	 *   `--no-hyperlinks`/`--hyperlinks` argv flags) override, otherwise
+	 *   `isTTY`.
+	 */
+	readonly hyperlinks?: boolean;
 }
 
 // --- Resolved options (all fields required, filled from defaults)
@@ -123,6 +138,7 @@ interface ResolvedOutputOptions {
 	readonly verbosity: Verbosity;
 	readonly jsonMode: boolean;
 	readonly color: boolean;
+	readonly isHyperlinkSupported: boolean;
 }
 
 /**
@@ -155,6 +171,21 @@ function clearRequestedExitCode(out: Out): void {
 	requestedExitCodes.delete(out);
 }
 
+/**
+ * Forced hyperlink decision from `NO_HYPERLINKS`/`FORCE_HYPERLINKS` and the
+ * `--no-hyperlinks`/`--hyperlinks` argv flags; `undefined` when unset.
+ *
+ * @see https://no-hyperlinks.org/
+ */
+function hyperlinkOverride(): boolean | undefined {
+	const proc = globalThis.process;
+	const env = proc?.env ?? {};
+	const argv = proc?.argv ?? [];
+	if (env.NO_HYPERLINKS || argv.includes('--no-hyperlinks')) return false;
+	if (env.FORCE_HYPERLINKS || argv.includes('--hyperlinks')) return true;
+	return undefined;
+}
+
 /** Merge user-supplied options with defaults. */
 function resolveOptions(options?: OutputOptions): ResolvedOutputOptions {
 	const isTTY = options?.isTTY ?? false;
@@ -168,6 +199,9 @@ function resolveOptions(options?: OutputOptions): ResolvedOutputOptions {
 		// Explicit `color` wins; otherwise gate on TTY, JSON mode, and
 		// environment support (NO_COLOR/FORCE_COLOR/--no-color/--color/CI).
 		color: options?.color ?? (isTTY && !jsonMode && isColorSupported),
+		// Explicit `hyperlinks` wins; otherwise NO_HYPERLINKS/FORCE_HYPERLINKS
+		// (and the matching argv flags) override, then fall back to TTY.
+		isHyperlinkSupported: options?.hyperlinks ?? hyperlinkOverride() ?? isTTY,
 	};
 }
 
@@ -212,12 +246,21 @@ class OutputChannel implements Out {
 	 */
 	readonly color: Colors;
 
+	/**
+	 * Whether OSC 8 hyperlinks should be emitted for this channel.
+	 *
+	 * Honors `NO_HYPERLINKS`/`FORCE_HYPERLINKS` and the
+	 * `--no-hyperlinks`/`--hyperlinks` argv flags, falling back to `isTTY`.
+	 */
+	readonly isHyperlinkSupported: boolean;
+
 	constructor(options: ResolvedOutputOptions) {
 		this.options = options;
 		this.policy = resolveOutputPolicy(options);
 		this.jsonMode = options.jsonMode;
 		this.isTTY = options.isTTY;
 		this.color = createColors(options.color);
+		this.isHyperlinkSupported = options.isHyperlinkSupported;
 
 		// Bind methods to the instance so they keep working when destructured
 		// off `out` (e.g. `const { log } = out`). Resolves subclass overrides

--- a/src/core/output/output-activity-dispatch.test.ts
+++ b/src/core/output/output-activity-dispatch.test.ts
@@ -34,6 +34,7 @@ function makeChannel(opts: { jsonMode?: boolean; isTTY?: boolean }): {
 		verbosity: 'normal',
 		jsonMode: opts.jsonMode ?? false,
 		color: false,
+		isHyperlinkSupported: false,
 	});
 	return { channel, stdout, stderr };
 }
@@ -139,6 +140,7 @@ describe('active handle tracking — implicit stop', () => {
 			isTTY: false,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: false,
 		});
 		const first = channel.spinner('First', { fallback: 'static' });
@@ -157,6 +159,7 @@ describe('active handle tracking — implicit stop', () => {
 			isTTY: true,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: false,
 		});
 		const spinner = channel.spinner('Spinning');
@@ -176,6 +179,7 @@ describe('active handle tracking — implicit stop', () => {
 			isTTY: true,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: false,
 		});
 		const progress = channel.progress({ total: 10 });
@@ -195,6 +199,7 @@ describe('active handle tracking — implicit stop', () => {
 			isTTY: false,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: false,
 		});
 		// Both are noop (non-TTY, silent fallback)
@@ -214,6 +219,7 @@ describe('active handle tracking — implicit stop', () => {
 			isTTY: true,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: true,
 		});
 		const first = channel.spinner('First');
@@ -256,6 +262,7 @@ describe('stopActive() — explicit cleanup', () => {
 				isTTY: true,
 				verbosity: 'normal',
 				color: false,
+				isHyperlinkSupported: false,
 				jsonMode: false,
 			});
 			channel.spinner('Leaked');
@@ -283,6 +290,7 @@ describe('stopActive() — explicit cleanup', () => {
 				isTTY: true,
 				verbosity: 'normal',
 				color: false,
+				isHyperlinkSupported: false,
 				jsonMode: false,
 			});
 			// Indeterminate progress starts a pulse timer
@@ -306,6 +314,7 @@ describe('stopActive() — explicit cleanup', () => {
 			isTTY: false,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: false,
 		});
 		expect(() => {
@@ -322,6 +331,7 @@ describe('stopActive() — explicit cleanup', () => {
 			isTTY: false,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: false,
 		});
 		const handle = channel.spinner('work', { fallback: 'static' });

--- a/src/core/output/output-tty.test.ts
+++ b/src/core/output/output-tty.test.ts
@@ -43,6 +43,7 @@ describe('OutputChannel.isTTY', () => {
 			isTTY: true,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: false,
 		});
 		expect(channel.isTTY).toBe(true);
@@ -56,6 +57,7 @@ describe('OutputChannel.isTTY', () => {
 			isTTY: true,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: false,
 		});
 		const piped = new OutputChannel({
@@ -64,6 +66,7 @@ describe('OutputChannel.isTTY', () => {
 			isTTY: false,
 			verbosity: 'normal',
 			color: false,
+			isHyperlinkSupported: false,
 			jsonMode: false,
 		});
 		expect(tty.isTTY).toBe(tty.options.isTTY);

--- a/src/core/output/output.test.ts
+++ b/src/core/output/output.test.ts
@@ -234,6 +234,15 @@ describe('resolveHyperlinkOverride', () => {
 	it('off wins when both off and on are present', () => {
 		expect(resolveHyperlinkOverride({ NO_HYPERLINKS: '1', FORCE_HYPERLINKS: '1' }, [])).toBe(false);
 	});
+
+	it('ignores flag tokens after the `--` separator', () => {
+		expect(resolveHyperlinkOverride({}, ['deploy', '--', '--no-hyperlinks'])).toBeUndefined();
+		expect(resolveHyperlinkOverride({}, ['deploy', '--', '--hyperlinks'])).toBeUndefined();
+	});
+
+	it('honors flag tokens before the `--` separator', () => {
+		expect(resolveHyperlinkOverride({}, ['--no-hyperlinks', '--', 'positional'])).toBe(false);
+	});
 });
 
 // --- createCaptureOutput — test helper

--- a/src/core/output/output.test.ts
+++ b/src/core/output/output.test.ts
@@ -1,5 +1,5 @@
 import type { Colors } from 'ansispeck';
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import type { Out } from '#internals/core/schema/command.ts';
 import type { CapturedOutput, OutputOptions, Verbosity, WriteFn } from './index.ts';
 import { createCaptureOutput, createOutput, getRequestedExitCode, OutputChannel } from './index.ts';
@@ -188,6 +188,39 @@ describe('isTTY', () => {
 	});
 });
 
+// --- Hyperlink support gate
+
+describe('isHyperlinkSupported', () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it('falls back to isTTY when no override is set', () => {
+		expect(createOutput({ isTTY: true }).isHyperlinkSupported).toBe(true);
+		expect(createOutput({ isTTY: false }).isHyperlinkSupported).toBe(false);
+	});
+
+	it('explicit hyperlinks option wins over isTTY', () => {
+		expect(createOutput({ isTTY: false, hyperlinks: true }).isHyperlinkSupported).toBe(true);
+		expect(createOutput({ isTTY: true, hyperlinks: false }).isHyperlinkSupported).toBe(false);
+	});
+
+	it('NO_HYPERLINKS forces off even on a TTY', () => {
+		vi.stubEnv('NO_HYPERLINKS', '1');
+		expect(createOutput({ isTTY: true }).isHyperlinkSupported).toBe(false);
+	});
+
+	it('FORCE_HYPERLINKS forces on even when piped', () => {
+		vi.stubEnv('FORCE_HYPERLINKS', '1');
+		expect(createOutput({ isTTY: false }).isHyperlinkSupported).toBe(true);
+	});
+
+	it('explicit hyperlinks option wins over environment overrides', () => {
+		vi.stubEnv('NO_HYPERLINKS', '1');
+		expect(createOutput({ isTTY: false, hyperlinks: true }).isHyperlinkSupported).toBe(true);
+	});
+});
+
 // --- createCaptureOutput — test helper
 
 describe('createCaptureOutput', () => {
@@ -241,6 +274,7 @@ describe('OutputChannel', () => {
 			verbosity: 'normal',
 			jsonMode: false,
 			color: false,
+			isHyperlinkSupported: false,
 		});
 		channel.log('test');
 		expect(lines).toEqual(['test\n']);
@@ -254,6 +288,7 @@ describe('OutputChannel', () => {
 			verbosity: 'quiet',
 			jsonMode: false,
 			color: false,
+			isHyperlinkSupported: false,
 		});
 		expect(channel.options.isTTY).toBe(true);
 		expect(channel.options.verbosity).toBe('quiet');
@@ -267,6 +302,7 @@ describe('OutputChannel', () => {
 			verbosity: 'quiet',
 			jsonMode: true,
 			color: false,
+			isHyperlinkSupported: false,
 		});
 		expect(channel.policy).toEqual({
 			jsonMode: true,

--- a/src/core/output/output.test.ts
+++ b/src/core/output/output.test.ts
@@ -1,8 +1,14 @@
 import type { Colors } from 'ansispeck';
-import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { Out } from '#internals/core/schema/command.ts';
 import type { CapturedOutput, OutputOptions, Verbosity, WriteFn } from './index.ts';
-import { createCaptureOutput, createOutput, getRequestedExitCode, OutputChannel } from './index.ts';
+import {
+	createCaptureOutput,
+	createOutput,
+	getRequestedExitCode,
+	OutputChannel,
+	resolveHyperlinkOverride,
+} from './index.ts';
 
 // --- createOutput — factory
 
@@ -191,10 +197,6 @@ describe('isTTY', () => {
 // --- Hyperlink support gate
 
 describe('isHyperlinkSupported', () => {
-	afterEach(() => {
-		vi.unstubAllEnvs();
-	});
-
 	it('falls back to isTTY when no override is set', () => {
 		expect(createOutput({ isTTY: true }).isHyperlinkSupported).toBe(true);
 		expect(createOutput({ isTTY: false }).isHyperlinkSupported).toBe(false);
@@ -204,20 +206,33 @@ describe('isHyperlinkSupported', () => {
 		expect(createOutput({ isTTY: false, hyperlinks: true }).isHyperlinkSupported).toBe(true);
 		expect(createOutput({ isTTY: true, hyperlinks: false }).isHyperlinkSupported).toBe(false);
 	});
+});
 
-	it('NO_HYPERLINKS forces off even on a TTY', () => {
-		vi.stubEnv('NO_HYPERLINKS', '1');
-		expect(createOutput({ isTTY: true }).isHyperlinkSupported).toBe(false);
+// --- resolveHyperlinkOverride — env/argv precedence
+
+describe('resolveHyperlinkOverride', () => {
+	it('returns undefined when nothing forces a decision', () => {
+		expect(resolveHyperlinkOverride({}, [])).toBeUndefined();
 	});
 
-	it('FORCE_HYPERLINKS forces on even when piped', () => {
-		vi.stubEnv('FORCE_HYPERLINKS', '1');
-		expect(createOutput({ isTTY: false }).isHyperlinkSupported).toBe(true);
+	it('NO_HYPERLINKS forces off', () => {
+		expect(resolveHyperlinkOverride({ NO_HYPERLINKS: '1' }, [])).toBe(false);
 	});
 
-	it('explicit hyperlinks option wins over environment overrides', () => {
-		vi.stubEnv('NO_HYPERLINKS', '1');
-		expect(createOutput({ isTTY: false, hyperlinks: true }).isHyperlinkSupported).toBe(true);
+	it('--no-hyperlinks forces off', () => {
+		expect(resolveHyperlinkOverride({}, ['--no-hyperlinks'])).toBe(false);
+	});
+
+	it('FORCE_HYPERLINKS forces on', () => {
+		expect(resolveHyperlinkOverride({ FORCE_HYPERLINKS: '1' }, [])).toBe(true);
+	});
+
+	it('--hyperlinks forces on', () => {
+		expect(resolveHyperlinkOverride({}, ['--hyperlinks'])).toBe(true);
+	});
+
+	it('off wins when both off and on are present', () => {
+		expect(resolveHyperlinkOverride({ NO_HYPERLINKS: '1', FORCE_HYPERLINKS: '1' }, [])).toBe(false);
 	});
 });
 

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -339,6 +339,7 @@ describe('full command composition', () => {
 			jsonMode: false,
 			isTTY: false,
 			color: createColors(false),
+			isHyperlinkSupported: false,
 		};
 
 		// Simulate what the runtime will do

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -211,6 +211,16 @@ interface Out {
 	readonly color: Colors;
 
 	/**
+	 * Whether OSC 8 terminal hyperlinks should be emitted.
+	 *
+	 * Honors `NO_HYPERLINKS`/`FORCE_HYPERLINKS` and the
+	 * `--no-hyperlinks`/`--hyperlinks` argv flags, falling back to `isTTY`.
+	 * Handlers rendering their own `out.color.link(...)` output can gate on
+	 * this to keep OSC 8 escapes out of piped or opted-out contexts.
+	 */
+	readonly isHyperlinkSupported: boolean;
+
+	/**
 	 * Render tabular data.
 	 *
 	 * - **TTY mode** (non-JSON): Pretty-print aligned columns with headers.


### PR DESCRIPTION
Closes #63.

## Problem

The root-help header hyperlink gate defaulted to raw `out.isTTY`:

```ts
hyperlinks: options?.help?.hyperlinks ?? this.schema.helpConfig?.hyperlinks ?? out.isTTY,
```

So `NO_HYPERLINKS=1 <cli> --help` still emitted OSC 8 links in the header. ansispeck resolves hyperlink support while honoring `NO_HYPERLINKS`/`FORCE_HYPERLINKS` and `--no-hyperlinks`/`--hyperlinks`, but the help gate never consulted that path.

## Fix

The output channel now resolves a new `isHyperlinkSupported` property, mirroring how `color` is resolved:

- explicit `hyperlinks` output option wins,
- then `NO_HYPERLINKS`/`FORCE_HYPERLINKS` and the `--no-hyperlinks`/`--hyperlinks` argv flags,
- then falls back to the channel's `isTTY`.

The env/argv override reads the same signals ansispeck does, but leaves the TTY fallback to the channel so an explicitly-configured `isTTY` (e.g. `.execute({ isTTY: true })`) still applies. The header gate consults `out.isHyperlinkSupported` instead of `out.isTTY`. `out.isHyperlinkSupported` is also exposed on the public `Out` interface for consumers rendering their own `out.color.link(...)` output.

## Tests

- `output.test.ts` — resolution matrix: TTY fallback, explicit option override, `NO_HYPERLINKS`/`FORCE_HYPERLINKS`, and explicit-option-beats-env.
- `cli-links.test.ts` — end-to-end: `NO_HYPERLINKS` suppresses header links on a TTY; `FORCE_HYPERLINKS` emits them without one.

Full typecheck, biome, dprint, and the output/cli/schema suites (919 tests) pass.

Bumps to `3.0.0-rc.12`.