### PR TITLE
feat(cli): pre-run render context probe (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0-rc.16] - 2026-07-20
+
+### Added
+
+- **`resolveRenderContext(argv, options?)`** — pre-`run()` probe returning the
+  output decisions the framework will make for a given argv: `jsonMode`
+  (`--`-aware `--json` detection), `isTTY`, the gated `color` palette, and
+  `isHyperlinkSupported`. Computed with the same composition `.execute()`/
+  `.run()` feed into the output channel, so content styled before `run()` —
+  banners, hand-rendered help — matches the channel that will actually render,
+  with zero argv re-parsing.
+- **`includesBeforeSeparator` / `stripBeforeSeparator`** exported from the
+  package root — the `--`-aware root-flag primitives, for consumers who only
+  need correct flag detection.
+
 ## [3.0.0-rc.15] - 2026-07-20
 
 ### Added
@@ -1300,7 +1315,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MIT License.
 - Markdownlint configuration.
 
-[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.15...HEAD
+[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.16...HEAD
+[3.0.0-rc.16]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.15...v3.0.0-rc.16
 [3.0.0-rc.15]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.14...v3.0.0-rc.15
 [3.0.0-rc.14]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.13...v3.0.0-rc.14
 [3.0.0-rc.13]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.12...v3.0.0-rc.13

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.15",
+	"version": "3.0.0-rc.16",
 	"license": "MIT",
 	"tasks": {
 		"check": {

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -116,6 +116,40 @@ The output channel automatically adjusts behavior:
 
 One code path, correct output everywhere.
 
+## Pre-run Render Context
+
+Inside a handler, `out` answers every rendering question: `out.jsonMode`,
+`out.isTTY`, `out.color`, `out.isHyperlinkSupported`. Content built **before**
+`run()` — a banner, hand-rendered help — has no `out`, and re-deriving the
+answers from raw argv goes wrong (`argv.includes('--json')` misreads a
+post-`--` literal like `mycli -- --json`).
+
+`resolveRenderContext` runs the same composition `run()` feeds into the output
+channel, so pre-run styling matches what will actually render:
+
+```ts twoslash
+import { resolveRenderContext } from '@kjanat/dreamcli';
+
+const ctx = resolveRenderContext(process.argv.slice(2), {
+  isTTY: process.stdout.isTTY === true,
+  env: process.env,
+});
+
+// Identity formatters when color is off — style unconditionally
+const banner = ctx.color.bold('mycli');
+// `ctx.jsonMode` used pre-separator-aware --json detection
+if (!ctx.jsonMode) console.error(banner);
+```
+
+The returned `color` is the same gated palette the channel will expose as
+`out.color` (`ctx.color.isColorSupported` is the boolean form), and
+`ctx.isHyperlinkSupported` honors `NO_HYPERLINKS`/`FORCE_HYPERLINKS` the same
+way the help header does.
+
+For just the `--`-aware flag reads, the primitives are also exported:
+`includesBeforeSeparator(argv, '--json')` and its strip counterpart
+`stripBeforeSeparator`.
+
 ## What's Next?
 
 - Related examples: [JSON mode](/examples/json-mode), [Spinner and progress](/examples/spinner-progress)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.15",
+	"version": "3.0.0-rc.16",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
 		"dreamcli",

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -9,6 +9,7 @@
  * @module dreamcli/core/cli
  */
 
+import type { Colors } from 'ansispeck';
 import type { CompletionOptions, Shell } from '#internals/core/completion/index.ts';
 import {
 	detectShell,
@@ -481,6 +482,104 @@ interface CLIRunOptions extends Omit<RunOptions, 'meta' | 'mergedSchema'> {
 	 * Ignored by `.execute()` (which is process-free by design).
 	 */
 	readonly adapter?: RuntimeAdapter;
+}
+
+// --- Render context
+
+/**
+ * Inputs for {@linkcode resolveRenderContext}. Pass the host facts (TTY
+ * status, environment) and any explicit overrides; the resolver applies the
+ * same gating `.execute()`/`.run()` feed into the output channel.
+ */
+interface RenderContextOptions {
+	/**
+	 * Whether stdout is connected to a TTY (e.g. `process.stdout.isTTY`).
+	 *
+	 * @defaultValue `false`
+	 */
+	readonly isTTY?: boolean;
+	/**
+	 * Force JSON mode on regardless of argv.
+	 *
+	 * @defaultValue detected from a pre-separator `--json` in `argv`
+	 */
+	readonly jsonMode?: boolean;
+	/**
+	 * Explicitly enable or disable colors, winning over the auto-gate.
+	 *
+	 * @defaultValue auto — `isTTY && !jsonMode` and environment support
+	 */
+	readonly color?: boolean;
+	/**
+	 * Environment variables consulted for `NO_HYPERLINKS`/`FORCE_HYPERLINKS`
+	 * (e.g. `process.env`).
+	 *
+	 * @defaultValue `{}`
+	 */
+	readonly env?: Readonly<Record<string, string | undefined>>;
+}
+
+/**
+ * The output decisions the framework will make for a given argv, resolved
+ * before `.run()`.
+ */
+interface RenderContext {
+	/** Whether a pre-separator `--json` puts the run in JSON mode. */
+	readonly jsonMode: boolean;
+	/** The TTY status the output channel will carry. */
+	readonly isTTY: boolean;
+	/**
+	 * The gated ANSI palette the output channel will expose as `out.color` —
+	 * identity formatters when color is off; `color.isColorSupported` is the
+	 * boolean gate.
+	 */
+	readonly color: Colors;
+	/** Whether OSC 8 hyperlinks should be emitted (see `out.isHyperlinkSupported`). */
+	readonly isHyperlinkSupported: boolean;
+}
+
+/**
+ * Resolve the render context for content built before `.run()`.
+ *
+ * Content styled ahead of execution — hand-rendered banners, custom help, or
+ * anything else emitted outside an action handler — has no `out` to consult,
+ * which pushes consumers into re-deriving the framework's decisions from raw
+ * argv (`argv.includes('--json')` misreads a post-`--` literal). This probe
+ * runs the same composition `.execute()`/`.run()` feed into the output
+ * channel — `--`-aware `--json` detection, the color gate, and the hyperlink
+ * override — so pre-run styling matches the channel that will render.
+ *
+ * @param argv - Raw argv tokens (NOT including the binary/script path,
+ *   i.e. equivalent to `process.argv.slice(2)`).
+ * @param options - Host facts and overrides.
+ * @returns The resolved output decisions.
+ *
+ * @example
+ * ```ts
+ * const ctx = resolveRenderContext(process.argv.slice(2), {
+ *   isTTY: process.stdout.isTTY === true,
+ *   env: process.env,
+ * });
+ * const banner = ctx.color.bold('mycli');
+ * ```
+ */
+function resolveRenderContext(
+	argv: readonly string[],
+	options?: RenderContextOptions,
+): RenderContext {
+	const jsonMode = includesBeforeSeparator(argv, '--json') || options?.jsonMode === true;
+	const out = createOutput({
+		jsonMode,
+		isTTY: options?.isTTY ?? false,
+		...(options?.color !== undefined ? { color: options.color } : {}),
+		...hyperlinksOption(resolveHyperlinkOverride(options?.env ?? {}, argv)),
+	});
+	return {
+		jsonMode: out.jsonMode,
+		isTTY: out.isTTY,
+		color: out.color,
+		isHyperlinkSupported: out.isHyperlinkSupported,
+	};
 }
 
 // --- Command run options builder
@@ -1796,6 +1895,8 @@ export type {
 	ManifestPresetSettings,
 	ManifestSettings,
 	PackageJsonSettings,
+	RenderContext,
+	RenderContextOptions,
 	ResolvedManifestSettings,
 };
-export { CLIBuilder, cli, formatRootHelp, isMainModule, plugin };
+export { CLIBuilder, cli, formatRootHelp, isMainModule, plugin, resolveRenderContext };

--- a/src/core/cli/render-context.test.ts
+++ b/src/core/cli/render-context.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for resolveRenderContext — the pre-`run()` probe exposing the same
+ * output decisions (`jsonMode`/`isTTY`/`color`/hyperlinks) the framework
+ * makes when building the output channel.
+ */
+import { describe, expect, it } from 'vitest';
+import { resolveRenderContext } from './index.ts';
+
+// === JSON mode detection
+
+describe('resolveRenderContext — jsonMode', () => {
+	it('detects a pre-separator --json', () => {
+		expect(resolveRenderContext(['deploy', '--json']).jsonMode).toBe(true);
+	});
+
+	it('ignores a post-separator --json literal', () => {
+		expect(resolveRenderContext(['deploy', '--', '--json']).jsonMode).toBe(false);
+	});
+
+	it('honors an explicit jsonMode override', () => {
+		expect(resolveRenderContext([], { jsonMode: true }).jsonMode).toBe(true);
+	});
+});
+
+// === TTY and color gate
+
+describe('resolveRenderContext — color', () => {
+	it('defaults isTTY to false and disables color', () => {
+		const ctx = resolveRenderContext([]);
+		expect(ctx.isTTY).toBe(false);
+		expect(ctx.color.isColorSupported).toBe(false);
+		expect(ctx.color.red('x')).toBe('x');
+	});
+
+	it('JSON mode disables color even on a TTY', () => {
+		const ctx = resolveRenderContext(['--json'], { isTTY: true });
+		expect(ctx.color.isColorSupported).toBe(false);
+	});
+
+	it('explicit color: true wins over the auto-gate', () => {
+		const ctx = resolveRenderContext(['--json'], { color: true });
+		expect(ctx.color.isColorSupported).toBe(true);
+		expect(ctx.color.red('x')).not.toBe('x');
+	});
+});
+
+// === Hyperlink gate
+
+describe('resolveRenderContext — hyperlinks', () => {
+	it('falls back to isTTY', () => {
+		expect(resolveRenderContext([]).isHyperlinkSupported).toBe(false);
+		expect(resolveRenderContext([], { isTTY: true }).isHyperlinkSupported).toBe(true);
+	});
+
+	it('NO_HYPERLINKS forces off on a TTY', () => {
+		const ctx = resolveRenderContext([], { isTTY: true, env: { NO_HYPERLINKS: '1' } });
+		expect(ctx.isHyperlinkSupported).toBe(false);
+	});
+
+	it('FORCE_HYPERLINKS forces on without a TTY', () => {
+		const ctx = resolveRenderContext([], { env: { FORCE_HYPERLINKS: '1' } });
+		expect(ctx.isHyperlinkSupported).toBe(true);
+	});
+
+	it('--no-hyperlinks before the separator forces off', () => {
+		const ctx = resolveRenderContext(['--no-hyperlinks'], { isTTY: true });
+		expect(ctx.isHyperlinkSupported).toBe(false);
+	});
+
+	it('--no-hyperlinks after the separator is a literal', () => {
+		const ctx = resolveRenderContext(['--', '--no-hyperlinks'], { isTTY: true });
+		expect(ctx.isHyperlinkSupported).toBe(true);
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,10 +36,18 @@ export type {
 	ManifestSettings,
 	PackageJsonSettings,
 	PluginCommandContext,
+	RenderContext,
+	RenderContextOptions,
 	ResolvedCommandParams,
 	ResolvedManifestSettings,
 } from './core/cli/index.ts';
-export { CLIBuilder, cli, isMainModule, plugin } from './core/cli/index.ts';
+export {
+	CLIBuilder,
+	cli,
+	isMainModule,
+	plugin,
+	resolveRenderContext,
+} from './core/cli/index.ts';
 export type { CompletionOptions, Shell } from './core/completion/index.ts';
 export {
 	generateBashCompletion,
@@ -100,7 +108,12 @@ export {
 export type { OutputOptions, Verbosity, WriteFn } from './core/output/index.ts';
 export { createOutput } from './core/output/index.ts';
 export type { ParseOptions, ParseResult, Token } from './core/parse/index.ts';
-export { parse, tokenize } from './core/parse/index.ts';
+export {
+	includesBeforeSeparator,
+	parse,
+	stripBeforeSeparator,
+	tokenize,
+} from './core/parse/index.ts';
 export type {
 	PromptEngine,
 	ReadFn,


### PR DESCRIPTION
Closes #69.

## Problem

Inside a handler, `out` answers every rendering question (`jsonMode`, `isTTY`, `color`, `isHyperlinkSupported`). Content built **before** `run()` has no `out`, so consumers re-derive the decisions from raw argv — in the naive form the framework's own docstring warns against:

```ts
const JSON_MODE = argv.includes('--json'); // wrong: `mycli -- --json` is a literal
```

The consumer and the framework then disagree about the same fact, using the same argv.

## Solution — both options from the issue

**Option 2 (the probe):** `resolveRenderContext(argv, options?)` returns `{ jsonMode, isTTY, color, isHyperlinkSupported }`. It is implemented by feeding the *same* composition `.execute()`/`.run()` give `createOutput` — `--`-aware `--json` detection via `includesBeforeSeparator`, the hyperlink override via `resolveHyperlinkOverride`, the color auto-gate — and reading the resolved channel back. No duplicated gating logic, so the probe cannot drift from the channel that will actually render.

One deviation from the issue's sketch: `color` is the gated `Colors` **palette** (the same shape as `out.color`) rather than a bare boolean — consumers want to style, and identity formatters mean they can do so unconditionally. `ctx.color.isColorSupported` is the boolean form.

`options` carries the host facts core cannot read (`isTTY`, `env`) plus explicit `jsonMode`/`color` overrides — same seams as `execute()`. Core stays process-free.

**Option 1 (the primitives):** `includesBeforeSeparator` and `stripBeforeSeparator` are exported from the package root for consumers who only need correct `--`-aware flag reads.

## Tests

`render-context.test.ts` — pre/post-separator `--json`, explicit overrides, TTY-default and JSON-mode color gating, explicit `color: true`, and the full hyperlink matrix (`NO_HYPERLINKS`, `FORCE_HYPERLINKS`, `--no-hyperlinks` pre/post-separator). Public-export JSDoc coverage passes.

## Docs

`guide/output.md` gains a "Pre-run Render Context" section with a validated twoslash example; built successfully.

Full suite (2893), typecheck, biome, dprint, `deno check`, docs build all pass.

Bumps to `3.0.0-rc.16`.