### PR TITLE
feat(output): quiet-suppressible status channel and global --quiet (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0-rc.17] - 2026-07-20
+
+### Added
+
+- **`out.status()`** — a success/status line channel that writes to **stderr**
+  (stdout stays clean for piping) and is suppressed under quiet verbosity.
+  `info` remains stdout-bound; `warn`/`error` remain always-emitted.
+- **Global `--quiet`/`-q` flag** — sets quiet verbosity on every CLI, wired
+  like `--json`: detected and stripped at the root before dispatch (command
+  schemas never see it), honoring the `--` separator so a literal `-q`
+  positional reaches the command unchanged. Listed under root help's
+  `Global options:`.
+
+### Fixed
+
+- **`.run()` misread a post-separator `--json`** — runtime preflight used a
+  naive `includes('--json')`, so `mycli cmd -- --json` entered JSON mode via
+  the adapter path even though `.execute()` correctly treats it as a
+  positional. Preflight now uses the `--`-aware detection.
+
 ## [3.0.0-rc.16] - 2026-07-20
 
 ### Added
@@ -1315,7 +1335,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MIT License.
 - Markdownlint configuration.
 
-[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.16...HEAD
+[Unreleased]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.17...HEAD
+[3.0.0-rc.17]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.16...v3.0.0-rc.17
 [3.0.0-rc.16]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.15...v3.0.0-rc.16
 [3.0.0-rc.15]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.14...v3.0.0-rc.15
 [3.0.0-rc.14]: https://github.com/kjanat/dreamcli/compare/v3.0.0-rc.13...v3.0.0-rc.14

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.16",
+	"version": "3.0.0-rc.17",
 	"license": "MIT",
 	"tasks": {
 		"check": {

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -44,6 +44,35 @@ command('status').action(({ out }) => {
 `setExitCode()` does not print anything and does not stop execution. Later calls
 win, and thrown `CLIError`s still use their own exit codes and error rendering.
 
+## Status Lines and Quiet Mode
+
+`out.status()` prints success and progress notes like `Wrote <path>` to
+**stderr**, so stdout stays clean for piping, and it is suppressed under quiet
+verbosity:
+
+```ts twoslash
+import { command } from '@kjanat/dreamcli';
+
+command('gen').action(({ out }) => {
+  out.log('dist/app.js');           // the result — stdout, always
+  out.status('Wrote dist/app.js');  // the note — stderr, silenced by -q
+});
+```
+
+Every CLI accepts a global `--quiet`/`-q` flag that sets quiet verbosity,
+suppressing `info` and `status` while `log`, `warn`, and `error` still emit.
+Like `--json`, it is a root-level flag: it is stripped before dispatch (so
+command schemas never see it) and only counts before the `--` separator — a
+literal `-q` after `--` reaches the command as a positional.
+
+| Method   | Stream                     | Suppressed by quiet |
+| -------- | -------------------------- | ------------------- |
+| `log`    | stdout                     | no                  |
+| `info`   | stdout (stderr in `--json`)| yes                 |
+| `status` | stderr                     | yes                 |
+| `warn`   | stderr                     | no                  |
+| `error`  | stderr                     | no                  |
+
 ## Tables
 
 ```ts twoslash

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -54,21 +54,21 @@ verbosity:
 import { command } from '@kjanat/dreamcli';
 
 command('gen').action(({ out }) => {
-  out.log('dist/app.js');           // the result — stdout, always
-  out.status('Wrote dist/app.js');  // the note — stderr, silenced by -q
+  out.log('dist/app.js');           // the result, on stdout (stderr in --json)
+  out.status('Wrote dist/app.js');  // the note, on stderr, silenced by -q
 });
 ```
 
 Every CLI accepts a global `--quiet`/`-q` flag that sets quiet verbosity,
 suppressing `info` and `status` while `log`, `warn`, and `error` still emit.
 Like `--json`, it is a root-level flag: it is stripped before dispatch (so
-command schemas never see it) and only counts before the `--` separator — a
+command schemas never see it) and only counts before the `--` separator; a
 literal `-q` after `--` reaches the command as a positional.
 
-| Method   | Stream                     | Suppressed by quiet |
-| -------- | -------------------------- | ------------------- |
-| `log`    | stdout                     | no                  |
-| `info`   | stdout (stderr in `--json`)| yes                 |
+| Method   | Stream                      | Suppressed by quiet |
+| -------- | --------------------------- | ------------------- |
+| `log`    | stdout (stderr in `--json`) | no                  |
+| `info`   | stdout (stderr in `--json`) | yes                 |
 | `status` | stderr                     | yes                 |
 | `warn`   | stderr                     | no                  |
 | `error`  | stderr                     | no                  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.16",
+	"version": "3.0.0-rc.17",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
 		"dreamcli",

--- a/src/core/cli/cli-quiet.test.ts
+++ b/src/core/cli/cli-quiet.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the global `--quiet`/`-q` flag: verbosity mapping, pre-dispatch
+ * stripping, `--` separator semantics, and the `.run()` adapter path.
+ */
+import { describe, expect, it } from 'vitest';
+import { command } from '#internals/core/schema/command.ts';
+import { arg } from '#internals/core/schema/arg.ts';
+import { createTestAdapter, ExitError } from '#internals/runtime/adapter.ts';
+import { cli } from './index.ts';
+
+// === Helpers
+
+function statusCommand() {
+	return command('gen')
+		.description('Generate a file')
+		.action(({ out }) => {
+			out.log('artifact');
+			out.info('starting');
+			out.status('Wrote dist/app.js');
+		});
+}
+
+// === --quiet / -q via execute()
+
+describe('global --quiet flag', () => {
+	it('suppresses info and status, keeps log and result output', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await app.execute(['gen', '--quiet']);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('artifact\n');
+		expect(result.stderr.join('')).toBe('');
+	});
+
+	it('-q works as the short form', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await app.execute(['gen', '-q']);
+		expect(result.stdout.join('')).toBe('artifact\n');
+		expect(result.stderr.join('')).toBe('');
+	});
+
+	it('emits status on stderr without the flag', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await app.execute(['gen']);
+		expect(result.stdout.join('')).toBe('artifact\nstarting\n');
+		expect(result.stderr.join('')).toBe('Wrote dist/app.js\n');
+	});
+
+	it('is stripped before dispatch, so commands never see it', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await app.execute(['--quiet', 'gen']);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('artifact\n');
+	});
+
+	it('a post-separator -q reaches the command as a positional', async () => {
+		const echo = command('echo')
+			.arg('value', arg.string())
+			.action(({ args, out }) => {
+				out.log(String(args.value));
+			});
+		const app = cli('mycli').command(echo);
+		const result = await app.execute(['echo', '--', '-q']);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('-q\n');
+	});
+
+	it('appears in root help global options', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await app.execute(['--help']);
+		expect(result.stdout.join('')).toContain('-q, --quiet');
+	});
+});
+
+// === .run() adapter path
+
+async function runWithAdapter(
+	app: ReturnType<typeof cli>,
+	argv: readonly string[],
+): Promise<{ stdout: string[]; stderr: string[]; exitCode: number }> {
+	const stdout: string[] = [];
+	const stderr: string[] = [];
+	let exitCode = 0;
+	const adapter = createTestAdapter({
+		argv: ['node', 'test', ...argv],
+		stdout: (s) => stdout.push(s),
+		stderr: (s) => stderr.push(s),
+	});
+	try {
+		await app.run({ adapter });
+	} catch (e: unknown) {
+		if (e instanceof ExitError) {
+			exitCode = e.code;
+		} else {
+			throw e;
+		}
+	}
+	return { stdout, stderr, exitCode };
+}
+
+describe('run() adapter path', () => {
+	it('honors --quiet through preflight', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await runWithAdapter(app, ['gen', '--quiet']);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('artifact\n');
+		expect(result.stderr.join('')).toBe('');
+	});
+
+	it('a post-separator --json literal does not enter JSON mode', async () => {
+		const echo = command('echo')
+			.arg('value', arg.string())
+			.action(({ args, out }) => {
+				out.log(String(args.value));
+				out.info(`json:${String(out.jsonMode)}`);
+			});
+		const app = cli('mycli').command(echo);
+		const result = await runWithAdapter(app, ['echo', '--', '--json']);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('--json\njson:false\n');
+	});
+});

