### PR TITLE
feat(resolve): honor mustExist: false and add flag.path directory create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0-rc.18] - 2026-07-21
+
+### Added
+
+- **`flag.path({ type: 'directory', create: true })`** — creates the directory
+  (recursively) at resolution time when nothing exists at the path. Only
+  available with `type: 'directory'`, enforced at the type level. Creation
+  runs through a new `mkdir` seam: `RuntimeAdapter.mkdir`, overridable via
+  run options, noop in the test adapter, so `src/core` stays process-free.
+
+### Fixed
+
+- **`flag.path({ type, mustExist: false })` rejected missing paths** — the
+  builder recorded the explicit `mustExist: false`, but resolution errored on
+  any missing path whenever path checks were active, making an optional
+  to-be-created path (e.g. an `--outdir` that the command itself creates)
+  impossible to declare. A missing path now passes when `mustExist` is
+  `false`; an existing path is still type-checked.
+
 ## [3.0.0-rc.17] - 2026-07-20
 
 ### Added

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.17",
+	"version": "3.0.0-rc.18",
 	"license": "MIT",
 	"tasks": {
 		"check": {

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -235,10 +235,16 @@ env, and config values are validated identically:
 flag.path(); // any string
 flag.path({ mustExist: true }); // rejects missing paths
 flag.path({ type: 'directory' }); // must exist and be a directory
+flag.path({ type: 'directory', mustExist: false }); // missing passes; existing must be a directory
+flag.path({ type: 'directory', create: true }); // created recursively when missing
 ```
 
+`create` is only available with `type: 'directory'` (enforced at the type
+level) and still rejects an existing non-directory path.
+
 In process-free execution (`.execute()` / `runCommand()`), pass a `stat`
-function via run options to enable the checks; without one they are skipped.
+function via run options to enable the checks (plus `mkdir` for `create`);
+without them the checks are skipped and nothing is created.
 
 ### Date
 

--- a/dreamcli.schema.json
+++ b/dreamcli.schema.json
@@ -227,6 +227,9 @@
                 "file",
                 "directory"
               ]
+            },
+            "create": {
+              "type": "boolean"
             }
           },
           "required": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.17",
+	"version": "3.0.0-rc.18",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
 		"dreamcli",

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -621,6 +621,7 @@ function buildCommandRunOptions(
 		...(options?.prompter !== undefined ? { prompter: options.prompter } : {}),
 		...(options?.answers !== undefined ? { answers: options.answers } : {}),
 		...(options?.stat !== undefined ? { stat: options.stat } : {}),
+		...(options?.mkdir !== undefined ? { mkdir: options.mkdir } : {}),
 		...(options?.verbosity !== undefined ? { verbosity: options.verbosity } : {}),
 		...(options?.jsonMode !== undefined ? { jsonMode: options.jsonMode } : {}),
 		...(options?.isTTY !== undefined ? { isTTY: options.isTTY } : {}),

--- a/src/core/cli/runtime-preflight.ts
+++ b/src/core/cli/runtime-preflight.ts
@@ -132,6 +132,8 @@ interface RuntimePreflightOptions {
 	readonly isTTY?: boolean;
 	/** Filesystem probe override for `flag.path()` checks; bypasses the adapter probe. */
 	readonly stat?: (path: string) => Promise<'file' | 'directory' | null>;
+	/** Directory creation override for `flag.path()` `create` checks; bypasses the adapter. */
+	readonly mkdir?: (path: string) => Promise<void>;
 }
 
 /**
@@ -158,6 +160,8 @@ interface RuntimeExecutionInputs {
 	readonly config?: Readonly<Record<string, unknown>>;
 	/** Filesystem probe (from the adapter) for `flag.path()` checks. */
 	readonly stat?: (path: string) => Promise<'file' | 'directory' | null>;
+	/** Directory creation (from the adapter) for `flag.path()` `create` checks. */
+	readonly mkdir?: (path: string) => Promise<void>;
 }
 
 /** Preflight succeeded — all runtime inputs are resolved and ready for execution. @internal */
@@ -453,6 +457,7 @@ async function prepareRuntimePreflight(
 			jsonMode,
 			verbosity: hasQuietFlag ? 'quiet' : (options.options?.verbosity ?? 'normal'),
 			stat: options.options?.stat ?? options.adapter.stat,
+			mkdir: options.options?.mkdir ?? options.adapter.mkdir,
 			...(stdinData !== undefined ? { stdinData } : {}),
 			...(options.options?.prompter !== undefined
 				? { prompter: options.options.prompter }

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -125,6 +125,7 @@ async function executeCommand(request: CommandExecutionRequest): Promise<Command
 			...(options?.config !== undefined ? { config: options.config } : {}),
 			...(effectivePrompter !== undefined ? { prompter: effectivePrompter } : {}),
 			...(options?.stat !== undefined ? { stat: options.stat } : {}),
+			...(options?.mkdir !== undefined ? { mkdir: options.mkdir } : {}),
 		};
 		const resolved = await resolve(schema, parsed, resolveOptions);
 		const resolvedParams: ResolvedCommandParams = {

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -295,6 +295,7 @@ function serializeFlag(schema: FlagSchema, opts: ResolvedOptions): Record<string
 		result.pathChecks = {
 			mustExist: schema.pathChecks.mustExist,
 			...(schema.pathChecks.type !== undefined ? { type: schema.pathChecks.type } : {}),
+			...(schema.pathChecks.create ? { create: true } : {}),
 		};
 	}
 	if (schema.valueHint !== undefined) {
@@ -1019,6 +1020,7 @@ const definitionMetaSchema: Record<string, unknown> = withDefinitionMetaSchemaDe
 						properties: {
 							mustExist: { type: 'boolean' },
 							type: { enum: ['file', 'directory'] },
+							create: { type: 'boolean' },
 						},
 						required: ['mustExist'],
 					},

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -306,7 +306,7 @@ describe('generateSchema — definition metadata', () => {
 				}),
 				path: flagDef({
 					kind: 'string',
-					pathChecks: { mustExist: true, type: 'file' },
+					pathChecks: { mustExist: true, type: 'file', create: false },
 					valueHint: 'path',
 				}),
 			},
@@ -862,7 +862,7 @@ describe('generateSchema — definition metadata', () => {
 			elementSchema: flagDef({ kind: 'string' }),
 			separator: ',',
 			unique: true,
-			pathChecks: { mustExist: true, type: 'file' },
+			pathChecks: { mustExist: true, type: 'file', create: false },
 			valueHint: 'version',
 			prompt: { kind: 'input', message: 'Version?', placeholder: 'v1' },
 			parseFn: (value: unknown) => value,

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -862,7 +862,7 @@ describe('generateSchema — definition metadata', () => {
 			elementSchema: flagDef({ kind: 'string' }),
 			separator: ',',
 			unique: true,
-			pathChecks: { mustExist: true, type: 'file', create: false },
+			pathChecks: { mustExist: true, type: 'directory', create: true },
 			valueHint: 'version',
 			prompt: { kind: 'input', message: 'Version?', placeholder: 'v1' },
 			parseFn: (value: unknown) => value,

--- a/src/core/resolve/contracts.ts
+++ b/src/core/resolve/contracts.ts
@@ -60,6 +60,11 @@ interface ResolveOptions {
 	 * `null` when nothing does. When absent, path checks are skipped.
 	 */
 	readonly stat?: (path: string) => Promise<'file' | 'directory' | null>;
+	/**
+	 * Recursive directory creation for `flag.path()` `create` checks. When
+	 * absent, missing paths are not created and existence rules apply as-is.
+	 */
+	readonly mkdir?: (path: string) => Promise<void>;
 }
 
 /** Structured deprecation notice emitted for explicitly sourced values. */

--- a/src/core/resolve/flags.ts
+++ b/src/core/resolve/flags.ts
@@ -27,6 +27,9 @@ type PromptResolveResult =
  */
 type StatFn = (path: string) => Promise<'file' | 'directory' | null>;
 
+/** Recursive directory creation injected by the caller for `flag.path()` `create` checks. */
+type MkdirFn = (path: string) => Promise<void>;
+
 /** Walk every declared flag through the resolution chain (cli -> env -> config -> prompt -> default), collecting deprecations and throwing aggregated errors. */
 async function resolveFlags(
 	flagSchemas: Readonly<Record<string, FlagSchema>>,
@@ -37,6 +40,7 @@ async function resolveFlags(
 	interactive: ErasedInteractiveResolver | undefined,
 	deprecations: DeprecationWarning[],
 	stat: StatFn | undefined,
+	mkdir: MkdirFn | undefined,
 ): Promise<Readonly<Record<string, unknown>>> {
 	const resolved: Record<string, unknown> = {};
 	const errors: ValidationError[] = [];
@@ -182,7 +186,7 @@ async function resolveFlags(
 		}
 
 		if (schema.pathChecks !== undefined && typeof value === 'string' && stat !== undefined) {
-			const violation = await validatePathChecks(name, value, schema.pathChecks, stat);
+			const violation = await validatePathChecks(name, value, schema.pathChecks, stat, mkdir);
 			if (violation !== undefined) {
 				errors.push(violation);
 			}
@@ -208,9 +212,28 @@ async function validatePathChecks(
 	value: string,
 	checks: NonNullable<FlagSchema['pathChecks']>,
 	stat: StatFn,
+	mkdir: MkdirFn | undefined,
 ): Promise<ValidationError | undefined> {
 	const found = await stat(value);
 	if (found === null) {
+		if (checks.create && mkdir !== undefined) {
+			try {
+				await mkdir(value);
+				return undefined;
+			} catch (error) {
+				return new ValidationError(
+					`Failed to create directory '${value}' for flag --${flagName}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+					{
+						code: 'CONSTRAINT_VIOLATED',
+						details: { flag: flagName, value, constraint: 'create' },
+						suggest: `Provide a creatable or existing directory path for --${flagName}`,
+					},
+				);
+			}
+		}
+		if (!checks.mustExist) return undefined;
 		return new ValidationError(`Path '${value}' for flag --${flagName} does not exist`, {
 			code: 'CONSTRAINT_VIOLATED',
 			details: { flag: flagName, value, constraint: 'mustExist' },

--- a/src/core/resolve/index.ts
+++ b/src/core/resolve/index.ts
@@ -82,6 +82,7 @@ async function resolve(
 			schema.interactive,
 			deprecations,
 			options?.stat,
+			options?.mkdir,
 		);
 	} catch (error) {
 		if (!isValidationError(error)) {

--- a/src/core/resolve/resolve-path-checks.test.ts
+++ b/src/core/resolve/resolve-path-checks.test.ts
@@ -268,6 +268,42 @@ describe('resolve() — path checks', () => {
 		expect(created).toEqual(['/build/out']);
 	});
 
+	it('creates a missing directory when create is set and mustExist is false', async () => {
+		const schema = makeSchema({
+			flags: {
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: false, type: 'directory', create: true },
+				}),
+			},
+		});
+		const parsed = makeParsed({ flags: { outDir: '/build/out' } });
+		const probe = statProbe();
+		const created: string[] = [];
+		const mkdir = (path: string): Promise<void> => {
+			created.push(path);
+			return Promise.resolve();
+		};
+
+		const result = await resolve(schema, parsed, { stat: probe.stat, mkdir });
+		expect(result.flags).toEqual({ outDir: '/build/out' });
+		expect(created).toEqual(['/build/out']);
+	});
+
+	it('passes a missing path when create is set with mustExist false and no mkdir is available', async () => {
+		const schema = makeSchema({
+			flags: {
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: false, type: 'directory', create: true },
+				}),
+			},
+		});
+		const parsed = makeParsed({ flags: { outDir: '/build/out' } });
+		const probe = statProbe();
+
+		const result = await resolve(schema, parsed, { stat: probe.stat });
+		expect(result.flags).toEqual({ outDir: '/build/out' });
+	});
+
 	it('does not call mkdir when the directory already exists', async () => {
 		const schema = makeSchema({
 			flags: {

--- a/src/core/resolve/resolve-path-checks.test.ts
+++ b/src/core/resolve/resolve-path-checks.test.ts
@@ -91,6 +91,7 @@ describe('flag.path() — builder schema', () => {
 		expect(flag.path({ mustExist: true }).schema.pathChecks).toEqual({
 			mustExist: true,
 			type: undefined,
+			create: false,
 		});
 	});
 
@@ -98,10 +99,12 @@ describe('flag.path() — builder schema', () => {
 		expect(flag.path({ type: 'directory' }).schema.pathChecks).toEqual({
 			mustExist: true,
 			type: 'directory',
+			create: false,
 		});
 		expect(flag.path({ type: 'file' }).schema.pathChecks).toEqual({
 			mustExist: true,
 			type: 'file',
+			create: false,
 		});
 	});
 
@@ -109,7 +112,23 @@ describe('flag.path() — builder schema', () => {
 		expect(flag.path({ mustExist: false, type: 'file' }).schema.pathChecks).toEqual({
 			mustExist: false,
 			type: 'file',
+			create: false,
 		});
+	});
+
+	it('stores create for directory paths', () => {
+		expect(flag.path({ type: 'directory', create: true }).schema.pathChecks).toEqual({
+			mustExist: true,
+			type: 'directory',
+			create: true,
+		});
+	});
+
+	it('rejects create without type: directory at the type level', () => {
+		// @ts-expect-error — create is only available with type: 'directory'
+		flag.path({ create: true });
+		// @ts-expect-error — create is only available with type: 'directory'
+		flag.path({ type: 'file', create: true });
 	});
 
 	// --- type inference
@@ -134,7 +153,7 @@ describe('flag.path() — builder schema', () => {
 
 	it('.nonEmpty() preserves pathChecks through the chain', () => {
 		const f = flag.path({ type: 'file' }).nonEmpty();
-		expect(f.schema.pathChecks).toEqual({ mustExist: true, type: 'file' });
+		expect(f.schema.pathChecks).toEqual({ mustExist: true, type: 'file', create: false });
 		expect(f.schema.stringConstraints).toEqual({ nonEmpty: true });
 	});
 });
@@ -145,7 +164,9 @@ describe('resolve() — path checks', () => {
 	it('passes when stat reports a file for mustExist', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', { pathChecks: { mustExist: true, type: undefined } }),
+				input: createSchema('string', {
+					pathChecks: { mustExist: true, type: undefined, create: false },
+				}),
 			},
 		});
 		const parsed = makeParsed({ flags: { input: '/data/report.csv' } });
@@ -159,7 +180,9 @@ describe('resolve() — path checks', () => {
 	it('rejects a missing path with CONSTRAINT_VIOLATED', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', { pathChecks: { mustExist: true, type: undefined } }),
+				input: createSchema('string', {
+					pathChecks: { mustExist: true, type: undefined, create: false },
+				}),
 			},
 		});
 		const parsed = makeParsed({ flags: { input: '/nope' } });
@@ -180,10 +203,188 @@ describe('resolve() — path checks', () => {
 		}
 	});
 
+	it('passes a missing path when mustExist is false', async () => {
+		const schema = makeSchema({
+			flags: {
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: false, type: 'directory', create: false },
+				}),
+			},
+		});
+		const parsed = makeParsed({ flags: { outDir: '/not/yet/created' } });
+		const probe = statProbe();
+
+		const result = await resolve(schema, parsed, { stat: probe.stat });
+		expect(result.flags).toEqual({ outDir: '/not/yet/created' });
+		expect(probe.calls).toEqual(['/not/yet/created']);
+	});
+
+	it('rejects an existing wrong-type path even when mustExist is false', async () => {
+		const schema = makeSchema({
+			flags: {
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: false, type: 'directory', create: false },
+				}),
+			},
+		});
+		const parsed = makeParsed({ flags: { outDir: '/data/report.csv' } });
+		const probe = statProbe({ '/data/report.csv': 'file' });
+
+		try {
+			await resolve(schema, parsed, { stat: probe.stat });
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect(isValidationError(err)).toBe(true);
+			if (isValidationError(err)) {
+				expect(err.code).toBe('CONSTRAINT_VIOLATED');
+				expect(err.details).toEqual({
+					flag: 'outDir',
+					value: '/data/report.csv',
+					constraint: 'pathType',
+					expected: 'directory',
+				});
+			}
+		}
+	});
+
+	it('creates a missing directory when create is set', async () => {
+		const schema = makeSchema({
+			flags: {
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: true, type: 'directory', create: true },
+				}),
+			},
+		});
+		const parsed = makeParsed({ flags: { outDir: '/build/out' } });
+		const probe = statProbe();
+		const created: string[] = [];
+		const mkdir = (path: string): Promise<void> => {
+			created.push(path);
+			return Promise.resolve();
+		};
+
+		const result = await resolve(schema, parsed, { stat: probe.stat, mkdir });
+		expect(result.flags).toEqual({ outDir: '/build/out' });
+		expect(created).toEqual(['/build/out']);
+	});
+
+	it('does not call mkdir when the directory already exists', async () => {
+		const schema = makeSchema({
+			flags: {
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: true, type: 'directory', create: true },
+				}),
+			},
+		});
+		const parsed = makeParsed({ flags: { outDir: '/build/out' } });
+		const probe = statProbe({ '/build/out': 'directory' });
+		const created: string[] = [];
+		const mkdir = (path: string): Promise<void> => {
+			created.push(path);
+			return Promise.resolve();
+		};
+
+		const result = await resolve(schema, parsed, { stat: probe.stat, mkdir });
+		expect(result.flags).toEqual({ outDir: '/build/out' });
+		expect(created).toEqual([]);
+	});
+
+	it('reports a failing mkdir as CONSTRAINT_VIOLATED', async () => {
+		const schema = makeSchema({
+			flags: {
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: true, type: 'directory', create: true },
+				}),
+			},
+		});
+		const parsed = makeParsed({ flags: { outDir: '/readonly/out' } });
+		const probe = statProbe();
+		const mkdir = (): Promise<void> => Promise.reject(new Error('EACCES: permission denied'));
+
+		try {
+			await resolve(schema, parsed, { stat: probe.stat, mkdir });
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect(isValidationError(err)).toBe(true);
+			if (isValidationError(err)) {
+				expect(err.code).toBe('CONSTRAINT_VIOLATED');
+				expect(err.message).toBe(
+					"Failed to create directory '/readonly/out' for flag --outDir: EACCES: permission denied",
+				);
+				expect(err.details).toEqual({
+					flag: 'outDir',
+					value: '/readonly/out',
+					constraint: 'create',
+				});
+			}
+		}
+	});
+
+	it('falls back to existence rules when create is set but no mkdir is available', async () => {
+		const schema = makeSchema({
+			flags: {
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: true, type: 'directory', create: true },
+				}),
+			},
+		});
+		const parsed = makeParsed({ flags: { outDir: '/build/out' } });
+		const probe = statProbe();
+
+		try {
+			await resolve(schema, parsed, { stat: probe.stat });
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect(isValidationError(err)).toBe(true);
+			if (isValidationError(err)) {
+				expect(err.details).toEqual({
+					flag: 'outDir',
+					value: '/build/out',
+					constraint: 'mustExist',
+				});
+			}
+		}
+	});
+
+	it('still rejects an existing file when create is set', async () => {
+		const schema = makeSchema({
+			flags: {
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: true, type: 'directory', create: true },
+				}),
+			},
+		});
+		const parsed = makeParsed({ flags: { outDir: '/build/out' } });
+		const probe = statProbe({ '/build/out': 'file' });
+		const created: string[] = [];
+		const mkdir = (path: string): Promise<void> => {
+			created.push(path);
+			return Promise.resolve();
+		};
+
+		try {
+			await resolve(schema, parsed, { stat: probe.stat, mkdir });
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect(isValidationError(err)).toBe(true);
+			if (isValidationError(err)) {
+				expect(err.details).toEqual({
+					flag: 'outDir',
+					value: '/build/out',
+					constraint: 'pathType',
+					expected: 'directory',
+				});
+			}
+		}
+		expect(created).toEqual([]);
+	});
+
 	it('rejects a file where a directory is expected', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', { pathChecks: { mustExist: true, type: 'directory' } }),
+				outDir: createSchema('string', {
+					pathChecks: { mustExist: true, type: 'directory', create: false },
+				}),
 			},
 		});
 		const parsed = makeParsed({ flags: { outDir: '/data/report.csv' } });
