### PR TITLE
feat(schema): function-form examples resolved with program meta (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0-rc.14] - 2026-07-20
+
+### Added
+
+- **Function-form examples** — `.example()` now accepts a
+  `(meta) => string` builder alongside the literal string. `meta` carries the
+  invoked program `name` (`help.binName`, falling back to the command name) and
+  `version`, resolved at render time, so examples reference the real program
+  name instead of hardcoding it and stay truthful under symlinks, `inheritName`,
+  and `npx x` vs a global install. The thunk resolves in both `--help` text
+  (composing with example highlighting) and `--json`/definition-schema output.
+- **`ExampleMeta`** and **`ExampleCommand`** public types for annotating
+  function-form example builders.
+
 ## [3.0.0-rc.13] - 2026-07-20
 
 ### Changed
@@ -1275,7 +1289,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MIT License.
 - Markdownlint configuration.
 
-[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.13...HEAD
+[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.14...HEAD
+[3.0.0-rc.14]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.13...v3.0.0-rc.14
 [3.0.0-rc.13]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.12...v3.0.0-rc.13
 [3.0.0-rc.12]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.11...v3.0.0-rc.12
 [3.0.0-rc.11]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.10...v3.0.0-rc.11

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.13",
+	"version": "3.0.0-rc.14",
 	"license": "MIT",
 	"tasks": {
 		"check": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.13",
+	"version": "3.0.0-rc.14",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
 		"dreamcli",

--- a/src/core/cli/cli-examples.test.ts
+++ b/src/core/cli/cli-examples.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from 'vitest';
 import { command } from '#internals/core/schema/command.ts';
 import { cli } from './index.ts';
 
+// === Helpers
+
 function deployCommand() {
 	return command('deploy')
 		.description('Deploy the app')
@@ -14,6 +16,8 @@ function deployCommand() {
 			out.log('deployed');
 		});
 }
+
+// === Function-form examples — end to end
 
 describe('function-form examples — end to end', () => {
 	it('resolves meta.name to the invoked program name in command help', async () => {
@@ -45,5 +49,14 @@ describe('function-form examples — end to end', () => {
 		const result = await app.execute(['deploy', '--help', '--json']);
 		const parsed = JSON.parse(result.stdout.join('')) as { examples?: { command: string }[] };
 		expect(parsed.examples?.[0]?.command).toBe('mycli deploy --force');
+	});
+
+	it('propagates a runtime binName override to root --json help', async () => {
+		const app = cli('mycli').command(deployCommand());
+		const result = await app.execute(['--help', '--json'], { help: { binName: 'renamed' } });
+		const parsed = JSON.parse(result.stdout.join('')) as {
+			commands?: { examples?: { command: string }[] }[];
+		};
+		expect(parsed.commands?.[0]?.examples?.[0]?.command).toBe('renamed deploy --force');
 	});
 });

--- a/src/core/cli/cli-examples.test.ts
+++ b/src/core/cli/cli-examples.test.ts
@@ -1,0 +1,49 @@
+/**
+ * End-to-end tests for function-form `.example()` commands, which resolve
+ * against the invoked program name/version at render time.
+ */
+import { describe, expect, it } from 'vitest';
+import { command } from '#internals/core/schema/command.ts';
+import { cli } from './index.ts';
+
+function deployCommand() {
+	return command('deploy')
+		.description('Deploy the app')
+		.example((m) => `${m.name} deploy --force`, 'Force deploy')
+		.action(({ out }) => {
+			out.log('deployed');
+		});
+}
+
+describe('function-form examples — end to end', () => {
+	it('resolves meta.name to the invoked program name in command help', async () => {
+		const app = cli('mycli').command(deployCommand());
+		const result = await app.execute(['deploy', '--help']);
+		expect(result.stdout.join('')).toContain('$ mycli deploy --force');
+	});
+
+	it('reflects an inheritName-style binName override', async () => {
+		const app = cli('mycli').command(deployCommand());
+		const result = await app.execute(['deploy', '--help'], { help: { binName: 'renamed' } });
+		expect(result.stdout.join('')).toContain('$ renamed deploy --force');
+	});
+
+	it('passes the program version to function-form examples', async () => {
+		const app = cli('mycli')
+			.version('4.2.0')
+			.command(
+				command('gen')
+					.example((m) => `gen@${m.version ?? 'dev'}`)
+					.action(() => {}),
+			);
+		const result = await app.execute(['gen', '--help']);
+		expect(result.stdout.join('')).toContain('$ gen@4.2.0');
+	});
+
+	it('serializes the resolved command in --json help, matching text help', async () => {
+		const app = cli('mycli').command(deployCommand());
+		const result = await app.execute(['deploy', '--help', '--json']);
+		const parsed = JSON.parse(result.stdout.join('')) as { examples?: { command: string }[] };
+		expect(parsed.examples?.[0]?.command).toBe('mycli deploy --force');
+	});
+});

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -1152,6 +1152,7 @@ class CLIBuilder {
 		// name, hyperlinks to the channel's resolved support (NO_HYPERLINKS/
 		// FORCE_HYPERLINKS honored, else TTY), and colors to the output
 		// channel's gated palette (escapes never leak into piped output).
+		const resolvedVersion = options?.help?.version ?? this.schema.version;
 		const helpOptions: HelpOptions = {
 			...this.schema.helpConfig,
 			...options?.help,
@@ -1159,6 +1160,7 @@ class CLIBuilder {
 			hyperlinks:
 				options?.help?.hyperlinks ?? this.schema.helpConfig?.hyperlinks ?? out.isHyperlinkSupported,
 			colors: options?.help?.colors ?? out.color,
+			...(resolvedVersion !== undefined ? { version: resolvedVersion } : {}),
 		};
 
 		// -- Shared options for command execution ----------------------------------
@@ -1242,7 +1244,12 @@ class CLIBuilder {
 
 			case 'needs-subcommand': {
 				if (jsonMode) {
-					out.json(generateCommandSchema(planned.command.schema));
+					out.json(
+						generateCommandSchema(planned.command.schema, undefined, {
+							name: planned.help.binName ?? planned.command.schema.name,
+							version: planned.help.version,
+						}),
+					);
 				} else {
 					const helpText = formatHelp(planned.command.schema, planned.help);
 					out.log(helpText);

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -1222,7 +1222,12 @@ class CLIBuilder {
 
 			case 'root-help': {
 				if (jsonMode) {
-					out.json(generateSchema(this.schema));
+					out.json(
+						generateSchema(this.schema, undefined, {
+							name: planned.help.binName ?? this.schema.name,
+							version: planned.help.version ?? this.schema.version,
+						}),
+					);
 				} else {
 					const helpText = formatRootHelp(resolveHelpLinksSchema(this.schema), planned.help);
 					out.log(helpText);

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -77,7 +77,12 @@ async function executeCommand(request: CommandExecutionRequest): Promise<Command
 			// layer (root `--json` is stripped from argv pre-dispatch) — an injected
 			// `out` may predate it, so the channel flag alone is not authoritative.
 			if (out.jsonMode || options?.jsonMode === true) {
-				out.json(generateCommandSchema(schema));
+				out.json(
+					generateCommandSchema(schema, undefined, {
+						name: options?.help?.binName ?? schema.name,
+						version: options?.help?.version,
+					}),
+				);
 				return { exitCode: 0, error: undefined };
 			}
 			// Standalone `cmd.run()` / testkit paths reach here without the CLI

--- a/src/core/help/help.test.ts
+++ b/src/core/help/help.test.ts
@@ -515,6 +515,25 @@ describe('formatHelp', () => {
 			expect(help).toContain('$ deploy staging');
 			expect(help).toContain('$ deploy production --force');
 		});
+
+		it('resolves a function-form example with the program name', () => {
+			const cmd = command('deploy').example((m) => `${m.name} deploy --force`, 'Force deploy');
+			const help = formatHelp(cmd.schema, { binName: 'mycli' });
+			expect(help).toContain('Force deploy:');
+			expect(help).toContain('$ mycli deploy --force');
+		});
+
+		it('passes the program version to a function-form example', () => {
+			const cmd = command('gen').example((m) => `gen@${m.version ?? 'dev'}`);
+			const help = formatHelp(cmd.schema, { binName: 'mycli', version: '1.2.3' });
+			expect(help).toContain('$ gen@1.2.3');
+		});
+
+		it('falls back meta.name to the command name when no binName is set', () => {
+			const cmd = command('deploy').example((m) => `${m.name} --force`);
+			const help = formatHelp(cmd.schema);
+			expect(help).toContain('$ deploy --force');
+		});
 	});
 
 	// -----------------------------------------------------------------------

--- a/src/core/help/index.ts
+++ b/src/core/help/index.ts
@@ -10,12 +10,14 @@
 
 import type { Colors } from 'ansispeck';
 import { formatDisplayValue } from '#internals/core/output/display-value.ts';
+import { resolveExampleCommand } from '#internals/core/schema/command.ts';
 import { getFlagAliasNames } from '#internals/core/schema/flag.ts';
 import type {
 	ArgSchema,
 	CommandArgEntry,
 	CommandExample,
 	CommandSchema,
+	ExampleMeta,
 	FlagSchema,
 } from '#internals/core/schema/index.ts';
 import { padEnd, visibleWidth, wrapText } from './ansi.ts';
@@ -30,6 +32,8 @@ interface HelpOptions {
 	readonly width?: number;
 	/** Binary/program name shown in the usage line. Defaults to command name. */
 	readonly binName?: string;
+	/** Program version passed to function-form examples as `meta.version`. */
+	readonly version?: string;
 	/**
 	 * Emit OSC 8 hyperlinks where link metadata is available (currently the
 	 * root-help header name/version configured via `CLIBuilder.links()`).
@@ -87,6 +91,7 @@ interface HelpOptions {
 interface ResolvedHelpOptions {
 	readonly width: number;
 	readonly binName: string | undefined;
+	readonly version: string | undefined;
 	readonly isDefaultHelp: boolean;
 	readonly theme: HelpTheme;
 }
@@ -103,6 +108,7 @@ function resolveOptions(options?: HelpOptions): ResolvedHelpOptions {
 	return {
 		width: options?.width ?? DEFAULT_WIDTH,
 		binName: options?.binName,
+		version: options?.version,
 		isDefaultHelp: options?.isDefaultHelp ?? false,
 		theme: resolveHelpTheme(options?.colors, options?.theme),
 	};
@@ -381,7 +387,8 @@ function formatHelpSections(schema: CommandSchema, options?: HelpOptions): reado
 
 	// ---- Examples -----------------------------------------------------------
 	if (schema.examples.length > 0) {
-		sections.push(formatExamplesSection(schema.examples, opts.theme));
+		const meta: ExampleMeta = { name: opts.binName ?? schema.name, version: opts.version };
+		sections.push(formatExamplesSection(schema.examples, opts.theme, meta));
 	}
 
 	return sections;
@@ -628,14 +635,19 @@ function highlightExampleCommand(command: string, theme: HelpTheme): string {
  * @param examples - Array of {@link CommandExample} entries.
  * @param theme - Theme applied to the section title, `$` prompt marker, and
  *   per-token command highlighting.
+ * @param meta - Program name/version passed to function-form example commands.
  * @returns Multi-line examples section string.
  */
-function formatExamplesSection(examples: readonly CommandExample[], theme: HelpTheme): string {
+function formatExamplesSection(
+	examples: readonly CommandExample[],
+	theme: HelpTheme,
+	meta: ExampleMeta,
+): string {
 	const lines: string[] = [theme.sectionTitle('Examples:')];
 	const prompt = theme.examplePrompt('$');
 
 	for (const example of examples) {
-		const command = highlightExampleCommand(example.command, theme);
+		const command = highlightExampleCommand(resolveExampleCommand(example.command, meta), theme);
 		if (example.description !== undefined) {
 			lines.push(`  ${example.description}:`);
 			lines.push(`    ${prompt} ${command}`);

--- a/src/core/help/theme.test.ts
+++ b/src/core/help/theme.test.ts
@@ -169,6 +169,15 @@ describe('example command highlighting', () => {
 		const colored = formatHelp(schema, { colors: on });
 		expect(stripAnsi(colored)).toBe(plain);
 	});
+
+	it('highlights a function-form example after resolving it', () => {
+		const schema = command('deploy')
+			.description('Deploy the app')
+			.example((m) => `${m.name} --force`).schema;
+		const help = formatHelp(schema, { binName: 'mycli', colors: on });
+		expect(help).toContain(on.bold('mycli'));
+		expect(help).toContain(on.cyan('--force'));
+	});
 });
 
 describe('defaultHelpTheme', () => {

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -115,6 +115,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  *
  * @param schema - The CLI schema from `CLIBuilder.schema`.
  * @param options - Generation options.
+ * @param meta - Program name/version for function-form examples; defaults to
+ *   the CLI schema's own `name`/`version`.
  * @returns A plain object suitable for `JSON.stringify()`.
  *
  * @example
@@ -124,9 +126,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * writeFileSync('cli-schema.json', JSON.stringify(definition, null, 2));
  * ```
  */
-function generateSchema(schema: CLISchema, options?: JsonSchemaOptions): Record<string, unknown> {
+function generateSchema(
+	schema: CLISchema,
+	options?: JsonSchemaOptions,
+	meta?: ExampleMeta,
+): Record<string, unknown> {
 	const opts = resolveOptions(options);
-	const meta: ExampleMeta = { name: schema.name, version: schema.version };
+	const resolvedMeta: ExampleMeta = meta ?? { name: schema.name, version: schema.version };
 
 	const result: Record<string, unknown> = {
 		$schema: DEFINITION_SCHEMA_URL,
@@ -146,12 +152,12 @@ function generateSchema(schema: CLISchema, options?: JsonSchemaOptions): Record<
 		// Full definition, not just the name — the default command lives only in
 		// `defaultCommand` (never in `commands`), so a name-only reference would
 		// drop its flags/args from the document entirely.
-		result.defaultCommand = serializeCommand(schema.defaultCommand.schema, opts, meta);
+		result.defaultCommand = serializeCommand(schema.defaultCommand.schema, opts, resolvedMeta);
 	}
 
 	result.commands = schema.commands
 		.filter((cmd) => opts.includeHidden || !cmd.schema.hidden)
-		.map((cmd) => serializeCommand(cmd.schema, opts, meta));
+		.map((cmd) => serializeCommand(cmd.schema, opts, resolvedMeta));
 
 	return result;
 }
@@ -168,6 +174,8 @@ function generateSchema(schema: CLISchema, options?: JsonSchemaOptions): Record<
  *
  * @param schema - The command schema to serialize.
  * @param options - Generation options.
+ * @param meta - Program name/version for function-form examples; defaults to
+ *   the command's own name with no version.
  * @returns A plain object suitable for `JSON.stringify()`.
  */
 function generateCommandSchema(

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -14,12 +14,14 @@
  */
 
 import type { CLISchema } from '#internals/core/cli/index.ts';
+import { resolveExampleCommand } from '#internals/core/schema/command.ts';
 import { getFlagAliasNames } from '#internals/core/schema/flag.ts';
 import type {
 	ArgSchema,
 	CommandArgEntry,
 	CommandExample,
 	CommandSchema,
+	ExampleMeta,
 	FlagSchema,
 	PromptConfig,
 	SelectChoice,
@@ -124,6 +126,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  */
 function generateSchema(schema: CLISchema, options?: JsonSchemaOptions): Record<string, unknown> {
 	const opts = resolveOptions(options);
+	const meta: ExampleMeta = { name: schema.name, version: schema.version };
 
 	const result: Record<string, unknown> = {
 		$schema: DEFINITION_SCHEMA_URL,
@@ -143,12 +146,12 @@ function generateSchema(schema: CLISchema, options?: JsonSchemaOptions): Record<
 		// Full definition, not just the name — the default command lives only in
 		// `defaultCommand` (never in `commands`), so a name-only reference would
 		// drop its flags/args from the document entirely.
-		result.defaultCommand = serializeCommand(schema.defaultCommand.schema, opts);
+		result.defaultCommand = serializeCommand(schema.defaultCommand.schema, opts, meta);
 	}
 
 	result.commands = schema.commands
 		.filter((cmd) => opts.includeHidden || !cmd.schema.hidden)
-		.map((cmd) => serializeCommand(cmd.schema, opts));
+		.map((cmd) => serializeCommand(cmd.schema, opts, meta));
 
 	return result;
 }
@@ -170,8 +173,10 @@ function generateSchema(schema: CLISchema, options?: JsonSchemaOptions): Record<
 function generateCommandSchema(
 	schema: CommandSchema,
 	options?: JsonSchemaOptions,
+	meta?: ExampleMeta,
 ): Record<string, unknown> {
-	return serializeCommand(schema, resolveOptions(options));
+	const resolvedMeta: ExampleMeta = meta ?? { name: schema.name, version: undefined };
+	return serializeCommand(schema, resolveOptions(options), resolvedMeta);
 }
 
 /**
@@ -181,7 +186,11 @@ function generateCommandSchema(
  * @param opts - Resolved generation options (hidden/prompt inclusion).
  * @returns JSON-serializable object representing the command.
  */
-function serializeCommand(schema: CommandSchema, opts: ResolvedOptions): Record<string, unknown> {
+function serializeCommand(
+	schema: CommandSchema,
+	opts: ResolvedOptions,
+	meta: ExampleMeta,
+): Record<string, unknown> {
 	const result: Record<string, unknown> = { name: schema.name };
 
 	if (schema.description !== undefined) {
@@ -194,7 +203,7 @@ function serializeCommand(schema: CommandSchema, opts: ResolvedOptions): Record<
 		result.hidden = true;
 	}
 	if (schema.examples.length > 0) {
-		result.examples = schema.examples.map(serializeExample);
+		result.examples = schema.examples.map((example) => serializeExample(example, meta));
 	}
 
 	// Flags — always present (consumers iterate without existence check)
@@ -210,7 +219,7 @@ function serializeCommand(schema: CommandSchema, opts: ResolvedOptions): Record<
 	// Subcommands — always present
 	result.commands = schema.commands
 		.filter((cmd) => opts.includeHidden || !cmd.hidden)
-		.map((cmd) => serializeCommand(cmd, opts));
+		.map((cmd) => serializeCommand(cmd, opts, meta));
 
 	return result;
 }
@@ -416,11 +425,17 @@ function serializeChoice(choice: SelectChoice): Record<string, unknown> {
 /**
  * Serialize a {@link CommandExample} into a plain object.
  *
+ * Function-form commands are resolved against `meta` so the output is a plain
+ * serializable string rather than a dropped function.
+ *
  * @param example - The example to serialize.
+ * @param meta - Program name/version passed to function-form commands.
  * @returns JSON-serializable object with command and optional description.
  */
-function serializeExample(example: CommandExample): Record<string, unknown> {
-	const result: Record<string, unknown> = { command: example.command };
+function serializeExample(example: CommandExample, meta: ExampleMeta): Record<string, unknown> {
+	const result: Record<string, unknown> = {
+		command: resolveExampleCommand(example.command, meta),
+	};
 	if (example.description !== undefined) {
 		result.description = example.description;
 	}

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -225,6 +225,17 @@ describe('generateSchema — definition metadata', () => {
 		);
 	});
 
+	it('resolves function-form example commands against the program meta', () => {
+		const cmd = commandDef({
+			name: 'deploy',
+			examples: [{ command: (m) => `${m.name}@${m.version ?? 'dev'} deploy` }],
+		});
+		const result = generateSchema(
+			minimalCLI({ name: 'mycli', version: '2.0.0', commands: [erased(cmd)] }),
+		);
+		expect(result).toHaveProperty(['commands', 0, 'examples'], [{ command: 'mycli@2.0.0 deploy' }]);
+	});
+
 	// -------------------------------------------------------------------
 	// Flag serialization
 	// -------------------------------------------------------------------

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -2,8 +2,15 @@ import { createColors } from 'ansispeck';
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { CLIError } from '#internals/core/errors/index.ts';
 import { arg } from './arg.ts';
-import type { ActionParams, CommandArgEntry, CommandSchema, Out } from './command.ts';
-import { CommandBuilder, command, group } from './command.ts';
+import type {
+	ActionParams,
+	CommandArgEntry,
+	CommandExample,
+	CommandSchema,
+	ExampleMeta,
+	Out,
+} from './command.ts';
+import { CommandBuilder, command, group, resolveExampleCommand } from './command.ts';
 import { flag } from './flag.ts';
 import { middleware } from './middleware.ts';
 
@@ -101,6 +108,17 @@ describe('.example()', () => {
 		const b = a.example('deploy staging');
 		expect(a).not.toBe(b);
 		expect(a.schema.examples).toEqual([]);
+	});
+
+	it('accepts a function-form command resolved against program meta', () => {
+		const build = (m: ExampleMeta) => `${m.name} deploy --force`;
+		const cmd = command('deploy').example(build, 'Force deploy');
+		const stored = cmd.schema.examples[0];
+		expect(stored?.command).toBe(build);
+		expect(stored?.description).toBe('Force deploy');
+		expect(resolveExampleCommand(build, { name: 'mycli', version: '1.0.0' })).toBe(
+			'mycli deploy --force',
+		);
 	});
 });
 
@@ -603,7 +621,7 @@ describe('CommandSchema', () => {
 		expectTypeOf(schema.description).toEqualTypeOf<string | undefined>();
 		expectTypeOf(schema.aliases).toEqualTypeOf<readonly string[]>();
 		expectTypeOf(schema.hidden).toBeBoolean();
-		expectTypeOf(schema.examples).toMatchTypeOf<readonly { command: string }[]>();
+		expectTypeOf(schema.examples).toEqualTypeOf<readonly CommandExample[]>();
 		expectTypeOf(schema.flags).toMatchTypeOf<Record<string, unknown>>();
 		expectTypeOf(schema.args).toMatchTypeOf<readonly CommandArgEntry[]>();
 		expectTypeOf(schema.hasAction).toBeBoolean();

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -453,12 +453,37 @@ type ExecutionStep =
 
 // --- Runtime schema data
 
+/**
+ * Program metadata passed to a function-form example, resolved at render time.
+ *
+ * `name` is the actually-invoked program name (`options.help.binName`, falling
+ * back to the command name) so examples stay truthful under symlinks,
+ * `inheritName`, and `npx x` vs a global install. `version` is the program
+ * version, or `undefined` when none is configured.
+ */
+interface ExampleMeta {
+	readonly name: string;
+	readonly version: string | undefined;
+}
+
+/**
+ * An example command line: a literal string, or a function resolved at render
+ * time with the program {@link ExampleMeta} (so the program name need not be
+ * hardcoded).
+ */
+type ExampleCommand = string | ((meta: ExampleMeta) => string);
+
 /** A single usage example shown in help text. */
 interface CommandExample {
 	/** The command invocation (e.g. `'deploy production --force'`). */
-	readonly command: string;
+	readonly command: ExampleCommand;
 	/** Optional description of what this example does. */
 	readonly description?: string;
+}
+
+/** Resolve an {@link ExampleCommand} to its string form for the given meta. */
+function resolveExampleCommand(command: ExampleCommand, meta: ExampleMeta): string {
+	return typeof command === 'function' ? command(meta) : command;
 }
 
 /**
@@ -1195,7 +1220,13 @@ class CommandBuilder<
 	 * Call multiple times to add several examples. Each example shows a
 	 * shell invocation, optionally with a description.
 	 *
-	 * @param cmd - The example command line (without the program name prefix).
+	 * `cmd` may be a literal string or a function receiving the program
+	 * {@link ExampleMeta} (`name`, `version`), resolved at render time. Use the
+	 * function form to reference the invoked program name instead of hardcoding
+	 * it, so examples stay truthful under symlinks, `inheritName`, and
+	 * `npx x` vs a global install.
+	 *
+	 * @param cmd - The example command line, or a `(meta) => string` builder.
 	 * @param description - Optional one-line explanation of what the example does.
 	 *
 	 * @example
@@ -1204,19 +1235,19 @@ class CommandBuilder<
 	 *   .arg('target', arg.string())
 	 *   .flag('force', flag.boolean().alias('f'))
 	 *   .example('deploy production', 'Deploy to production')
-	 *   .example('deploy staging -f', 'Force deploy to staging')
+	 *   .example((m) => `${m.name} deploy staging -f`, 'Force deploy to staging')
 	 *   .action(({ args, flags }) => { ... });
 	 *
 	 * // $ mycli deploy --help
 	 * // ...
 	 * // Examples:
-	 * //   deploy production      Deploy to production
-	 * //   deploy staging -f      Force deploy to staging
+	 * //   deploy production        Deploy to production
+	 * //   mycli deploy staging -f  Force deploy to staging
 	 * ```
 	 *
 	 * @returns The builder (for chaining).
 	 */
-	example(cmd: string, description?: string): CommandBuilder<F, A, C> {
+	example(cmd: ExampleCommand, description?: string): CommandBuilder<F, A, C> {
 		const entry: CommandExample =
 			description !== undefined ? { command: cmd, description } : { command: cmd };
 		return new CommandBuilder(
@@ -1536,6 +1567,8 @@ export type {
 	ErasedCommand,
 	ErasedDeriveHandler,
 	ErasedInteractiveResolver,
+	ExampleCommand,
+	ExampleMeta,
 	InteractiveParams,
 	InteractiveResolver,
 	InteractiveResult,
@@ -1544,4 +1577,4 @@ export type {
 	WidenContext,
 	WidenDerivedContext,
 };
-export { CommandBuilder, command, group };
+export { CommandBuilder, command, group, resolveExampleCommand };

--- a/src/core/schema/index.ts
+++ b/src/core/schema/index.ts
@@ -44,12 +44,14 @@ export type {
 	ErasedCommand,
 	ErasedDeriveHandler,
 	ErasedInteractiveResolver,
+	ExampleCommand,
+	ExampleMeta,
 	InteractiveParams,
 	InteractiveResolver,
 	InteractiveResult,
 	Out,
 } from './command.ts';
-export { CommandBuilder, command, group } from './command.ts';
+export { CommandBuilder, command, group, resolveExampleCommand } from './command.ts';
 export type {
 	ConfirmPromptConfig,
 	DateFlagOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,4 +206,5 @@ export {
 	getFlagNegatedName,
 	group,
 	middleware,
+	resolveExampleCommand,
 } from './core/schema/index.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,8 @@ export type {
 	DeriveHandler,
 	DeriveParams,
 	DuplicatePolicy,
+	ExampleCommand,
+	ExampleMeta,
 	Fallback,
 	FlagConfig,
 	FlagFactory,


### PR DESCRIPTION
Closes #66.

## Problem

`.example(command, description?)` took a literal string, so the program name had to be hardcoded. But the command doesn't know its own invoked name — that's the parent `cli(name)`, overridable at runtime (`inheritName`, symlinks, `npx x` vs global). Hardcoding drifts: rename the bin and every example silently lies.

## Solution — function-form example

`command` may now be `string | ((meta: ExampleMeta) => string)`, resolved at render time:

```ts
.example((m) => `${m.name} --package 'x=jsr:@a/x@^1' --scope './tests/::y=z'`, 'Add deps')
// m: { name: string; version: string | undefined } — name = the actually-invoked program name
```

- Type-safe, plain template literals (no magic tokens), composes with example highlighting (#65): resolve thunk → highlight → emit.
- `meta.name` = `help.binName` (the invoked program name) falling back to the command name; `meta.version` = program version (`undefined` when unset — typed honestly rather than lying).
- Backward compatible: literal strings work unchanged.

## Both surfaces agree

The thunk resolves in **`--help` text** and in **`--json`/definition-schema** output. The CLI threads `binName`/`version` into help options and into the JSON serializer's meta, so `mycli deploy --help` and `mycli deploy --help --json` render the same resolved command (`mycli deploy --force`), rather than the text path using the invoked name and JSON falling back to the declared name.

`serializeExample` resolves the thunk to a plain string, so function-form examples never leak an unserializable function into the definition schema.

## Scope

- `schema/command.ts` — `ExampleMeta`, `ExampleCommand`, `.example()` overload, `resolveExampleCommand`.
- `help/index.ts` — `version` help option; `formatExamplesSection` resolves the thunk against `{ name: binName ?? schema.name, version }` before highlighting.
- `json-schema/index.ts` — `serializeExample`/`serializeCommand` thread meta; `generateSchema` uses the CLI name/version, `generateCommandSchema` accepts an optional meta.
- `cli/index.ts`, `execution/index.ts` — thread the invoked `binName`/`version` into help options and the two `--json` help paths.
- Public types `ExampleMeta`/`ExampleCommand` exported from the package entry.

## Tests

- `command.test.ts` — function-form stored verbatim; `resolveExampleCommand` resolution.
- `help.test.ts` / `theme.test.ts` — resolved with program name; `version` passed through; `meta.name` falls back to command name without `binName`; composes with highlighting.
- `json-schema.test.ts` — function-form serializes to the resolved string using program meta.
- `cli-examples.test.ts` (new) — end-to-end: invoked binName, `binName` override, `version`, and `--json` matching text help.

Full suite (2874 tests), typecheck, biome, dprint, `deno check` all pass. Definition schema (`dreamcli.schema.json`) byte-unchanged.

Bumps to `3.0.0-rc.14`.