### PR TITLE
feat(help): syntax-highlight example commands (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0-rc.13] - 2026-07-20
+
+### Changed
+
+- **Syntax-highlighted example commands** — the `Examples:` help section now
+  highlights each command per token: the leading binary via `usageBin` (bold)
+  and flag tokens (`-x`, `--long`) via `flag` (cyan), with values left plain.
+  Tokenizing is quote-aware so `--scope './a b'` stays one token, and the
+  existing color gate is respected (identity formatters when `NO_COLOR` or
+  non-TTY), so `stripAnsi(colored)` still equals the plain rendering.
+
 ## [3.0.0-rc.12] - 2026-07-20
 
 ### Added
@@ -1264,7 +1275,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MIT License.
 - Markdownlint configuration.
 
-[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.12...HEAD
+[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.13...HEAD
+[3.0.0-rc.13]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.12...v3.0.0-rc.13
 [3.0.0-rc.12]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.11...v3.0.0-rc.12
 [3.0.0-rc.11]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.10...v3.0.0-rc.11
 [3.0.0-rc.10]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.9...v3.0.0-rc.10

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.12",
+	"version": "3.0.0-rc.13",
 	"license": "MIT",
 	"tasks": {
 		"check": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.12",
+	"version": "3.0.0-rc.13",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
 		"dreamcli",

--- a/src/core/help/index.ts
+++ b/src/core/help/index.ts
@@ -598,10 +598,36 @@ function formatCommandsSection(
 }
 
 /**
+ * One shell token: a single- or double-quoted span (kept whole so internal
+ * spaces don't split it) or a run of non-whitespace characters.
+ */
+const EXAMPLE_TOKEN = /(?:'[^']*'|"[^"]*"|\S)+/g;
+
+/**
+ * Highlight an example command per token: the leading binary via `usageBin`,
+ * flag tokens (`-x`, `--long`) via `flag`, everything else plain.
+ *
+ * Uses `replace` so only the token spans are wrapped and the whitespace
+ * between them is preserved verbatim — with the color gate off (identity
+ * formatters) the result equals `command`, so `stripAnsi(highlighted)` stays
+ * equal to the plain rendering.
+ */
+function highlightExampleCommand(command: string, theme: HelpTheme): string {
+	let index = 0;
+	return command.replace(EXAMPLE_TOKEN, (token) => {
+		const styled =
+			index === 0 ? theme.usageBin(token) : token.startsWith('-') ? theme.flag(token) : token;
+		index += 1;
+		return styled;
+	});
+}
+
+/**
  * Render the `Examples:` help section.
  *
  * @param examples - Array of {@link CommandExample} entries.
- * @param theme - Theme applied to the section title and `$` prompt marker.
+ * @param theme - Theme applied to the section title, `$` prompt marker, and
+ *   per-token command highlighting.
  * @returns Multi-line examples section string.
  */
 function formatExamplesSection(examples: readonly CommandExample[], theme: HelpTheme): string {
@@ -609,11 +635,12 @@ function formatExamplesSection(examples: readonly CommandExample[], theme: HelpT
 	const prompt = theme.examplePrompt('$');
 
 	for (const example of examples) {
+		const command = highlightExampleCommand(example.command, theme);
 		if (example.description !== undefined) {
 			lines.push(`  ${example.description}:`);
-			lines.push(`    ${prompt} ${example.command}`);
+			lines.push(`    ${prompt} ${command}`);
 		} else {
-			lines.push(`  ${prompt} ${example.command}`);
+			lines.push(`  ${prompt} ${command}`);
 		}
 	}
 

--- a/src/core/help/theme.test.ts
+++ b/src/core/help/theme.test.ts
@@ -145,6 +145,13 @@ describe('example command highlighting', () => {
 		expect(help).not.toContain(on.cyan("'./a b'"));
 	});
 
+	it('cyans short flags as well as long flags', () => {
+		const help = formatHelp(exampleCommand('mycli -f production'), { colors: on });
+		expect(help).toContain(on.cyan('-f'));
+		expect(help).toContain('production');
+		expect(help).not.toContain(on.cyan('production'));
+	});
+
 	it('keeps a quoted argument with internal spaces as one plain token', () => {
 		const help = formatHelp(exampleCommand("mycli --msg 'a b c'"), { colors: on });
 		expect(help).toContain(`${on.cyan('--msg')} 'a b c'`);

--- a/src/core/help/theme.test.ts
+++ b/src/core/help/theme.test.ts
@@ -132,6 +132,38 @@ describe('formatHelp theming', () => {
 	});
 });
 
+describe('example command highlighting', () => {
+	function exampleCommand(cmd: string) {
+		return command('deploy').description('Deploy the app').example(cmd).schema;
+	}
+
+	it('bolds the binary, cyans flag tokens, and leaves values plain', () => {
+		const help = formatHelp(exampleCommand("mycli --scope './a b' run"), { colors: on });
+		expect(help).toContain(on.bold('mycli'));
+		expect(help).toContain(on.cyan('--scope'));
+		expect(help).toContain("'./a b'");
+		expect(help).not.toContain(on.cyan("'./a b'"));
+	});
+
+	it('keeps a quoted argument with internal spaces as one plain token', () => {
+		const help = formatHelp(exampleCommand("mycli --msg 'a b c'"), { colors: on });
+		expect(help).toContain(`${on.cyan('--msg')} 'a b c'`);
+	});
+
+	it('emits no escapes when color is off', () => {
+		const help = formatHelp(exampleCommand("mycli --scope './a b' run"));
+		expect(help).not.toContain(ESC);
+		expect(help).toContain("$ mycli --scope './a b' run");
+	});
+
+	it('strip-equivalence holds with quoted args and irregular spacing', () => {
+		const schema = exampleCommand("mycli --scope './a b'  run --force");
+		const plain = formatHelp(schema);
+		const colored = formatHelp(schema, { colors: on });
+		expect(stripAnsi(colored)).toBe(plain);
+	});
+});
+
 describe('defaultHelpTheme', () => {
 	it('is identity end-to-end with a disabled palette', () => {
 		const theme = defaultHelpTheme(createColors(false));


### PR DESCRIPTION
Closes #65.

## Problem

The `Examples:` section renders each command verbatim — only the `$` prompt is themed, so the binary, flags, and values are all unstyled while the rest of help is colored.

## Fix

`highlightExampleCommand` styles each token: the leading binary via `usageBin` (bold), flag tokens (`-x`, `--long`) via `flag` (cyan), values plain. No new theme roles — it reuses existing formatters.

Tokenizing is quote-aware (`/(?:'[^']*'|"[^"]*"|\S)+/g`) so `--scope './a b'` stays one token. The highlighter uses `String.replace` rather than the issue's `match().join(' ')`, so it wraps **only** the token spans and leaves the whitespace between them untouched. That preserves the color-gate invariant exactly: with identity formatters (`NO_COLOR`/non-TTY) the output equals the original command, so `stripAnsi(highlighted)` still equals the plain rendering — even with irregular spacing.

## Tests

`theme.test.ts` — binary bold / flags cyan / values plain; quoted arg with internal spaces stays one plain token; no escapes when color is off; and strip-equivalence with quoted args plus irregular spacing. The existing whole-help strip-equivalence test also guards the example line.

Full help suite (103 tests), typecheck, biome, dprint pass.

Bumps to `3.0.0-rc.13`.