@@ -213,7 +414,9 @@ describe('resolve() — path checks', () => {
 	it('rejects a directory where a file is expected', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', { pathChecks: { mustExist: true, type: 'file' } }),
+				input: createSchema('string', {
+					pathChecks: { mustExist: true, type: 'file', create: false },
+				}),
 			},
 		});
 		const parsed = makeParsed({ flags: { input: '/data' } });
@@ -239,7 +442,9 @@ describe('resolve() — path checks', () => {
 	it('skips checks when no stat is provided', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', { pathChecks: { mustExist: true, type: 'file' } }),
+				input: createSchema('string', {
+					pathChecks: { mustExist: true, type: 'file', create: false },
+				}),
 			},
 		});
 		const parsed = makeParsed({ flags: { input: '/nope' } });
@@ -254,7 +459,7 @@ describe('resolve() — path checks', () => {
 				input: createSchema('string', {
 					presence: 'defaulted',
 					defaultValue: '/default/missing',
-					pathChecks: { mustExist: true, type: undefined },
+					pathChecks: { mustExist: true, type: undefined, create: false },
 				}),
 			},
 		});
@@ -277,7 +482,9 @@ describe('resolve() — path checks', () => {
 	it('does not call stat when the optional path flag is unresolved', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', { pathChecks: { mustExist: true, type: 'file' } }),
+				input: createSchema('string', {
+					pathChecks: { mustExist: true, type: 'file', create: false },
+				}),
 			},
 		});
 		const parsed = makeParsed({ flags: {} });

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -189,19 +189,47 @@ type FlagParseFn<T> = (raw: unknown) => T;
 type CustomFlagValue<A> =
 	A extends FlagParseFn<infer T> ? T : A extends StandardSchemaV1 ? InferStandardOutput<A> : never;
 