--- a/src/core/cli/cli-quiet.test.ts
+++ b/src/core/cli/cli-quiet.test.ts
@@ -3,8 +3,8 @@
  * stripping, `--` separator semantics, and the `.run()` adapter path.
  */
 import { describe, expect, it } from 'vitest';
-import { command } from '#internals/core/schema/command.ts';
 import { arg } from '#internals/core/schema/arg.ts';
+import { command } from '#internals/core/schema/command.ts';
 import { createTestAdapter, ExitError } from '#internals/runtime/adapter.ts';
 import { cli } from './index.ts';
 

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -24,7 +24,7 @@ import { buildRunResult, executeCommand } from '#internals/core/execution/index.
 import type { HelpOptions, HelpThemeFactory } from '#internals/core/help/index.ts';
 import { formatHelp } from '#internals/core/help/index.ts';
 import { generateCommandSchema, generateSchema } from '#internals/core/json-schema/index.ts';
-import type { CapturedOutput } from '#internals/core/output/index.ts';
+import type { CapturedOutput, Verbosity } from '#internals/core/output/index.ts';
 import {
 	clearRequestedExitCode,
 	createCaptureOutput,
@@ -1240,14 +1240,17 @@ class CLIBuilder {
 	 * @returns Structured result with exit code and captured output.
 	 */
 	async execute(argv: readonly string[], options?: CLIRunOptions): Promise<RunResult> {
-		// -- Detect global --json mode before building output ---------------------
-		// Only a `--json` before the `--` separator toggles JSON mode; a literal
-		// `--json` positional (after `--`) must reach the command unchanged (#28).
+		// -- Detect global --json / --quiet before building output ----------------
+		// Only occurrences before the `--` separator count; a literal positional
+		// (after `--`) must reach the command unchanged (#28).
 		const hasJsonFlag = includesBeforeSeparator(argv, '--json');
 		const jsonMode = hasJsonFlag || options?.jsonMode === true;
+		const hasQuietFlag =
+			includesBeforeSeparator(argv, '--quiet') || includesBeforeSeparator(argv, '-q');
+		const verbosity: Verbosity | undefined = hasQuietFlag ? 'quiet' : options?.verbosity;
 
 		const captureOptions = {
-			...(options?.verbosity !== undefined ? { verbosity: options.verbosity } : {}),
+			...(verbosity !== undefined ? { verbosity } : {}),
 			...(jsonMode ? { jsonMode } : {}),
 			...(options?.isTTY !== undefined ? { isTTY: options.isTTY } : {}),
 			...hyperlinksOption(resolveHyperlinkOverride(options?.env ?? {}, argv)),
@@ -1286,12 +1289,13 @@ class CLIBuilder {
 			...options,
 			plugins: this.schema.plugins,
 			...(jsonMode ? { jsonMode } : {}),
+			...(verbosity !== undefined ? { verbosity } : {}),
 			...(flagSettings !== undefined ? { flags: flagSettings } : {}),
 		};
 		const output: OutputPolicy = {
 			jsonMode,
 			isTTY: out.isTTY,
-			verbosity: options?.verbosity ?? 'normal',
+			verbosity: verbosity ?? 'normal',
 		};
 		// The planner scans flag arity during dispatch, so it must see the same
 		// merged flag settings (runtime override wins) that command parsing uses.

--- a/src/core/cli/planner.ts
+++ b/src/core/cli/planner.ts
@@ -444,6 +444,9 @@ function planCompletionsFlag(
 	return undefined;
 }
 
+/** Root-level output flags stripped before dispatch (never part of a command schema). */
+const ROOT_OUTPUT_FLAGS = new Set(['--json', '--quiet', '-q']);
+
 /**
  * Decide what to do with an argv invocation before any command executes.
  *
@@ -453,14 +456,17 @@ function planCompletionsFlag(
  * @internal
  */
 function planInvocation(options: PlanInvocationOptions): InvocationPlan {
-	// `--json` is a root-level flag, not part of any command schema, so it is
-	// stripped before dispatch/parse — but only before the `--` separator, so a
-	// literal `--json` positional (after `--`) survives and reaches the command
-	// (#28). The `--json` *output mode* is detected separately in `.execute()`.
+	// `--json` and `--quiet`/`-q` are root-level flags, not part of any command
+	// schema, so they are stripped before dispatch/parse — but only before the
+	// `--` separator, so a literal positional (after `--`) survives and reaches
+	// the command (#28). The output mode/verbosity themselves are detected
+	// separately in `.execute()`.
 	const separatorIndex = options.argv.indexOf('--');
 	const head = separatorIndex === -1 ? options.argv : options.argv.slice(0, separatorIndex);
 	const tail = separatorIndex === -1 ? [] : options.argv.slice(separatorIndex);
-	const filteredHead = head.includes('--json') ? head.filter((arg) => arg !== '--json') : head;
+	const filteredHead = head.some((arg) => ROOT_OUTPUT_FLAGS.has(arg))
+		? head.filter((arg) => !ROOT_OUTPUT_FLAGS.has(arg))
+		: head;
 	const filteredArgv = separatorIndex === -1 ? filteredHead : [...filteredHead, ...tail];
 
 	const defaultCommand = options.schema.defaultCommand;

--- a/src/core/cli/root-help.ts
+++ b/src/core/cli/root-help.ts
@@ -347,6 +347,10 @@ function formatGlobalOptionsSection(
 		});
 	}
 	entries.push({ left: theme.flag('--json'), description: 'Emit machine-readable JSON output' });
+	entries.push({
+		left: theme.flag('-q, --quiet'),
+		description: 'Suppress informational output',
+	});
 	if (schema.configSettings !== undefined) {
 		entries.push({
 			left: `${theme.flag('--config')} ${theme.placeholder('<path>')}`,

--- a/src/core/cli/runtime-preflight.ts
+++ b/src/core/cli/runtime-preflight.ts
@@ -18,7 +18,7 @@ import { CLIError, ParseError } from '#internals/core/errors/index.ts';
 import type { HelpThemeFactory } from '#internals/core/help/index.ts';
 import type { Verbosity } from '#internals/core/output/index.ts';
 import type { ParseOptions } from '#internals/core/parse/index.ts';
-import { parse } from '#internals/core/parse/index.ts';
+import { includesBeforeSeparator, parse } from '#internals/core/parse/index.ts';
 import type { PromptEngine } from '#internals/core/prompt/index.ts';
 import { createTerminalPrompter } from '#internals/core/prompt/index.ts';
 import type { CommandSchema, ErasedCommand } from '#internals/core/schema/command.ts';
@@ -405,8 +405,12 @@ async function prepareRuntimePreflight(
 		options.schema.configSettings !== undefined
 			? extractConfigFlag(rawArgv)
 			: { configPath: undefined, filteredArgv: rawArgv };
-	const hasJsonFlag = filteredArgv.includes('--json');
+	// Only pre-separator occurrences count; a literal after `--` is a
+	// positional for the command (#28).
+	const hasJsonFlag = includesBeforeSeparator(filteredArgv, '--json');
 	const jsonMode = hasJsonFlag || options.options?.jsonMode === true;
+	const hasQuietFlag =
+		includesBeforeSeparator(filteredArgv, '--quiet') || includesBeforeSeparator(filteredArgv, '-q');
 	const isCompletions = isCompletionsInvocation(options.schema, filteredArgv);
 	const schema = await applyPackageJsonDiscovery(
 		options.schema,
@@ -447,7 +451,7 @@ async function prepareRuntimePreflight(
 			env: options.options?.env ?? options.adapter.env,
 			isTTY: options.options?.isTTY ?? options.adapter.isTTY,
 			jsonMode,
-			verbosity: options.options?.verbosity ?? 'normal',
+			verbosity: hasQuietFlag ? 'quiet' : (options.options?.verbosity ?? 'normal'),
 			stat: options.options?.stat ?? options.adapter.stat,
 			...(stdinData !== undefined ? { stdinData } : {}),
 			...(options.options?.prompter !== undefined

--- a/src/core/output/contracts.ts
+++ b/src/core/output/contracts.ts
@@ -104,7 +104,7 @@ function resolveTextStream(policy: OutputPolicy): OutputStream {
 	return policy.jsonMode ? 'stderr' : 'stdout';
 }
 
-/** Whether `info()` messages should be emitted under the current policy. */
+/** Whether `info()`/`status()` messages should be emitted under the current policy. */
 function shouldEmitInfo(policy: OutputPolicy): boolean {
 	return policy.verbosity !== 'quiet';
 }

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -293,6 +293,15 @@ class OutputChannel implements Out {
 		writeLine(writer, message);
 	}
 
+	/**
+	 * Status line to stderr (stdout stays clean for piping).
+	 * Suppressed when verbosity is `'quiet'`.
+	 */
+	status(message: string): void {
+		if (!shouldEmitInfo(this.policy)) return;
+		writeLine(this.options.stderr, message);
+	}
+
 	/** Warning to stderr. Always emitted. */
 	warn(message: string): void {
 		writeLine(this.options.stderr, message);

--- a/src/core/output/output.test.ts
+++ b/src/core/output/output.test.ts
@@ -173,6 +173,38 @@ describe('verbosity', () => {
 	});
 });
 
+// --- status() — quiet-suppressible stderr channel
+
+describe('status', () => {
+	it('writes to stderr, keeping stdout clean', () => {
+		const [out, captured] = createCaptureOutput();
+		out.status('Wrote dist/app.js');
+		expect(captured.stdout).toEqual([]);
+		expect(captured.stderr).toEqual(['Wrote dist/app.js\n']);
+	});
+
+	it('is suppressed in quiet mode', () => {
+		const [out, captured] = createCaptureOutput({ verbosity: 'quiet' });
+		out.status('Wrote dist/app.js');
+		expect(captured.stderr).toEqual([]);
+	});
+
+	it('stays on stderr in JSON mode', () => {
+		const [out, captured] = createCaptureOutput({ jsonMode: true });
+		out.status('Wrote dist/app.js');
+		out.json({ ok: true });
+		expect(captured.stdout).toEqual(['{"ok":true}\n']);
+		expect(captured.stderr).toEqual(['Wrote dist/app.js\n']);
+	});
+
+	it('keeps working when destructured off out', () => {
+		const [out, captured] = createCaptureOutput();
+		const { status } = out;
+		status('detached');
+		expect(captured.stderr).toEqual(['detached\n']);
+	});
+});
+
 // --- TTY detection
 
 describe('isTTY', () => {

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -346,6 +346,7 @@ describe('full command composition', () => {
 		const mockOut: Out = {
 			log: vi.fn(),
 			info: vi.fn(),
+			status: vi.fn(),
 			warn: vi.fn(),
 			error: vi.fn(),
 			setExitCode: vi.fn(),

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -150,6 +150,13 @@ interface Out {
 	log(message: string): void;
 	/** Informational (may be suppressed in quiet mode). */
 	info(message: string): void;
+	/**
+	 * Status line to stderr, suppressed in quiet mode.
+	 *
+	 * Keeps stdout clean for piping; for success and progress notes like
+	 * `Wrote <path>` that scripts silence with `--quiet`.
+	 */
+	status(message: string): void;
 	/** Warning to stderr. */
 	warn(message: string): void;
 	/** Error to stderr. */


### PR DESCRIPTION
Closes #64.

## Problem

No way to print a **success/status** line that is both on **stderr** (stdout stays clean for piping) and **suppressed under quiet**: `info` is suppressible but stdout-bound; `warn`/`error` are stderr but always emitted and semantically wrong for success. And there was no built-in `--quiet` — every CLI wired its own.

## Solution — two of the issue's proposals

**`out.status(message)`** — stderr, suppressed when verbosity is `'quiet'`, same gate as `info` (`shouldEmitInfo`). In JSON mode it stays on stderr like `warn`, so stdout remains pure JSON. Bound like every channel method (works destructured).

**Global `--quiet`/`-q`** — maps to `verbosity: 'quiet'`, wired exactly like `--json`:
- detected in `execute()` and runtime preflight (both `--`-separator aware),
- stripped by the planner before dispatch so command schemas never see it (like `--json`, the name is reserved at the root),
- a literal `-q` after `--` reaches the command as a positional,
- listed in root help under `Global options:` (`-q, --quiet`).

The flag wins over a caller-supplied `verbosity` option, mirroring `--json`'s flag-or-option semantics.

## Bug fix (same class, found while wiring)

`.run()`'s preflight used naive `filteredArgv.includes('--json')`, so `mycli cmd -- --json` entered JSON mode via the adapter path even though `.execute()` handles it correctly. Preflight now uses `includesBeforeSeparator`. Regression test included (fails on the old code).

## Tests

- `output.test.ts` — `status()`: stderr routing, quiet suppression, JSON-mode stderr, destructuring.
- `cli-quiet.test.ts` (new) — `--quiet`/`-q` suppress `info`+`status` end-to-end; flag-before-command stripping; post-`--` `-q` as positional; root help listing; `.run()` adapter path incl. the `--json` separator regression.

Full suite (2905), typecheck, biome, dprint, `deno check`, docs build all pass.

## Docs

`guide/output.md` gains "Status Lines and Quiet Mode" with the stream/suppression matrix.

Bumps to `3.0.0-rc.17`.