### PR TITLE
ci: replace local dprint-warmup with kjanat/install-dprint@v2

### DIFF
--- a/.github/actions/dprint-warmup/action.yml
+++ b/.github/actions/dprint-warmup/action.yml
@@ -1,9 +1,0 @@
-name: dprint-warmup
-description: Cache dprint's plugin store and pre-resolve plugins with a hang-detecting retry. plugins.dprint.dev occasionally stalls mid-download, which otherwise hangs dprint tasks until the job timeout.
-runs: {
-  using: composite,
-  steps: [
-    { uses: actions/cache@v6, with: { path: ~/.cache/dprint, key: "dprint-${{ runner.os }}-${{ hashFiles('.dprint.jsonc') }}" } },
-    { shell: bash, run: "bash scripts/ci-retry-hang.sh 20 bunx dprint output-file-paths > /dev/null" },
-  ],
-}

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install
-      - uses: kjanat/install-dprint@cfa3ca1bbc43c86ffd42b17b72b8ca1f064de084 # v2.0.0
+      - uses: kjanat/install-dprint@v2
         with: { version: 0.55.2 }
       - run: run -s fmt:autofix lint:autofix
       # `dprint config update` queries every plugin registry and may download

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: ./.github/actions/setup
       - run: runner install
       - uses: kjanat/install-dprint@v2
-        with: { version: 0.55.2 }
       - run: run -s fmt:autofix lint:autofix
       # `dprint config update` queries every plugin registry and may download
       # and compile new plugin versions; 20s starves legitimate runs.

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install
-      - uses: ./.github/actions/dprint-warmup
+      - uses: kjanat/install-dprint@v2
+        with: { version: 0.55.2 }
       - run: run -s fmt:autofix lint:autofix
       # `dprint config update` queries every plugin registry and may download
       # and compile new plugin versions; 20s starves legitimate runs.

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install
-      - uses: kjanat/install-dprint@v2
+      - uses: kjanat/install-dprint@cfa3ca1bbc43c86ffd42b17b72b8ca1f064de084 # v2.0.0
         with: { version: 0.55.2 }
       - run: run -s fmt:autofix lint:autofix
       # `dprint config update` queries every plugin registry and may download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: ./.github/actions/setup
       - run: runner install --frozen schema:emit version:check
       - uses: kjanat/install-dprint@v2
-        with: { version: 0.55.2 }
       - run: run -pk typecheck meta-descriptions:check lint format:check typecheck:gh
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install --frozen schema:emit version:check
-      - uses: kjanat/install-dprint@v2
+      - uses: kjanat/install-dprint@cfa3ca1bbc43c86ffd42b17b72b8ca1f064de084 # v2.0.0
         with: { version: 0.55.2 }
       - run: run -pk typecheck meta-descriptions:check lint format:check typecheck:gh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install --frozen schema:emit version:check
-      - uses: ./.github/actions/dprint-warmup
+      - uses: kjanat/install-dprint@v2
+        with: { version: 0.55.2 }
       - run: run -pk typecheck meta-descriptions:check lint format:check typecheck:gh
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install --frozen schema:emit version:check
-      - uses: kjanat/install-dprint@cfa3ca1bbc43c86ffd42b17b72b8ca1f064de084 # v2.0.0
+      - uses: kjanat/install-dprint@v2
         with: { version: 0.55.2 }
       - run: run -pk typecheck meta-descriptions:check lint format:check typecheck:gh
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install --frozen
-      - uses: kjanat/install-dprint@cfa3ca1bbc43c86ffd42b17b72b8ca1f064de084 # v2.0.0
+      - uses: kjanat/install-dprint@v2
         with: { version: 0.55.2 }
       - run: run -s schema:emit version:check ci smoke
       - id: pack
@@ -79,6 +79,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - uses: kjanat/install-dprint@cfa3ca1bbc43c86ffd42b17b72b8ca1f064de084 # v2.0.0
+      - uses: kjanat/install-dprint@v2
         with: { version: 0.55.2 }
       - run: runner install -fK build jsr:publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install --frozen
-      - uses: ./.github/actions/dprint-warmup
+      - uses: kjanat/install-dprint@v2
+        with: { version: 0.55.2 }
       - run: run -s schema:emit version:check ci smoke
       - id: pack
         run: echo "tarball=$(bun pm pack --quiet --ignore-scripts | tr -d '[:space:]')" >> "${GITHUB_OUTPUT}"
@@ -78,4 +79,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
+      - uses: kjanat/install-dprint@v2
+        with: { version: 0.55.2 }
       - run: runner install -fK build jsr:publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install --frozen
-      - uses: kjanat/install-dprint@v2
+      - uses: kjanat/install-dprint@cfa3ca1bbc43c86ffd42b17b72b8ca1f064de084 # v2.0.0
         with: { version: 0.55.2 }
       - run: run -s schema:emit version:check ci smoke
       - id: pack
@@ -79,6 +79,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - uses: kjanat/install-dprint@v2
+      - uses: kjanat/install-dprint@cfa3ca1bbc43c86ffd42b17b72b8ca1f064de084 # v2.0.0
         with: { version: 0.55.2 }
       - run: runner install -fK build jsr:publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: ./.github/actions/setup
       - run: runner install --frozen
       - uses: kjanat/install-dprint@v2
-        with: { version: 0.55.2 }
       - run: run -s schema:emit version:check ci smoke
       - id: pack
         run: echo "tarball=$(bun pm pack --quiet --ignore-scripts | tr -d '[:space:]')" >> "${GITHUB_OUTPUT}"
@@ -80,5 +79,4 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - uses: kjanat/install-dprint@v2
-        with: { version: 0.55.2 }
       - run: runner install -fK build jsr:publish


### PR DESCRIPTION
## What

Swaps the local `.github/actions/dprint-warmup` composite for `kjanat/install-dprint@v2` (pinned `version: 0.55.2` to match the repo's devDep) in every dprint-touching job, and adds it to **Publish to JSR**, which previously had no warmup at all.

## Why

rc.18's JSR publish hung for 4+ minutes (run 29795960287, attempt 1): the `build` task's `onSuccess: dprint fmt package.json` ran on a cold runner and dprint stalled downloading its full plugin set. The checks job was protected by the local warmup; the JSR job was not.

The action supersedes the composite: binary layer cached per OS/arch/version, plugin cache keyed off all discovered dprint configs, warmup with 60s×3 hang-retry, always-save post step.

## Changes

- `ci.yml` static checks, `autofix.yml`, `publish.yml` checks: composite → action
- `publish.yml` Publish to JSR: action added before `runner install -fK build jsr:publish`
- `.github/actions/dprint-warmup` deleted (no remaining references)
- `autofix.yml` keeps the 90s `ci-retry-hang.sh` wrapper on `fmt:update` (fetches new plugin versions the warmed cache can't cover)

## Verification

- `actionlint` clean
- `grep -rn dprint-warmup .github/` empty after swap