-/** Options accepted by `flag.path()`. */
-interface PathFlagOptions {
+/** Options accepted by `flag.path()` for any-kind or file paths. */
+interface FilePathFlagOptions {
 	/**
 	 * Reject the value if nothing exists at the path.
 	 * @defaultValue `false` (`true` when `type` is set)
 	 */
 	readonly mustExist?: boolean;
 	/**
-	 * Require the path to be a file or a directory. Implies existence.
+	 * Require the path to be a file or a directory. Implies existence
+	 * unless `mustExist` is explicitly `false`, in which case a missing
+	 * path passes and only an existing path is type-checked.
 	 * @defaultValue `undefined` (any kind)
 	 */
-	readonly type?: 'file' | 'directory';
+	readonly type?: 'file';
+	/** Directory creation is only available with `type: 'directory'`. */
+	readonly create?: never;
 }
+
+/** Options accepted by `flag.path()` for directory paths. */
+interface DirectoryPathFlagOptions {
+	/**
+	 * Reject the value if nothing exists at the path.
+	 * @defaultValue `false` (`true` when `type` is set)
+	 */
+	readonly mustExist?: boolean;
+	/**
+	 * Require the path to be a directory. Implies existence unless
+	 * `mustExist` is explicitly `false`, in which case a missing path
+	 * passes and only an existing path is type-checked.
+	 */
+	readonly type: 'directory';
+	/**
+	 * Create the directory (recursively) when nothing exists at the path.
+	 * An existing non-directory path still fails the type check.
+	 * @defaultValue `false`
+	 */
+	readonly create?: boolean;
+}
+
+/** Options accepted by `flag.path()`. */
+type PathFlagOptions = FilePathFlagOptions | DirectoryPathFlagOptions;
 
 /**
  * Filesystem expectations attached by `flag.path()`.
@@ -215,9 +243,11 @@ interface PathChecks {
 	readonly mustExist: boolean;
 	/**
 	 * Require the existing path to be a file or a directory. Implies
-	 * existence when set.
+	 * existence when set, unless `mustExist` is `false`.
 	 */
 	readonly type: 'file' | 'directory' | undefined;
+	/** Create the directory (recursively) when nothing exists at the path. */
+	readonly create: boolean;
 }
 
 /** Runtime descriptor for a flag alias. */
