### PR TITLE
feat(config): expand discovery across project, user, and system scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0-rc.19] - 2026-07-21
+
+### Added
+
+- **Expanded config discovery** (#61) — the default search now covers three
+  scopes, first match wins, no merging:
+  1. **Project**: the base directory (default `cwd`) and every ancestor up
+     to the filesystem root, nearest first, each probed for
+     `.{appName}.{ext}`, `{appName}.config.{ext}`, and the new
+     `.config/{appName}.{ext}` convention.
+  2. **User**: XDG / AppData as before, plus
+     `~/Library/Application Support/{appName}/config.{ext}` on macOS.
+  3. **System**: `/etc/{appName}/config.{ext}` on Linux and macOS.
+- **`baseDir` discovery option** — `discoverConfig()` accepts a base
+  directory to anchor the project-scope walk somewhere other than `cwd`.
+- **`RuntimeAdapter.userConfigDirs` / `systemConfigDirs`** — optional
+  ordered config roots supplied by the runtime adapters; discovery falls
+  back to `[configDir]` / `[]` when a custom adapter omits them.
+
+### Changed
+
+- **Breaking**: `buildConfigSearchPaths(appName, options)` replaces the
+  positional `(appName, cwd, configDir, loaders?)` signature; options carry
+  `baseDir`, `userConfigDirs`, `systemConfigDirs`, and `loaders`.
+
 ## [3.0.0-rc.18] - 2026-07-21
 
 ### Added

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.18",
+	"version": "3.0.0-rc.19",
 	"license": "MIT",
 	"tasks": {
 		"check": {

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -34,14 +34,27 @@ This searches standard locations for config files named `.mycli.json`, `mycli.co
 
 ### Search Paths
 
-Config discovery is platform-aware:
+Config discovery is platform-aware. The first match wins; files are never
+merged across locations.
 
-1. `--config <path>` or `--config=<path>` (explicit override)
-2. `./.mycli.json`, `./mycli.config.json` (project-local)
-3. Unix: `$XDG_CONFIG_HOME/mycli/config.json`
-4. Unix fallback: `~/.config/mycli/config.json`
-5. Windows: `%APPDATA%\\mycli\\config.json`
-6. Windows fallback: `%USERPROFILE%\\AppData\\Roaming\\mycli\\config.json`
+1. `--config <path>` or `--config=<path>` (explicit override, skips discovery)
+2. Project scope — for the working directory and each ancestor up to the
+   filesystem root, nearest first:
+   1. `.mycli.json`
+   2. `mycli.config.json`
+   3. `.config/mycli.json`
+3. User scope, in order:
+   - Unix: `$XDG_CONFIG_HOME/mycli/config.json`, falling back to
+     `~/.config/mycli/config.json`
+   - macOS: the Unix locations, then
+     `~/Library/Application Support/mycli/config.json`
+   - Windows: `%APPDATA%\\mycli\\config.json`, falling back to
+     `%USERPROFILE%\\AppData\\Roaming\\mycli\\config.json`
+4. System scope — `/etc/mycli/config.json` on Linux and macOS
+
+When calling `discoverConfig()` directly, `baseDir` anchors the project-scope
+walk to a directory other than `cwd` (useful for editor integrations operating
+on a specific file), and custom `searchPaths` replace the whole default list.
 
 ## Custom Formats
 

--- a/docs/reference/main.md
+++ b/docs/reference/main.md
@@ -471,19 +471,21 @@ Generate a shell completion script from a command schema.
 
 ## Config
 
-### `buildConfigSearchPaths(appName, cwd, configDir, loaders?)`
+### `buildConfigSearchPaths(appName, options)`
 
 Build the default search-path list dreamcli uses for config discovery. This is mainly useful for
-debugging, custom bootstrapping, or help text that wants to show the exact probed paths.
+debugging, custom bootstrapping, or help text that wants to show the exact probed paths. Options
+carry the scope directories: `baseDir` (project ancestor walk starts here), `userConfigDirs`,
+`systemConfigDirs`, and `loaders`.
 
 ```ts twoslash
 import { buildConfigSearchPaths } from '@kjanat/dreamcli';
 
-const paths = buildConfigSearchPaths(
-  'mycli',
-  process.cwd(),
-  '/home/me/.config',
-);
+const paths = buildConfigSearchPaths('mycli', {
+  baseDir: process.cwd(),
+  userConfigDirs: ['/home/me/.config'],
+  systemConfigDirs: ['/etc'],
+});
 ```
 
 ### `configFormat(extensions, parseFn)`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kjanat/dreamcli",
-	"version": "3.0.0-rc.18",
+	"version": "3.0.0-rc.19",
 	"description": "Schema-first, fully typed TypeScript CLI framework",
 	"keywords": [
 		"dreamcli",

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -791,12 +791,16 @@ class CLIBuilder {
 	/**
 	 * Enable automatic config file discovery.
 	 *
-	 * When enabled, `.run()` probes standard paths before dispatching:
-	 * 1. `$CWD/.{appName}.json`
-	 * 2. `$CWD/{appName}.config.json`
-	 * 3. `$CONFIG_DIR/{appName}/config.json`
-	 *    (`$XDG_CONFIG_HOME` / `~/.config` on Unix,
+	 * When enabled, `.run()` probes standard paths before dispatching,
+	 * first match wins, no merging:
+	 * 1. Project scope — for `$CWD` and each ancestor directory up to the
+	 *    filesystem root, nearest first:
+	 *    `.{appName}.json`, `{appName}.config.json`, `.config/{appName}.json`
+	 * 2. User scope — `{dir}/{appName}/config.json` for each user config
+	 *    root (`$XDG_CONFIG_HOME` / `~/.config` on Unix, plus
+	 *    `~/Library/Application Support` on macOS,
 	 *    `%APPDATA%` / `%USERPROFILE%\\AppData\\Roaming` on Windows)
+	 * 3. System scope — `/etc/{appName}/config.json` on Linux and macOS
 	 *
 	 * The user can override the path via `--config <path>` or `--config=<path>`.
 	 *

--- a/src/core/config/config.test.ts
+++ b/src/core/config/config.test.ts
@@ -16,6 +16,12 @@ function stubAdapter(
 		cwd: overrides?.cwd ?? '/project',
 		configDir: overrides?.configDir ?? '/home/alice/.config',
 		readFile: overrides?.readFile ?? (async (path: string) => files?.[path] ?? null),
+		...(overrides?.userConfigDirs !== undefined
+			? { userConfigDirs: overrides.userConfigDirs }
+			: {}),
+		...(overrides?.systemConfigDirs !== undefined
+			? { systemConfigDirs: overrides.systemConfigDirs }
+			: {}),
 	};
 }
 
@@ -38,35 +44,75 @@ const tomlLoader: FormatLoader = {
 // === buildConfigSearchPaths
 
 describe('buildConfigSearchPaths', () => {
-	it('returns 3 JSON paths in priority order', () => {
-		const paths = buildConfigSearchPaths('myapp', '/project', '/home/alice/.config');
+	it('walks ancestors then user then system scopes in priority order', () => {
+		const paths = buildConfigSearchPaths('myapp', {
+			baseDir: '/repo/pkg',
+			userConfigDirs: ['/home/alice/.config'],
+			systemConfigDirs: ['/etc'],
+		});
 		expect(paths).toEqual([
-			'/project/.myapp.json',
-			'/project/myapp.config.json',
+			'/repo/pkg/.myapp.json',
+			'/repo/pkg/myapp.config.json',
+			'/repo/pkg/.config/myapp.json',
+			'/repo/.myapp.json',
+			'/repo/myapp.config.json',
+			'/repo/.config/myapp.json',
+			'/.myapp.json',
+			'/myapp.config.json',
+			'/.config/myapp.json',
 			'/home/alice/.config/myapp/config.json',
+			'/etc/myapp/config.json',
 		]);
 	});
 
-	it('uses backslash when base paths contain backslash', () => {
-		const paths = buildConfigSearchPaths(
-			'myapp',
-			'C:\\Users\\alice\\project',
-			'C:\\Users\\alice\\AppData\\Roaming',
-		);
+	it('probes multiple user scopes in order', () => {
+		const paths = buildConfigSearchPaths('myapp', {
+			baseDir: '/p',
+			userConfigDirs: ['/home/alice/.config', '/home/alice/Library/Application Support'],
+		});
+		expect(paths.slice(-2)).toEqual([
+			'/home/alice/.config/myapp/config.json',
+			'/home/alice/Library/Application Support/myapp/config.json',
+		]);
+	});
+
+	it('uses backslash and stops at the drive root for backslash paths', () => {
+		const paths = buildConfigSearchPaths('myapp', {
+			baseDir: 'C:\\Users\\alice\\project',
+			userConfigDirs: ['C:\\Users\\alice\\AppData\\Roaming'],
+		});
 		expect(paths).toEqual([
 			'C:\\Users\\alice\\project\\.myapp.json',
 			'C:\\Users\\alice\\project\\myapp.config.json',
+			'C:\\Users\\alice\\project\\.config\\myapp.json',
+			'C:\\Users\\alice\\.myapp.json',
+			'C:\\Users\\alice\\myapp.config.json',
+			'C:\\Users\\alice\\.config\\myapp.json',
+			'C:\\Users\\.myapp.json',
+			'C:\\Users\\myapp.config.json',
+			'C:\\Users\\.config\\myapp.json',
+			'C:\\.myapp.json',
+			'C:\\myapp.config.json',
+			'C:\\.config\\myapp.json',
 			'C:\\Users\\alice\\AppData\\Roaming\\myapp\\config.json',
 		]);
 	});
 
 	it('includes additional extensions from loaders', () => {
-		const paths = buildConfigSearchPaths('myapp', '/project', '/home/.config', [tomlLoader]);
-		expect(paths).toEqual([
+		const paths = buildConfigSearchPaths('myapp', {
+			baseDir: '/project',
+			userConfigDirs: ['/home/.config'],
+			loaders: [tomlLoader],
+		});
+		expect(paths.slice(0, 6)).toEqual([
 			'/project/.myapp.json',
 			'/project/.myapp.toml',
 			'/project/myapp.config.json',
 			'/project/myapp.config.toml',
+			'/project/.config/myapp.json',
+			'/project/.config/myapp.toml',
+		]);
+		expect(paths.slice(-2)).toEqual([
 			'/home/.config/myapp/config.json',
 			'/home/.config/myapp/config.toml',
 		]);
@@ -77,8 +123,20 @@ describe('buildConfigSearchPaths', () => {
 			extensions: ['json'],
 			parse: JSON.parse as (content: string) => Record<string, unknown>,
 		};
-		const paths = buildConfigSearchPaths('myapp', '/p', '/c', [extraJsonLoader]);
-		expect(paths).toEqual(['/p/.myapp.json', '/p/myapp.config.json', '/c/myapp/config.json']);
+		const paths = buildConfigSearchPaths('myapp', {
+			baseDir: '/p',
+			userConfigDirs: ['/c'],
+			loaders: [extraJsonLoader],
+		});
+		expect(paths).toEqual([
+			'/p/.myapp.json',
+			'/p/myapp.config.json',
+			'/p/.config/myapp.json',
+			'/.myapp.json',
+			'/myapp.config.json',
+			'/.config/myapp.json',
+			'/c/myapp/config.json',
+		]);
 	});
 });
 
@@ -92,6 +150,93 @@ describe('discoverConfig', () => {
 			const adapter = stubAdapter();
 			const result = await discoverConfig('myapp', adapter);
 			expect(result).toEqual({ found: false });
+		});
+
+		it('finds a config in an ancestor directory', async () => {
+			const adapter = stubAdapter(
+				{ '/repo/.myapp.json': '{"source":"ancestor"}' },
+				{ cwd: '/repo/packages/app' },
+			);
+			const result = await discoverConfig('myapp', adapter);
+			expect(result.found).toBe(true);
+			if (result.found) {
+				expect(result.path).toBe('/repo/.myapp.json');
+				expect(result.data).toEqual({ source: 'ancestor' });
+			}
+		});
+
+		it('prefers the nearest directory over an ancestor', async () => {
+			const adapter = stubAdapter(
+				{
+					'/repo/.myapp.json': '{"source":"root"}',
+					'/repo/packages/app/.config/myapp.json': '{"source":"leaf"}',
+				},
+				{ cwd: '/repo/packages/app' },
+			);
+			const result = await discoverConfig('myapp', adapter);
+			expect(result.found).toBe(true);
+			if (result.found) {
+				expect(result.path).toBe('/repo/packages/app/.config/myapp.json');
+			}
+		});
+
+		it('finds a project .config/ candidate', async () => {
+			const adapter = stubAdapter({ '/project/.config/myapp.json': '{"scope":"dot-config"}' });
+			const result = await discoverConfig('myapp', adapter);
+			expect(result.found).toBe(true);
+			if (result.found) {
+				expect(result.path).toBe('/project/.config/myapp.json');
+			}
+		});
+
+		it('anchors the ancestor walk to baseDir instead of cwd', async () => {
+			const adapter = stubAdapter({ '/elsewhere/.myapp.json': '{"anchor":"base"}' });
+			const result = await discoverConfig('myapp', adapter, { baseDir: '/elsewhere/deep' });
+			expect(result.found).toBe(true);
+			if (result.found) {
+				expect(result.path).toBe('/elsewhere/.myapp.json');
+			}
+		});
+
+		it('probes secondary user config dirs after the primary', async () => {
+			const adapter = stubAdapter(
+				{ '/home/alice/Library/Application Support/myapp/config.json': '{"scope":"mac"}' },
+				{
+					userConfigDirs: ['/home/alice/.config', '/home/alice/Library/Application Support'],
+				},
+			);
+			const result = await discoverConfig('myapp', adapter);
+			expect(result.found).toBe(true);
+			if (result.found) {
+				expect(result.path).toBe('/home/alice/Library/Application Support/myapp/config.json');
+			}
+		});
+
+		it('falls back to a system config dir after user scopes', async () => {
+			const adapter = stubAdapter(
+				{ '/etc/myapp/config.json': '{"scope":"system"}' },
+				{ systemConfigDirs: ['/etc'] },
+			);
+			const result = await discoverConfig('myapp', adapter);
+			expect(result.found).toBe(true);
+			if (result.found) {
+				expect(result.path).toBe('/etc/myapp/config.json');
+			}
+		});
+
+		it('prefers a user config over a system config', async () => {
+			const adapter = stubAdapter(
+				{
+					'/home/alice/.config/myapp/config.json': '{"scope":"user"}',
+					'/etc/myapp/config.json': '{"scope":"system"}',
+				},
+				{ systemConfigDirs: ['/etc'] },
+			);
+			const result = await discoverConfig('myapp', adapter);
+			expect(result.found).toBe(true);
+			if (result.found) {
+				expect(result.path).toBe('/home/alice/.config/myapp/config.json');
+			}
 		});
 
 		it('finds dotfile in cwd first', async () => {
@@ -644,7 +789,11 @@ describe('configFormat — convenience factory', () => {
 
 	it('created loader appears in search paths', () => {
 		const loader = configFormat(['toml', 'tml'], () => ({}));
-		const paths = buildConfigSearchPaths('myapp', '/p', '/c', [loader]);
+		const paths = buildConfigSearchPaths('myapp', {
+			baseDir: '/p',
+			userConfigDirs: ['/c'],
+			loaders: [loader],
+		});
 		expect(paths).toContain('/p/.myapp.toml');
 		expect(paths).toContain('/p/.myapp.tml');
 		expect(paths).toContain('/p/myapp.config.toml');

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -71,6 +71,15 @@ interface ConfigDiscoveryOptions {
 	 * Probed in order; first found wins.
 	 */
 	readonly searchPaths?: readonly string[];
+
+	/**
+	 * Directory the project-scope ancestor walk starts from.
+	 * Anchors discovery to a location other than the process working
+	 * directory (e.g. the directory of a file an editor integration is
+	 * operating on).
+	 * @defaultValue `adapter.cwd`
+	 */
+	readonly baseDir?: string;
 }
 
 /** Successful config discovery — file found and parsed. */
@@ -121,7 +130,35 @@ const jsonLoader: FormatLoader = {
  */
 function joinPath(base: string, ...segments: readonly string[]): string {
 	const sep = base.includes('\\') ? '\\' : '/';
-	return [base, ...segments].join(sep);
+	const trimmed = base.endsWith(sep) ? base.slice(0, -1) : base;
+	return [trimmed, ...segments].join(sep);
+}
+
+/**
+ * List a directory and every ancestor up to the filesystem root,
+ * nearest first. Separator is inferred from the input; POSIX (`/`) and
+ * Windows drive roots (`C:\`) both terminate the walk.
+ *
+ * @internal
+ */
+function ancestorDirs(base: string): readonly string[] {
+	const sep = base.includes('\\') ? '\\' : '/';
+	let current = base;
+	while (current.length > 1 && current.endsWith(sep) && !current.endsWith(`:${sep}`)) {
+		current = current.slice(0, -1);
+	}
+	const dirs: string[] = [current];
+	while (true) {
+		const idx = current.lastIndexOf(sep);
+		if (idx < 0) break;
+		let parent = current.slice(0, idx);
+		if (parent === '') parent = sep;
+		else if (/^[A-Za-z]:$/.test(parent)) parent = `${parent}${sep}`;
+		if (parent === current) break;
+		dirs.push(parent);
+		current = parent;
+	}
+	return dirs;
 }
 
 /**
@@ -139,6 +176,24 @@ function getExtension(path: string): string {
 
 // --- buildConfigSearchPaths
 
+/** Directory scopes feeding {@link buildConfigSearchPaths}. */
+interface ConfigSearchPathOptions {
+	/** Directory the project-scope ancestor walk starts from. */
+	readonly baseDir: string;
+	/**
+	 * User-scope config roots, highest priority first
+	 * (XDG / AppData, plus `~/Library/Application Support` on macOS).
+	 */
+	readonly userConfigDirs: readonly string[];
+	/**
+	 * System-scope config roots (`/etc` on Linux and macOS).
+	 * @defaultValue `[]`
+	 */
+	readonly systemConfigDirs?: readonly string[];
+	/** Custom {@link FormatLoader}s whose extensions expand the search set. */
+	readonly loaders?: readonly FormatLoader[];
+}
+
 /**
  * Build the default config search paths for an app.
  *
@@ -147,43 +202,59 @@ function getExtension(path: string): string {
  * manually. Exported for debugging, custom discovery flows, and help text.
  *
  * Search order (first match wins):
- * 1. `$CWD/.{appName}.json` — dotfile in project root
- * 2. `$CWD/{appName}.config.json` — explicit config in project root
- * 3. `$CONFIG_DIR/{appName}/config.json` — XDG / AppData standard
- *    (`$XDG_CONFIG_HOME` / `~/.config` on Unix,
- *    `%APPDATA%` / `%USERPROFILE%\\AppData\\Roaming` on Windows)
+ * 1. Project scope — for `baseDir` and each ancestor directory up to the
+ *    filesystem root, nearest first:
+ *    1. `{dir}/.{appName}.json` — dotfile
+ *    2. `{dir}/{appName}.config.json` — explicit config
+ *    3. `{dir}/.config/{appName}.json` — project `.config/` convention
+ * 2. User scope — `{userConfigDir}/{appName}/config.json` for each entry of
+ *    `userConfigDirs`, in order.
+ * 3. System scope — `{systemConfigDir}/{appName}/config.json` for each entry
+ *    of `systemConfigDirs`, in order.
  *
  * When custom {@link ConfigDiscoveryOptions.loaders | loaders} are registered,
  * each path pattern is repeated per supported extension (JSON always first).
  *
  * @param appName - CLI application name used to derive config filenames.
- * @param cwd - Current working directory (project-root search location).
- * @param configDir - Platform config directory (XDG / AppData).
- * @param loaders - Optional custom {@link FormatLoader}s whose extensions expand the search set.
+ * @param options - Directory scopes and loaders (see {@link ConfigSearchPathOptions}).
  * @returns Ordered list of candidate config file paths (first match wins).
  *
  * @example
  * ```ts
- * const paths = buildConfigSearchPaths('mycli', '/repo', '/home/me/.config');
+ * const paths = buildConfigSearchPaths('mycli', {
+ *   baseDir: '/repo/packages/app',
+ *   userConfigDirs: ['/home/me/.config'],
+ *   systemConfigDirs: ['/etc'],
+ * });
  * ```
  */
 function buildConfigSearchPaths(
 	appName: string,
-	cwd: string,
-	configDir: string,
-	loaders?: readonly FormatLoader[],
+	options: ConfigSearchPathOptions,
 ): readonly string[] {
-	const extensions = buildExtensionList(loaders);
+	const extensions = buildExtensionList(options.loaders);
 
 	const paths: string[] = [];
-	for (const ext of extensions) {
-		paths.push(joinPath(cwd, `.${appName}.${ext}`));
+	for (const dir of ancestorDirs(options.baseDir)) {
+		for (const ext of extensions) {
+			paths.push(joinPath(dir, `.${appName}.${ext}`));
+		}
+		for (const ext of extensions) {
+			paths.push(joinPath(dir, `${appName}.config.${ext}`));
+		}
+		for (const ext of extensions) {
+			paths.push(joinPath(dir, '.config', `${appName}.${ext}`));
+		}
 	}
-	for (const ext of extensions) {
-		paths.push(joinPath(cwd, `${appName}.config.${ext}`));
+	for (const dir of options.userConfigDirs) {
+		for (const ext of extensions) {
+			paths.push(joinPath(dir, appName, `config.${ext}`));
+		}
 	}
-	for (const ext of extensions) {
-		paths.push(joinPath(configDir, appName, `config.${ext}`));
+	for (const dir of options.systemConfigDirs ?? []) {
+		for (const ext of extensions) {
+			paths.push(joinPath(dir, appName, `config.${ext}`));
+		}
 	}
 	return paths;
 }
@@ -260,7 +331,8 @@ function buildLoaderMap(loaders?: readonly FormatLoader[]): ReadonlyMap<string, 
  * Exported so custom hosts and tests can type the minimal adapter required by
  * {@link discoverConfig} without depending on the full runtime adapter shape.
  */
-type ConfigAdapter = Pick<RuntimeAdapter, 'readFile' | 'cwd' | 'configDir'>;
+type ConfigAdapter = Pick<RuntimeAdapter, 'readFile' | 'cwd' | 'configDir'> &
+	Partial<Pick<RuntimeAdapter, 'userConfigDirs' | 'systemConfigDirs'>>;
 
 /**
  * Discover and load a config file.
@@ -298,7 +370,12 @@ async function discoverConfig(
 		options?.configPath !== undefined
 			? [options.configPath]
 			: (options?.searchPaths ??
-				buildConfigSearchPaths(appName, adapter.cwd, adapter.configDir, options?.loaders));
+				buildConfigSearchPaths(appName, {
+					baseDir: options?.baseDir ?? adapter.cwd,
+					userConfigDirs: adapter.userConfigDirs ?? [adapter.configDir],
+					systemConfigDirs: adapter.systemConfigDirs ?? [],
+					...(options?.loaders !== undefined ? { loaders: options.loaders } : {}),
+				}));
 
 	for (const candidatePath of searchPaths) {
 		const content = await adapter.readFile(candidatePath);
@@ -413,6 +490,7 @@ export type {
 	ConfigDiscoveryResult,
 	ConfigFound,
 	ConfigNotFound,
+	ConfigSearchPathOptions,
 	FormatLoader,
 };
 export { buildConfigSearchPaths, configFormat, discoverConfig };

--- a/src/runtime/adapter.ts
+++ b/src/runtime/adapter.ts
@@ -146,6 +146,23 @@ interface RuntimeAdapter {
 	 * Config discovery appends the app-specific subdirectory.
 	 */
 	readonly configDir: string;
+
+	/**
+	 * User-scope config roots for discovery, highest priority first.
+	 *
+	 * - Unix: `[configDir]`
+	 * - macOS: `[configDir, ~/Library/Application Support]`
+	 * - Windows: `[configDir]`
+	 *
+	 * When absent, discovery falls back to `[configDir]`.
+	 */
+	readonly userConfigDirs?: readonly string[];
+
+	/**
+	 * System-scope config roots for discovery (`['/etc']` on Linux and
+	 * macOS, `[]` on Windows). When absent, discovery probes none.
+	 */
+	readonly systemConfigDirs?: readonly string[];
 }
 
 /** Current terminal dimensions in columns and rows. */
@@ -264,6 +281,12 @@ interface TestAdapterOptions {
 
 	/** Config directory (defaults to `'/home/test/.config'`). */
 	readonly configDir?: string;
+
+	/** User-scope config roots for discovery (defaults to `[configDir]`). */
+	readonly userConfigDirs?: readonly string[];
+
+	/** System-scope config roots for discovery (defaults to `[]`). */
+	readonly systemConfigDirs?: readonly string[];
 }
 
 /**
@@ -364,6 +387,8 @@ function createTestAdapter(options?: TestAdapterOptions): RuntimeAdapter {
 		mkdir: options?.mkdir ?? noopMkdir,
 		homedir: options?.homedir ?? '/home/test',
 		configDir: options?.configDir ?? '/home/test/.config',
+		userConfigDirs: options?.userConfigDirs ?? [options?.configDir ?? '/home/test/.config'],
+		systemConfigDirs: options?.systemConfigDirs ?? [],
 	};
 }
 

--- a/src/runtime/deno.ts
+++ b/src/runtime/deno.ts
@@ -260,6 +260,9 @@ function createDenoAdapter(ns?: DenoNamespace): RuntimeAdapter {
 		mkdir: (path) => d.mkdir(path, { recursive: true }),
 		homedir,
 		configDir,
+		userConfigDirs:
+			d.build.os === 'darwin' ? [configDir, `${homedir}/Library/Application Support`] : [configDir],
+		systemConfigDirs: d.build.os === 'windows' ? [] : ['/etc'],
 	};
 }
 

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -220,6 +220,9 @@ function createNodeAdapter(proc?: NodeProcess): RuntimeAdapter {
 
 	const homedir = resolveHomedir(p.env, p.platform);
 	const configDir = resolveConfigDir(p.env, p.platform, homedir);
+	const userConfigDirs =
+		p.platform === 'darwin' ? [configDir, `${homedir}/Library/Application Support`] : [configDir];
+	const systemConfigDirs = p.platform === 'win32' ? [] : ['/etc'];
 
 	const stdinIsTTY = p.stdin.isTTY === true;
 
@@ -241,6 +244,8 @@ function createNodeAdapter(proc?: NodeProcess): RuntimeAdapter {
 		mkdir,
 		homedir,
 		configDir,
+		userConfigDirs,
+		systemConfigDirs,
 	};
 }
 


### PR DESCRIPTION
Closes #61. Bumps to 3.0.0-rc.19.

## What

Default config discovery now covers three scopes, first match wins, no merging:

1. **Project** — the base directory (default `cwd`) and every ancestor up to the filesystem root, nearest first, each probed for `.{app}.{ext}`, `{app}.config.{ext}`, and the new `.config/{app}.{ext}` convention. POSIX and Windows drive roots both terminate the walk.
2. **User** — XDG / AppData as before, plus `~/Library/Application Support/{app}/config.{ext}` on macOS.
3. **System** — `/etc/{app}/config.{ext}` on Linux and macOS.

`discoverConfig()` gains `baseDir` so editor-style integrations can anchor the walk to a file's directory. Explicit `--config`, custom `searchPaths`, custom loaders, parse errors, and first-match semantics keep their existing guarantees (covered by the untouched test suite).

## How

- Scope roots come from the adapters: optional `RuntimeAdapter.userConfigDirs` / `systemConfigDirs` (Node/Bun and Deno provide platform values; discovery falls back to `[configDir]` / `[]` for custom adapters, so none break).
- `src/core` stays runtime-agnostic: the ancestor walk is pure string work with separator inference, all I/O still flows through `adapter.readFile`.
- **Breaking**: `buildConfigSearchPaths(appName, options)` replaces the positional signature.

## Acceptance criteria from #61

- [x] Exact search order specified (builder TSDoc, `buildConfigSearchPaths` TSDoc, docs) and covered by tests
- [x] Ancestor walk from a caller-selectable base directory
- [x] `.config/{appName}.{ext}` at each project level
- [x] XDG / macOS / Windows user-directory behavior covered
- [x] Linux system fallback documented and tested
- [x] Existing guarantees retained
- [x] Node, Bun, Deno adapters consistent
- [x] Docs list every default candidate and its precedence

The embedded-section/source-hook question from the issue is split out as future follow-up per the issue's own suggestion; #67 (executable configs) covers the loader side separately.

## Verification

- `run -s ci` green (tests, docs build with twoslash against rebuilt dist)
- `run -s smoke`, `run -s schema:emit`, version sync green
- 48 config tests including: ancestor pickup, nearest-first, `.config/` candidate, `baseDir` anchor, secondary user dir (mac), `/etc` fallback, user-beats-system, drive-root termination