### PR TITLE
feat(help): configurable flag order in help output (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0-rc.15] - 2026-07-20
+
+### Added
+
+- **Configurable flag order in help** — `.help({ flagOrder })` controls the
+  `Flags:` table order: `'alphabetical'` (default, short-aliased flags first
+  then alphabetical) or `'declaration'` (the order `.flag()` was called). For
+  full control, `.help({ sortFlags: (a, b) => number })` supplies a custom
+  comparator over flag names that wins over `flagOrder`. Both are also
+  accepted at runtime via `execute`/`run` `help` options.
+
 ## [3.0.0-rc.14] - 2026-07-20
 
 ### Added
@@ -1289,7 +1300,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MIT License.
 - Markdownlint configuration.
 
-[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.14...HEAD
+[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.15...HEAD
+[3.0.0-rc.15]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.14...v3.0.0-rc.15
 [3.0.0-rc.14]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.13...v3.0.0-rc.14
 [3.0.0-rc.13]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.12...v3.0.0-rc.13
 [3.0.0-rc.12]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.11...v3.0.0-rc.12

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.14",
+	"version": "3.0.0-rc.15",
 	"license": "MIT",
 	"tasks": {
 		"check": {

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -86,6 +86,22 @@ command('deploy')
   );
 ```
 
+An example can also be a function, resolved at render time with the program
+`meta` (`name`, `version`). Use it to reference the invoked program name instead
+of hardcoding it, so examples stay truthful under symlinks, `inheritName`, and
+`npx x` vs a global install:
+
+```ts twoslash
+import { command } from '@kjanat/dreamcli';
+
+command('deploy')
+  .description('Deploy to an environment')
+  // `m.name` is the actually-invoked program name (help.binName), not a literal
+  .example((m) => `${m.name} deploy production --force`, 'Force deploy to prod');
+```
+
+The resolved command is what renders in both `--help` text and `--json` output.
+
 ### Default Command
 
 Set a default command that runs when no subcommand is specified:

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -100,7 +100,8 @@ command('deploy')
   .example((m) => `${m.name} deploy production --force`, 'Force deploy to prod');
 ```
 
-The resolved command is what renders in both `--help` text and `--json` output.
+The string the callback returns is rendered verbatim as the example, in both
+`--help` text and `--json` output.
 
 ### Default Command
 

--- a/docs/guide/help.md
+++ b/docs/guide/help.md
@@ -23,10 +23,58 @@ cli('mycli')
     footer: true,
     // Pin the line width (defaults to the terminal width, falling back to 80)
     width: 100,
-    // OSC 8 hyperlinks in the header (defaults to TTY detection)
+    // OSC 8 hyperlinks in the header. Defaults to the channel's resolved
+    // support: NO_HYPERLINKS/FORCE_HYPERLINKS (and --no-hyperlinks/--hyperlinks)
+    // are honored, otherwise TTY detection.
     hyperlinks: true,
+    // Order of the Flags: table — 'alphabetical' (default) or 'declaration'
+    flagOrder: 'declaration',
   });
 ```
+
+### Flag order
+
+By default the `Flags:` table lists short-aliased flags first, then
+alphabetically by name. `flagOrder: 'declaration'` instead preserves the order
+you called `.flag()`, so you control the layout by ordering your builder calls:
+
+```ts twoslash
+import { cli, command, flag } from '@kjanat/dreamcli';
+
+cli('mycli')
+  .command(
+    command('serve')
+      .flag('port', flag.number())
+      .flag('host', flag.string())
+      .action(() => {}),
+  )
+  // 'port' then 'host', as declared — not alphabetized to 'host', 'port'
+  .help({ flagOrder: 'declaration' });
+```
+
+For full control, `sortFlags` supplies a comparator over flag long names and
+wins over `flagOrder`:
+
+```ts twoslash
+import { cli, command } from '@kjanat/dreamcli';
+
+cli('mycli')
+  .command(command('serve').action(() => {}))
+  // Reverse-alphabetical
+  .help({ sortFlags: (a, b) => b.localeCompare(a) });
+```
+
+Both are also accepted per call via `execute(argv, { help })` / `run({ help })`.
+
+### Header hyperlinks
+
+The root-help header can wrap the program name and version in OSC 8 terminal
+hyperlinks (pointing at the repository and release tag). Emission follows the
+standard hyperlink signals: `NO_HYPERLINKS` / `--no-hyperlinks` force them off,
+`FORCE_HYPERLINKS` / `--hyperlinks` force them on, otherwise the header links
+only on a TTY. The same resolved decision is exposed to handlers as
+`out.isHyperlinkSupported`, so code rendering its own `out.color.link(...)`
+output can gate on it and keep escapes out of piped or opted-out contexts.
 
 ## Theming
 
@@ -52,7 +100,11 @@ The built-in theme follows clap/cargo conventions:
 | `headerVersion` | `vX.Y.Z` in the root header                            | dim              |
 | `examplePrompt` | the `$` marker in `Examples:`                          | dim              |
 
-Descriptions stay unstyled for readability.
+Descriptions stay unstyled for readability. Example commands are highlighted
+per token with the existing roles — the leading binary via `usageBin` (bold)
+and flag tokens (`-x`, `--long`) via `flag` (cyan), values plain. Tokenizing is
+quote-aware, so `--scope './a b'` stays one token, and the highlighting respects
+the color gate: with color off the command is byte-identical to its plain form.
 
 ### Custom Themes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.14",
+	"version": "3.0.0-rc.15",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
 		"dreamcli",

--- a/src/core/cli/cli-flag-order.test.ts
+++ b/src/core/cli/cli-flag-order.test.ts
@@ -1,0 +1,49 @@
+/**
+ * End-to-end tests for `.help({ flagOrder })` / `sortFlags`, verifying the
+ * builder-level and runtime help config reaches the flags table renderer.
+ */
+import { describe, expect, it } from 'vitest';
+import { command } from '#internals/core/schema/command.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import { cli } from './index.ts';
+
+// === Helpers
+
+function orderedCommand() {
+	return command('run')
+		.flag('zebra', flag.boolean())
+		.flag('apple', flag.boolean().alias('a'))
+		.flag('mango', flag.boolean())
+		.flag('banana', flag.boolean().alias('b'))
+		.action(() => {});
+}
+
+function flagOrderIn(help: string): string[] {
+	return ['zebra', 'apple', 'mango', 'banana']
+		.map((name) => ({ name, at: help.indexOf(`--${name}`) }))
+		.sort((x, y) => x.at - y.at)
+		.map((entry) => entry.name);
+}
+
+// === Flag ordering — end to end
+
+describe('flag ordering — end to end', () => {
+	it('defaults to short-first alphabetical', async () => {
+		const result = await cli('mycli').command(orderedCommand()).execute(['run', '--help']);
+		expect(flagOrderIn(result.stdout.join(''))).toEqual(['apple', 'banana', 'mango', 'zebra']);
+	});
+
+	it("honors builder .help({ flagOrder: 'declaration' })", async () => {
+		const app = cli('mycli').help({ flagOrder: 'declaration' }).command(orderedCommand());
+		const result = await app.execute(['run', '--help']);
+		expect(flagOrderIn(result.stdout.join(''))).toEqual(['zebra', 'apple', 'mango', 'banana']);
+	});
+
+	it('honors a runtime sortFlags comparator', async () => {
+		const app = cli('mycli').command(orderedCommand());
+		const result = await app.execute(['run', '--help'], {
+			help: { sortFlags: (a, b) => b.localeCompare(a) },
+		});
+		expect(flagOrderIn(result.stdout.join(''))).toEqual(['zebra', 'mango', 'banana', 'apple']);
+	});
+});

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -342,6 +342,24 @@ interface HelpConfig {
 	/** Emit OSC 8 hyperlinks in the header when supported. */
 	readonly hyperlinks?: boolean;
 	/**
+	 * Order of flags in the `Flags:` table.
+	 *
+	 * - `'alphabetical'` — short-aliased flags first, then alphabetical by name.
+	 * - `'declaration'` — the order `.flag()` was called.
+	 *
+	 * Ignored when {@link HelpConfig.sortFlags} is set.
+	 *
+	 * @defaultValue `'alphabetical'`
+	 */
+	readonly flagOrder?: 'alphabetical' | 'declaration';
+	/**
+	 * Custom comparator over flag long names for the `Flags:` table. When set,
+	 * it wins over {@link HelpConfig.flagOrder}.
+	 *
+	 * @defaultValue `undefined` (use `flagOrder`)
+	 */
+	readonly sortFlags?: (a: string, b: string) => number;
+	/**
 	 * Theme overrides for help output, merged over the built-in theme.
 	 *
 	 * The factory receives the gated ansispeck palette (same instance as

--- a/src/core/help/help.test.ts
+++ b/src/core/help/help.test.ts
@@ -488,6 +488,52 @@ describe('formatHelp', () => {
 	});
 
 	// -----------------------------------------------------------------------
+	// Flag ordering
+	// -----------------------------------------------------------------------
+
+	describe('flag ordering', () => {
+		// Declaration order differs from every derived order, so each mode is
+		// distinguishable: zebra/mango are long-only, apple/banana short-aliased.
+		function ordered() {
+			return command('run')
+				.flag('zebra', flag.boolean())
+				.flag('apple', flag.boolean().alias('a'))
+				.flag('mango', flag.boolean())
+				.flag('banana', flag.boolean().alias('b'));
+		}
+
+		function flagOrderIn(help: string): string[] {
+			return ['zebra', 'apple', 'mango', 'banana']
+				.map((name) => ({ name, at: help.indexOf(`--${name}`) }))
+				.sort((x, y) => x.at - y.at)
+				.map((entry) => entry.name);
+		}
+
+		it('defaults to short-aliased first, then alphabetical', () => {
+			const help = formatHelp(ordered().schema);
+			expect(flagOrderIn(help)).toEqual(['apple', 'banana', 'mango', 'zebra']);
+		});
+
+		it("flagOrder: 'declaration' preserves .flag() call order", () => {
+			const help = formatHelp(ordered().schema, { flagOrder: 'declaration' });
+			expect(flagOrderIn(help)).toEqual(['zebra', 'apple', 'mango', 'banana']);
+		});
+
+		it('sortFlags applies a custom comparator', () => {
+			const help = formatHelp(ordered().schema, { sortFlags: (a, b) => b.localeCompare(a) });
+			expect(flagOrderIn(help)).toEqual(['zebra', 'mango', 'banana', 'apple']);
+		});
+
+		it('sortFlags wins over flagOrder', () => {
+			const help = formatHelp(ordered().schema, {
+				flagOrder: 'declaration',
+				sortFlags: (a, b) => a.localeCompare(b),
+			});
+			expect(flagOrderIn(help)).toEqual(['apple', 'banana', 'mango', 'zebra']);
+		});
+	});
+
+	// -----------------------------------------------------------------------
 	// Examples section
 	// -----------------------------------------------------------------------
 

--- a/src/core/help/index.ts
+++ b/src/core/help/index.ts
@@ -35,6 +35,24 @@ interface HelpOptions {
 	/** Program version passed to function-form examples as `meta.version`. */
 	readonly version?: string;
 	/**
+	 * Order of flags in the `Flags:` table.
+	 *
+	 * - `'alphabetical'` — short-aliased flags first, then alphabetical by name.
+	 * - `'declaration'` — the order `.flag()` was called.
+	 *
+	 * Ignored when {@link HelpOptions.sortFlags} is set.
+	 *
+	 * @defaultValue `'alphabetical'`
+	 */
+	readonly flagOrder?: 'alphabetical' | 'declaration';
+	/**
+	 * Custom comparator over flag long names for the `Flags:` table. When set,
+	 * it wins over {@link HelpOptions.flagOrder}.
+	 *
+	 * @defaultValue `undefined` (use `flagOrder`)
+	 */
+	readonly sortFlags?: (a: string, b: string) => number;
+	/**
 	 * Emit OSC 8 hyperlinks where link metadata is available (currently the
 	 * root-help header name/version configured via `CLIBuilder.links()`).
 	 * Defaults to `false`; `CLIBuilder.execute()`/`.run()` enable it
@@ -92,6 +110,8 @@ interface ResolvedHelpOptions {
 	readonly width: number;
 	readonly binName: string | undefined;
 	readonly version: string | undefined;
+	readonly flagOrder: 'alphabetical' | 'declaration';
+	readonly sortFlags: ((a: string, b: string) => number) | undefined;
 	readonly isDefaultHelp: boolean;
 	readonly theme: HelpTheme;
 }
@@ -109,6 +129,8 @@ function resolveOptions(options?: HelpOptions): ResolvedHelpOptions {
 		width: options?.width ?? DEFAULT_WIDTH,
 		binName: options?.binName,
 		version: options?.version,
+		flagOrder: options?.flagOrder ?? 'alphabetical',
+		sortFlags: options?.sortFlags,
 		isDefaultHelp: options?.isDefaultHelp ?? false,
 		theme: resolveHelpTheme(options?.colors, options?.theme),
 	};
@@ -261,38 +283,59 @@ function formatFlagDescription(schema: FlagSchema, theme: HelpTheme): string {
 }
 
 /**
- * Build the flag entries sorted: short-aliased first, then alphabetical.
+ * Default flag order: short-aliased flags first, then alphabetical by name.
+ */
+function defaultFlagOrder(
+	a: string,
+	b: string,
+	flags: Readonly<Record<string, FlagSchema>>,
+): number {
+	const aSchema = flags[a];
+	const bSchema = flags[b];
+	if (aSchema === undefined || bSchema === undefined) return 0;
+	const aHasShort = getFlagAliasNames(aSchema, { kind: 'short' }).length > 0;
+	const bHasShort = getFlagAliasNames(bSchema, { kind: 'short' }).length > 0;
+	if (aHasShort && !bHasShort) return -1;
+	if (!aHasShort && bHasShort) return 1;
+	return a.localeCompare(b);
+}
+
+/**
+ * Order flag names for the table: an explicit `sortFlags` comparator wins,
+ * then `'declaration'` preserves `.flag()` call order, otherwise the default
+ * short-first alphabetical order.
+ */
+function orderFlagNames(
+	names: readonly string[],
+	flags: Readonly<Record<string, FlagSchema>>,
+	opts: ResolvedHelpOptions,
+): readonly string[] {
+	if (opts.sortFlags !== undefined) return [...names].sort(opts.sortFlags);
+	if (opts.flagOrder === 'declaration') return names;
+	return [...names].sort((a, b) => defaultFlagOrder(a, b, flags));
+}
+
+/**
+ * Build the flag entries in the configured order.
  *
  * @param flags - Map of flag names to {@link FlagSchema} definitions.
- * @param theme - Theme threaded into the per-flag formatters.
- * @returns Sorted array of {@link FlagEntry} objects for the flags table.
+ * @param opts - Resolved help options (theme + flag ordering).
+ * @returns Array of {@link FlagEntry} objects for the flags table.
  */
 function buildFlagEntries(
 	flags: Readonly<Record<string, FlagSchema>>,
-	theme: HelpTheme,
+	opts: ResolvedHelpOptions,
 ): readonly FlagEntry[] {
 	const names = Object.keys(flags);
 	if (names.length === 0) return [];
 
-	// Sort: flags with short aliases first, then alphabetically by name
-	const sorted = [...names].sort((a, b) => {
-		const aSchema = flags[a];
-		const bSchema = flags[b];
-		if (aSchema === undefined || bSchema === undefined) return 0;
-		const aHasShort = getFlagAliasNames(aSchema, { kind: 'short' }).length > 0;
-		const bHasShort = getFlagAliasNames(bSchema, { kind: 'short' }).length > 0;
-		if (aHasShort && !bHasShort) return -1;
-		if (!aHasShort && bHasShort) return 1;
-		return a.localeCompare(b);
-	});
-
 	const entries: FlagEntry[] = [];
-	for (const name of sorted) {
+	for (const name of orderFlagNames(names, flags, opts)) {
 		const schema = flags[name];
 		if (schema === undefined) continue;
 		entries.push({
-			left: formatFlagLeft(name, schema, theme),
-			description: formatFlagDescription(schema, theme),
+			left: formatFlagLeft(name, schema, opts.theme),
+			description: formatFlagDescription(schema, opts.theme),
 		});
 	}
 	return entries;
@@ -516,7 +559,7 @@ function formatFlagsSection(
 ): string {
 	return formatFlagEntriesBlock(
 		opts.theme.sectionTitle('Flags:'),
-		buildFlagEntries(flags, opts.theme),
+		buildFlagEntries(flags, opts),
 		opts.width,
 	);
 }


### PR DESCRIPTION
Closes #68.

## Problem

The `Flags:` table order was hardcoded in the renderer (short-aliased flags first, then alphabetical). Declaration order was discarded and there was no option, theme role, or hook to change it — the only "workarounds" (renaming flags, dropping a short alias) mutate the actual CLI surface.

## Solution

Two knobs on help options, both accepted via builder `.help({ ... })` and at runtime through `execute`/`run` help options:

- **`flagOrder: 'alphabetical' | 'declaration'`** (default `'alphabetical'`) — the primary opt-in. `'declaration'` renders flags in the order `.flag()` was called, so authors control order by ordering their calls.
- **`sortFlags: (a, b) => number`** — a comparator over flag long names for full control; wins over `flagOrder` when set.

Precedence: `sortFlags` → `flagOrder: 'declaration'` → default short-first alphabetical. The default is unchanged, so existing output is byte-identical.

## Implementation

`buildFlagEntries` now orders names via `orderFlagNames(names, flags, opts)` (comparator > declaration > default), and the default sort is factored into `defaultFlagOrder`. `flagOrder`/`sortFlags` are added to `HelpOptions`, `ResolvedHelpOptions`, and the builder's `HelpConfig`, threading through the existing helpConfig/runtime spread.

## Tests

- `help.test.ts` — default, `'declaration'`, custom `sortFlags`, and `sortFlags`-wins-over-`flagOrder`, using a command whose declaration order differs from every derived order.
- `cli-flag-order.test.ts` (new) — end-to-end through `execute`: default, builder `.help({ flagOrder: 'declaration' })`, and runtime `sortFlags`.

Full suite (2882 tests), typecheck, biome, dprint, `deno check` all pass. Default flag order unchanged.

Bumps to `3.0.0-rc.15`.