@@ -1257,7 +1287,7 @@ interface FlagFactory {
 	 * env, and config values are validated identically.
 	 *
 	 * @param options - Optional existence/type checks. `type` implies
-	 *   existence.
+	 *   existence unless `mustExist` is explicitly `false`.
 	 * @returns A {@link FlagBuilder} for path strings.
 	 *
 	 * @example
@@ -1265,6 +1295,10 @@ interface FlagFactory {
 	 * flag.path()                          // any string, help shows <path>
 	 * flag.path({ mustExist: true })       // rejects missing paths
 	 * flag.path({ type: 'directory' })     // must exist and be a directory
+	 * flag.path({ type: 'directory', mustExist: false })
+	 *                                      // missing passes; existing must be a directory
+	 * flag.path({ type: 'directory', create: true })
+	 *                                      // created recursively when missing
 	 * ```
 	 */
 	path(options?: PathFlagOptions): FlagBuilder<{
@@ -1505,7 +1539,11 @@ const flag: FlagFactory = {
 	}> {
 		const pathChecks =
 			options?.mustExist === true || options?.type !== undefined
-				? { mustExist: options.mustExist ?? true, type: options.type }
+				? {
+						mustExist: options.mustExist ?? true,
+						type: options.type,
+						create: options.type === 'directory' && options.create === true,
+					}
 				: undefined;
 		return new FlagBuilder(createSchema('string', { pathChecks, valueHint: 'path' }));
 	},

--- a/src/core/schema/run.ts
+++ b/src/core/schema/run.ts
@@ -86,6 +86,14 @@ export interface RunOptions {
 	readonly stat?: (path: string) => Promise<'file' | 'directory' | null>;
 
 	/**
+	 * Recursive directory creation for `flag.path()` `create` checks.
+	 *
+	 * `CLIBuilder.run()` supplies the runtime adapter's implementation
+	 * automatically. When absent, missing paths are not created.
+	 */
+	readonly mkdir?: (path: string) => Promise<void>;
+
+	/**
 	 * Verbosity level for the output channel.
 	 * @defaultValue `'normal'`
 	 */

--- a/src/runtime/adapter.ts
+++ b/src/runtime/adapter.ts
@@ -120,6 +120,16 @@ interface RuntimeAdapter {
 	readonly stat: (path: string) => Promise<'file' | 'directory' | null>;
 
 	/**
+	 * Create a directory, including missing parents.
+	 *
+	 * Succeeds when the directory already exists. Throws on other I/O errors
+	 * (permission denied, existing file at the path, etc.).
+	 *
+	 * Used by `flag.path()` `create` checks after resolution.
+	 */
+	readonly mkdir: (path: string) => Promise<void>;
+
+	/**
 	 * User home directory (absolute path).
 	 *
 	 * - Node/Bun: derived from `HOME` / `USERPROFILE` env
@@ -243,6 +253,12 @@ interface TestAdapterOptions {
 	 */
 	readonly stat?: (path: string) => Promise<'file' | 'directory' | null>;
 
+	/**
+	 * Directory creation stub for `flag.path()` `create` checks (defaults to
+	 * a noop that resolves without creating anything).
+	 */
+	readonly mkdir?: (path: string) => Promise<void>;
+
 	/** Home directory (defaults to `'/home/test'`). */
 	readonly homedir?: string;
 
@@ -293,6 +309,9 @@ const noopReadFile: (path: string) => Promise<string | null> = () => Promise.res
 const noopStat: (path: string) => Promise<'file' | 'directory' | null> = () =>
 	Promise.resolve(null);
 
+/** Noop mkdir — resolves without creating anything. */
+const noopMkdir: (path: string) => Promise<void> = () => Promise.resolve();
+
 /**
  * Create a test runtime adapter with injectable process state.
  *
@@ -342,6 +361,7 @@ function createTestAdapter(options?: TestAdapterOptions): RuntimeAdapter {
 			}),
 		readFile: options?.readFile ?? noopReadFile,
 		stat: options?.stat ?? noopStat,
+		mkdir: options?.mkdir ?? noopMkdir,
 		homedir: options?.homedir ?? '/home/test',
 		configDir: options?.configDir ?? '/home/test/.config',
 	};

--- a/src/runtime/deno.test.ts
+++ b/src/runtime/deno.test.ts
@@ -95,6 +95,7 @@ function mockDeno(overrides?: Partial<DenoNamespace>): DenoNamespace {
 		exit: overrides?.exit ?? (vi.fn() as unknown as (code: number) => never),
 		readTextFile: overrides?.readTextFile ?? (() => Promise.reject(makeDenoError('NotFound'))),
 		stat: overrides?.stat ?? (() => Promise.reject(makeDenoError('NotFound'))),
+		mkdir: overrides?.mkdir ?? (() => Promise.resolve()),
 	};
 }
 

--- a/src/runtime/deno.ts
+++ b/src/runtime/deno.ts
@@ -107,6 +107,9 @@ interface DenoNamespace {
 
 	/** Probe a filesystem path (requires `--allow-read`). */
 	stat(path: string): Promise<{ readonly isDirectory: boolean }>;
+
+	/** Create a directory (requires `--allow-write`). */
+	mkdir(path: string, options?: { readonly recursive?: boolean }): Promise<void>;
 }
 
 // --- Permission-safe helpers
@@ -254,6 +257,7 @@ function createDenoAdapter(ns?: DenoNamespace): RuntimeAdapter {
 		exit: (code) => d.exit(code),
 		readFile,
 		stat,
+		mkdir: (path) => d.mkdir(path, { recursive: true }),
 		homedir,
 		configDir,
 	};

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -213,6 +213,11 @@ function createNodeAdapter(proc?: NodeProcess): RuntimeAdapter {
 		}
 	};
 
+	const mkdir = async (path: string): Promise<void> => {
+		const fs = await import('node:fs/promises');
+		await fs.mkdir(path, { recursive: true });
+	};
+
 	const homedir = resolveHomedir(p.env, p.platform);
 	const configDir = resolveConfigDir(p.env, p.platform, homedir);
 
@@ -233,6 +238,7 @@ function createNodeAdapter(proc?: NodeProcess): RuntimeAdapter {
 		exit: (code) => p.exit(code),
 		readFile,
 		stat,
+		mkdir,
 		homedir,
 		configDir,
 	};

--- a/src/runtime/test-helpers.ts
+++ b/src/runtime/test-helpers.ts
@@ -35,6 +35,7 @@ export function createMockDenoNamespace(): DenoNamespace {
 		exit: vi.fn() as unknown as (code: number) => never,
 		readTextFile: () => Promise.reject(Object.assign(new Error('not found'), { name: 'NotFound' })),
 		stat: () => Promise.reject(Object.assign(new Error('not found'), { name: 'NotFound' })),
+		mkdir: () => Promise.resolve(),
 		version: { deno: '2.6.0' },
 	};
 }


### PR DESCRIPTION
## What

Two changes to `flag.path()` filesystem checks, bumping to 3.0.0-rc.18.

### Fix: `mustExist: false` was ignored

`flag.path({ type: 'directory', mustExist: false })` recorded the explicit `false` in the schema, but `validatePathChecks` errored on any missing path whenever path checks were active. Declaring an optional to-be-created path (an `--outdir` the command itself creates) was impossible:

```
Path '/…/dist' for flag --outdir does not exist
```

A missing path now passes when `mustExist` is `false`; an existing path is still type-checked.

### Feature: `create` for directory paths

`flag.path({ type: 'directory', create: true })` creates the directory recursively at resolution time when nothing exists. Only available with `type: 'directory'`, enforced at the type level (`create?: never` on the file/any variant). An existing non-directory path still fails the type check.

Creation runs through a new `mkdir` seam mirroring `stat`: `RuntimeAdapter.mkdir` (node: `fs.mkdir({ recursive: true })`, deno: `Deno.mkdir`), overridable via run options, noop in the test adapter, so `src/core` stays process-free.

## Verification

- `bunx tsc --noEmit` clean
- `run -s ci` green (tests + docs build with twoslash)
- `run -s smoke`, `run -s schema:emit`, version sync check green
- New resolve-level tests: missing-path pass, wrong-type reject, mkdir create, mkdir skip on existing, mkdir failure, no-mkdir fallback, type-level `create` constraint