### PR TITLE
fix(output): suppress spinner/progress under quiet, expose resolved verbosity

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,5 +7,6 @@ runs: {
     uses: denoland/setup-deno@v2,
     { uses: oven-sh/setup-bun@v2, with: { bun-version: latest } },
     { uses: actions/setup-node@v7, with: { node-version: latest } },
+    uses: kjanat/install-dprint@v2,
   ],
 }

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -8,6 +8,7 @@ permissions: { contents: read }
 concurrency: { group: "autofix-${{ github.ref }}", cancel-in-progress: true }
 jobs:
   autofix:
+    if: github.event_name != 'pull_request' || github.event.pull_request.stack == null
     runs-on: ubuntu-latest
     timeout-minutes: 8
     env: { RUNNER_PM: bun }

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install
-      - uses: kjanat/install-dprint@v2
       - run: run -s fmt:autofix lint:autofix
       # `dprint config update` queries every plugin registry and may download
       # and compile new plugin versions; 20s starves legitimate runs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install --frozen schema:emit docs:build
-      - run: git diff --exit-code && test -z "$(git status --porcelain --untracked-files=all)"
+      - run: git diff --exit-code; status="$(git status --porcelain --untracked-files=all)"; test -z "${status}"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install --frozen schema:emit version:check
-      - uses: kjanat/install-dprint@v2
       - run: run -pk typecheck meta-descriptions:check lint format:check typecheck:gh
 
   test:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: runner install --frozen
-      - uses: kjanat/install-dprint@v2
       - run: run -s schema:emit version:check ci smoke
       - id: pack
         run: echo "tarball=$(bun pm pack --quiet --ignore-scripts | tr -d '[:space:]')" >> "${GITHUB_OUTPUT}"
@@ -78,7 +77,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - uses: kjanat/install-dprint@v2
       - run: runner install -fK build jsr:publish
 
   deploy-site:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - run: runner install --frozen
       - run: run -s schema:emit version:check ci smoke
       - id: pack
-        run: echo "tarball=$(bun pm pack --quiet --ignore-scripts | tr -d '[:space:]')" >> "${GITHUB_OUTPUT}"
+        run: tarball="$(bun pm pack --quiet --ignore-scripts)"; echo "tarball=${tarball}" >> "${GITHUB_OUTPUT}"
       - uses: actions/upload-artifact@v7
         with: { name: tarball, path: "${{ steps.pack.outputs.tarball }}", retention-days: 1 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Public output verbosity state** — action handlers can read `out.verbosity`,
+  while `resolveRenderContext()` now exposes the same `verbosity` decision for
+  custom content built before `.run()` (including `--`-aware `--quiet`/`-q`
+  detection). `verbosity` is a required member of `Out`, so a hand-rolled
+  `Out` object literal stops compiling until it declares one. Hand-rolling
+  `Out` is unsupported; take a real channel from the testkit and spy on it
+  instead:
+
+  ```ts
+  const [out] = createCaptureOutput();
+  vi.spyOn(out, 'info');
+  ```
+
+  Do not spread a channel (`{ ...out, info: vi.fn() }`) — its methods are
+  non-enumerable bound copies, so the spread result has none of them.
+
+### Fixed
+
+- **Quiet mode leaked spinner and progress output** — activity handles now
+  resolve to no-ops under quiet verbosity, including interactive TTYs and
+  explicit static fallbacks. Consumers can route informational rows through
+  `out.info()` and rely on DreamCLI to suppress the complete presentation
+  layer without reading private output policy state.
+
 ## [3.0.1] - 2026-07-21
 
 No library code changed; this release ships agent-facing material that was

--- a/docs/.vitepress/theme/twoslash-mobile.css
+++ b/docs/.vitepress/theme/twoslash-mobile.css
@@ -60,6 +60,14 @@
 		box-shadow: none !important;
 	}
 
+	/* Backdrop overlay when bottom sheet is open */
+	.twoslash-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.3);
+		z-index: 9998;
+	}
+
 	/*
 	 * 4. Hidden state must hide the sheet and backdrop completely.
 	 *    A dismissed popper that keeps its inner visible leaves a stuck
@@ -84,14 +92,6 @@
 		max-height: none;
 		padding: 8px !important;
 		font-size: 0.8em;
-	}
-
-	/* Backdrop overlay when bottom sheet is open */
-	.twoslash-backdrop {
-		position: fixed;
-		inset: 0;
-		background: rgba(0, 0, 0, 0.3);
-		z-index: 9998;
 	}
 }
 
@@ -159,6 +159,14 @@
 		box-shadow: none !important;
 	}
 
+	/* Backdrop overlay when bottom sheet is open */
+	html.twoslash-touch .twoslash-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.3);
+		z-index: 9998;
+	}
+
 	/*
 	 * 4. Hidden state must hide the sheet and backdrop completely.
 	 *    A dismissed popper that keeps its inner visible leaves a stuck
@@ -183,14 +191,6 @@
 		max-height: none;
 		padding: 8px !important;
 		font-size: 0.8em;
-	}
-
-	/* Backdrop overlay when bottom sheet is open */
-	html.twoslash-touch .twoslash-backdrop {
-		position: fixed;
-		inset: 0;
-		background: rgba(0, 0, 0, 0.3);
-		z-index: 9998;
 	}
 }
 

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -60,7 +60,8 @@ command('gen').action(({ out }) => {
 ```
 
 Every CLI accepts a global `--quiet`/`-q` flag that sets quiet verbosity,
-suppressing `info` and `status` while `log`, `warn`, and `error` still emit.
+suppressing `info`, `status`, spinners, and progress bars while `log`, `warn`,
+and `error` still emit.
 Like `--json`, it is a root-level flag: it is stripped before dispatch (so
 command schemas never see it) and only counts before the `--` separator; a
 literal `-q` after `--` reaches the command as a positional.
@@ -110,7 +111,7 @@ spinner.succeed('Done');
 ```
 
 Spinners auto-disable when stdout is not a TTY (CI, piped output).
-In `--json` mode, spinners are suppressed entirely.
+In quiet and `--json` modes, spinners are suppressed entirely.
 
 ## Progress Bars
 
@@ -141,6 +142,7 @@ The output channel automatically adjusts behavior:
 | -------- | ---------------------------------------------------- |
 | TTY      | Pretty formatting, spinners animate, colors          |
 | Piped    | Minimal stable output, spinners suppressed           |
+| `--quiet` | Informational text and activity suppressed           |
 | `--json` | Structured JSON to stdout, everything else to stderr |
 
 One code path, correct output everywhere.
@@ -148,7 +150,7 @@ One code path, correct output everywhere.
 ## Pre-run Render Context
 
 Inside a handler, `out` answers every rendering question: `out.jsonMode`,
-`out.isTTY`, `out.color`, `out.isHyperlinkSupported`. Content built **before**
+`out.verbosity`, `out.isTTY`, `out.color`, `out.isHyperlinkSupported`. Content built **before**
 `run()` — a banner, hand-rendered help — has no `out`, and re-deriving the
 answers from raw argv goes wrong (`argv.includes('--json')` misreads a
 post-`--` literal like `mycli -- --json`).
@@ -167,7 +169,7 @@ const ctx = resolveRenderContext(process.argv.slice(2), {
 // Identity formatters when color is off — style unconditionally
 const banner = ctx.color.bold('mycli');
 // `ctx.jsonMode` used pre-separator-aware --json detection
-if (!ctx.jsonMode) console.error(banner);
+if (!ctx.jsonMode && ctx.verbosity !== 'quiet') console.error(banner);
 ```
 
 The returned `color` is the same gated palette the channel will expose as

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -142,7 +142,7 @@ The output channel automatically adjusts behavior:
 | -------- | ---------------------------------------------------- |
 | TTY      | Pretty formatting, spinners animate, colors          |
 | Piped    | Minimal stable output, spinners suppressed           |
-| `--quiet` | Informational text and activity suppressed           |
+| `--quiet` | `info()`, `status()`, and rendered spinner/progress activity suppressed; `log()` remains enabled |
 | `--json` | Structured JSON to stdout, everything else to stderr |
 
 One code path, correct output everywhere.

--- a/docs/reference/output-contract.md
+++ b/docs/reference/output-contract.md
@@ -35,7 +35,7 @@ The intent is simple:
 
 - `jsonMode` reserves stdout for `json()` and JSON-form table output
 - `isTTY` enables decorative activity rendering only when JSON mode is off
-- `verbosity` suppresses informational text and activity, not warnings, errors, or structured output
+- `verbosity` suppresses `info()`, `status()`, and rendered spinner/progress activity; `log()` remains enabled
 
 ## Activity Policy
 

--- a/docs/reference/output-contract.md
+++ b/docs/reference/output-contract.md
@@ -35,7 +35,7 @@ The intent is simple:
 
 - `jsonMode` reserves stdout for `json()` and JSON-form table output
 - `isTTY` enables decorative activity rendering only when JSON mode is off
-- `verbosity` affects informational text, not warnings, errors, or structured output
+- `verbosity` suppresses informational text and activity, not warnings, errors, or structured output
 
 ## Activity Policy
 
@@ -66,7 +66,8 @@ Current cleanup facts:
 The frozen facts in `outputContract` are:
 
 - JSON mode reserves stdout for structured data
-- quiet mode suppresses `info()` only
+- quiet mode suppresses `info()`, `status()`, and rendered spinner/progress activity
+- capture records logical activity lifecycle events regardless of verbosity; quiet governs rendered bytes
 - non-capture activity uses stderr
 - TTY activity requires both `isTTY` and `!jsonMode`
 - spinner and progress cleanup semantics are explicit and distinct

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -505,6 +505,13 @@ interface RenderContextOptions {
 	 */
 	readonly jsonMode?: boolean;
 	/**
+	 * Output verbosity override when argv does not contain root `--quiet`/`-q`.
+	 *
+	 * @defaultValue detected from a pre-separator `--quiet`/`-q` in `argv`,
+	 *   otherwise `'normal'`
+	 */
+	readonly verbosity?: Verbosity;
+	/**
 	 * Explicitly enable or disable colors, winning over the auto-gate.
 	 *
 	 * @defaultValue auto — `isTTY && !jsonMode` and environment support
@@ -526,6 +533,8 @@ interface RenderContextOptions {
 interface RenderContext {
 	/** Whether a pre-separator `--json` puts the run in JSON mode. */
 	readonly jsonMode: boolean;
+	/** Active verbosity after pre-separator `--quiet`/`-q` detection. */
+	readonly verbosity: Verbosity;
 	/** The TTY status the output channel will carry. */
 	readonly isTTY: boolean;
 	/**
@@ -568,14 +577,19 @@ function resolveRenderContext(
 	options?: RenderContextOptions,
 ): RenderContext {
 	const jsonMode = includesBeforeSeparator(argv, '--json') || options?.jsonMode === true;
+	const hasQuietFlag =
+		includesBeforeSeparator(argv, '--quiet') || includesBeforeSeparator(argv, '-q');
+	const verbosity = hasQuietFlag ? 'quiet' : (options?.verbosity ?? 'normal');
 	const out = createOutput({
 		jsonMode,
 		isTTY: options?.isTTY ?? false,
+		verbosity,
 		...(options?.color !== undefined ? { color: options.color } : {}),
 		...hyperlinksOption(resolveHyperlinkOverride(options?.env ?? {}, argv)),
 	});
 	return {
 		jsonMode: out.jsonMode,
+		verbosity: out.verbosity,
 		isTTY: out.isTTY,
 		color: out.color,
 		isHyperlinkSupported: out.isHyperlinkSupported,

--- a/src/core/cli/render-context.test.ts
+++ b/src/core/cli/render-context.test.ts
@@ -22,6 +22,27 @@ describe('resolveRenderContext — jsonMode', () => {
 	});
 });
 
+// === Verbosity detection
+
+describe('resolveRenderContext — verbosity', () => {
+	it('defaults to normal verbosity', () => {
+		expect(resolveRenderContext([]).verbosity).toBe('normal');
+	});
+
+	it('detects pre-separator --quiet and -q', () => {
+		expect(resolveRenderContext(['deploy', '--quiet']).verbosity).toBe('quiet');
+		expect(resolveRenderContext(['-q', 'deploy']).verbosity).toBe('quiet');
+	});
+
+	it('ignores a post-separator --quiet literal', () => {
+		expect(resolveRenderContext(['deploy', '--', '--quiet']).verbosity).toBe('normal');
+	});
+
+	it('honors an explicit verbosity override when argv is not quiet', () => {
+		expect(resolveRenderContext([], { verbosity: 'quiet' }).verbosity).toBe('quiet');
+	});
+});
+
 // === TTY and color gate
 
 describe('resolveRenderContext — color', () => {

--- a/src/core/cli/render-context.test.ts
+++ b/src/core/cli/render-context.test.ts
@@ -41,6 +41,10 @@ describe('resolveRenderContext — verbosity', () => {
 	it('honors an explicit verbosity override when argv is not quiet', () => {
 		expect(resolveRenderContext([], { verbosity: 'quiet' }).verbosity).toBe('quiet');
 	});
+
+	it('lets a pre-separator quiet flag override explicit normal verbosity', () => {
+		expect(resolveRenderContext(['--quiet'], { verbosity: 'normal' }).verbosity).toBe('quiet');
+	});
 });
 
 // === TTY and color gate

--- a/src/core/output/contracts.test.ts
+++ b/src/core/output/contracts.test.ts
@@ -100,6 +100,20 @@ describe('output contracts', () => {
 			});
 		});
 
+		it('suppresses static fallback activity in quiet mode without a TTY', () => {
+			const quietPolicy = { ...basePolicy, verbosity: 'quiet' as const };
+			expect(resolveSpinnerPolicy(quietPolicy, 'static')).toEqual({
+				mode: 'noop',
+				stream: 'stderr',
+				cleanup: 'none',
+			});
+			expect(resolveProgressPolicy(quietPolicy, 'static')).toEqual({
+				mode: 'noop',
+				stream: 'stderr',
+				cleanup: 'none',
+			});
+		});
+
 		it('uses done cleanup for progress handles', () => {
 			expect(resolveProgressPolicy({ ...basePolicy, isTTY: true }, 'silent')).toEqual({
 				mode: 'tty',

--- a/src/core/output/contracts.test.ts
+++ b/src/core/output/contracts.test.ts
@@ -121,7 +121,7 @@ describe('output contracts', () => {
 		});
 
 		it('activity policy remains renderer-agnostic metadata', () => {
-			expectTypeOf<ActivityPolicy>().toMatchTypeOf<{
+			expectTypeOf<ActivityPolicy>().toExtend<{
 				readonly mode: 'noop' | 'static' | 'tty';
 				readonly stream: 'stderr';
 				readonly cleanup: 'none' | 'stop' | 'done';

--- a/src/core/output/contracts.test.ts
+++ b/src/core/output/contracts.test.ts
@@ -86,6 +86,20 @@ describe('output contracts', () => {
 			});
 		});
 
+		it('suppresses all spinner and progress activity in quiet mode', () => {
+			const quietPolicy = { ...basePolicy, isTTY: true, verbosity: 'quiet' as const };
+			expect(resolveSpinnerPolicy(quietPolicy, 'static')).toEqual({
+				mode: 'noop',
+				stream: 'stderr',
+				cleanup: 'none',
+			});
+			expect(resolveProgressPolicy(quietPolicy, 'static')).toEqual({
+				mode: 'noop',
+				stream: 'stderr',
+				cleanup: 'none',
+			});
+		});
+
 		it('uses done cleanup for progress handles', () => {
 			expect(resolveProgressPolicy({ ...basePolicy, isTTY: true }, 'silent')).toEqual({
 				mode: 'tty',
@@ -118,6 +132,7 @@ describe('output contracts', () => {
 			expect(outputContract).toEqual({
 				jsonReservesStdoutForStructuredData: true,
 				quietSuppressesInfo: true,
+				quietSuppressesRenderedActivity: true,
 				activityUsesStderrOutsideCapture: true,
 				ttyActivityRequiresTTYAndNonJson: true,
 				spinnerCleanupUsesStop: true,

--- a/src/core/output/contracts.ts
+++ b/src/core/output/contracts.ts
@@ -70,6 +70,8 @@ interface OutputContract {
 	readonly jsonReservesStdoutForStructuredData: true;
 	/** Quiet verbosity suppresses `info()` messages entirely. */
 	readonly quietSuppressesInfo: true;
+	/** Quiet verbosity suppresses rendered spinner/progress output; capture still records lifecycle events. */
+	readonly quietSuppressesRenderedActivity: true;
 	/** Spinner/progress writes go to stderr so stdout stays parseable. */
 	readonly activityUsesStderrOutsideCapture: true;
 	/** Animated TTY spinners require both a real terminal and non-JSON mode. */
@@ -84,6 +86,7 @@ interface OutputContract {
 const outputContract = {
 	jsonReservesStdoutForStructuredData: true,
 	quietSuppressesInfo: true,
+	quietSuppressesRenderedActivity: true,
 	activityUsesStderrOutsideCapture: true,
 	ttyActivityRequiresTTYAndNonJson: true,
 	spinnerCleanupUsesStop: true,
@@ -136,7 +139,7 @@ function resolveActivityRenderMode(
 	policy: OutputPolicy,
 	fallback: Fallback,
 ): ActivityPolicy['mode'] {
-	if (policy.jsonMode) {
+	if (policy.jsonMode || policy.verbosity === 'quiet') {
 		return 'noop';
 	}
 

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -231,6 +231,9 @@ class OutputChannel implements Out {
 	/** Whether JSON output mode is active. */
 	readonly jsonMode: boolean;
 
+	/** Active verbosity level for informational output and activity rendering. */
+	readonly verbosity: Verbosity;
+
 	/**
 	 * Whether stdout is connected to a TTY.
 	 *
@@ -260,6 +263,7 @@ class OutputChannel implements Out {
 		this.options = options;
 		this.policy = resolveOutputPolicy(options);
 		this.jsonMode = options.jsonMode;
+		this.verbosity = this.policy.verbosity;
 		this.isTTY = options.isTTY;
 		this.color = createColors(options.color);
 		this.isHyperlinkSupported = options.isHyperlinkSupported;
@@ -398,7 +402,7 @@ class OutputChannel implements Out {
 	 * Create a spinner handle.
 	 *
 	 * Mode dispatch:
-	 * - `jsonMode` → noop (structured output only, spinners suppressed)
+	 * - quiet or `jsonMode` → noop (informational activity suppressed)
 	 * - `isTTY` → animated TTY spinner (braille frames, ANSI overwrite)
 	 * - `!isTTY && fallback: 'static'` → plain text at lifecycle boundaries
 	 * - `!isTTY && fallback: 'silent'` (default) → noop
@@ -429,7 +433,7 @@ class OutputChannel implements Out {
 	 * Create a progress handle.
 	 *
 	 * Mode dispatch:
-	 * - `jsonMode` → noop (structured output only, progress suppressed)
+	 * - quiet or `jsonMode` → noop (informational activity suppressed)
 	 * - `isTTY` → animated TTY progress bar (determinate or indeterminate)
 	 * - `!isTTY && fallback: 'static'` → plain text at lifecycle boundaries
 	 * - `!isTTY && fallback: 'silent'` (default) → noop

--- a/src/core/output/output-activity-dispatch.test.ts
+++ b/src/core/output/output-activity-dispatch.test.ts
@@ -101,6 +101,14 @@ describe('OutputChannel.spinner() — mode dispatch', () => {
 		handle.succeed('done');
 		expect(stderr).toEqual([]);
 	});
+
+	it('quiet mode → noop for non-TTY static fallback', () => {
+		const { channel, stdout, stderr } = makeChannel({ isTTY: false, verbosity: 'quiet' });
+		const handle = channel.spinner('Loading', { fallback: 'static' });
+		handle.succeed('done');
+		expect(stdout).toEqual([]);
+		expect(stderr).toEqual([]);
+	});
 });
 
 // === OutputChannel — mode dispatch for progress()
@@ -143,6 +151,14 @@ describe('OutputChannel.progress() — mode dispatch', () => {
 		const { channel, stderr } = makeChannel({ isTTY: true, verbosity: 'quiet' });
 		const handle = channel.progress({ total: 10, label: 'Files', fallback: 'static' });
 		handle.done('done');
+		expect(stderr).toEqual([]);
+	});
+
+	it('quiet mode → noop for non-TTY static fallback', () => {
+		const { channel, stdout, stderr } = makeChannel({ isTTY: false, verbosity: 'quiet' });
+		const handle = channel.progress({ total: 10, label: 'Files', fallback: 'static' });
+		handle.done('done');
+		expect(stdout).toEqual([]);
 		expect(stderr).toEqual([]);
 	});
 });
@@ -364,6 +380,34 @@ describe('stopActive() — explicit cleanup', () => {
 // === createCaptureOutput — activity event capture
 
 describe('createCaptureOutput — activity capture', () => {
+	it('records spinner activity without text output in quiet mode', () => {
+		const [out, captured] = createCaptureOutput({ verbosity: 'quiet' });
+		const handle = out.spinner('Loading');
+		handle.update('Still loading');
+		handle.succeed('Done');
+		expect(captured.stdout).toEqual([]);
+		expect(captured.stderr).toEqual([]);
+		expect(captured.activity).toEqual([
+			{ type: 'spinner:start', text: 'Loading' },
+			{ type: 'spinner:update', text: 'Still loading' },
+			{ type: 'spinner:succeed', text: 'Done' },
+		]);
+	});
+
+	it('records progress activity without text output in quiet mode', () => {
+		const [out, captured] = createCaptureOutput({ verbosity: 'quiet' });
+		const handle = out.progress({ total: 10, label: 'Files' });
+		handle.increment(3);
+		handle.done('Complete');
+		expect(captured.stdout).toEqual([]);
+		expect(captured.stderr).toEqual([]);
+		expect(captured.activity).toEqual([
+			{ type: 'progress:start', label: 'Files', total: 10 },
+			{ type: 'progress:increment', delta: 3 },
+			{ type: 'progress:done', text: 'Complete' },
+		]);
+	});
+
 	it('captures spinner lifecycle events', () => {
 		const [out, captured] = createCaptureOutput();
 		const handle = out.spinner('Loading');

--- a/src/core/output/output-activity-dispatch.test.ts
+++ b/src/core/output/output-activity-dispatch.test.ts
@@ -20,7 +20,11 @@ import { createCaptureOutput, OutputChannel } from './index.ts';
 
 // --- Test helpers ---
 
-function makeChannel(opts: { jsonMode?: boolean; isTTY?: boolean }): {
+function makeChannel(opts: {
+	jsonMode?: boolean;
+	isTTY?: boolean;
+	verbosity?: 'normal' | 'quiet';
+}): {
 	channel: OutputChannel;
 	stdout: string[];
 	stderr: string[];
@@ -31,7 +35,7 @@ function makeChannel(opts: { jsonMode?: boolean; isTTY?: boolean }): {
 		stdout: (s) => stdout.push(s),
 		stderr: (s) => stderr.push(s),
 		isTTY: opts.isTTY ?? false,
-		verbosity: 'normal',
+		verbosity: opts.verbosity ?? 'normal',
 		jsonMode: opts.jsonMode ?? false,
 		color: false,
 		isHyperlinkSupported: false,
@@ -90,6 +94,13 @@ describe('OutputChannel.spinner() — mode dispatch', () => {
 		// jsonMode takes precedence — no output
 		expect(stdout).toEqual([]);
 	});
+
+	it('quiet mode → noop even when TTY', () => {
+		const { channel, stderr } = makeChannel({ isTTY: true, verbosity: 'quiet' });
+		const handle = channel.spinner('Loading', { fallback: 'static' });
+		handle.succeed('done');
+		expect(stderr).toEqual([]);
+	});
 });
 
 // === OutputChannel — mode dispatch for progress()
@@ -126,6 +137,13 @@ describe('OutputChannel.progress() — mode dispatch', () => {
 		const all = stderr.join('');
 		expect(all).toContain('\x1b[?25l');
 		expect(all).toContain('\x1b[?25h');
+	});
+
+	it('quiet mode → noop even when TTY', () => {
+		const { channel, stderr } = makeChannel({ isTTY: true, verbosity: 'quiet' });
+		const handle = channel.progress({ total: 10, label: 'Files', fallback: 'static' });
+		handle.done('done');
+		expect(stderr).toEqual([]);
 	});
 });
 

--- a/src/core/output/output.test.ts
+++ b/src/core/output/output.test.ts
@@ -15,7 +15,7 @@ import {
 describe('createOutput', () => {
 	it('returns an object satisfying the Out interface', () => {
 		const out = createOutput();
-		expectTypeOf(out).toMatchTypeOf<Out>();
+		expectTypeOf(out).toExtend<Out>();
 		expect(typeof out.log).toBe('function');
 		expect(typeof out.info).toBe('function');
 		expect(typeof out.warn).toBe('function');
@@ -291,8 +291,8 @@ describe('createCaptureOutput', () => {
 		expect(Array.isArray(result)).toBe(true);
 		expect(result).toHaveLength(2);
 		const [out, captured] = result;
-		expectTypeOf(out).toMatchTypeOf<Out>();
-		expectTypeOf(captured).toMatchTypeOf<CapturedOutput>();
+		expectTypeOf(out).toExtend<Out>();
+		expectTypeOf(captured).toExtend<CapturedOutput>();
 	});
 
 	it('captures stdout and stderr separately', () => {
@@ -585,7 +585,7 @@ describe('jsonMode', () => {
 describe('out.color', () => {
 	it('is exposed on every channel and typed as Colors', () => {
 		const out = createOutput();
-		expectTypeOf(out.color).toMatchTypeOf<Colors>();
+		expectTypeOf(out.color).toExtend<Colors>();
 		expect(typeof out.color.red).toBe('function');
 		expect(typeof out.color.bold).toBe('function');
 	});

--- a/src/core/output/output.test.ts
+++ b/src/core/output/output.test.ts
@@ -169,7 +169,13 @@ describe('verbosity', () => {
 	it('defaults to normal verbosity', () => {
 		const [out, captured] = createCaptureOutput();
 		out.info('visible');
+		expect(out.verbosity).toBe('normal');
 		expect(captured.stdout).toEqual(['visible\n']);
+	});
+
+	it('exposes quiet verbosity on the public output channel', () => {
+		const out = createOutput({ verbosity: 'quiet' });
+		expect(out.verbosity).toBe('quiet');
 	});
 });
 

--- a/src/core/prompt/prompt.test.ts
+++ b/src/core/prompt/prompt.test.ts
@@ -139,7 +139,7 @@ describe('createTestPrompter', () => {
 
 	it('satisfies PromptEngine interface', () => {
 		const prompter = createTestPrompter([]);
-		expectTypeOf(prompter).toMatchTypeOf<PromptEngine>();
+		expectTypeOf(prompter).toExtend<PromptEngine>();
 	});
 
 	it('ignores config parameter (uses queue only)', async () => {
@@ -658,7 +658,7 @@ describe('createTerminalPrompter', () => {
 				() => Promise.resolve(null),
 				() => {},
 			);
-			expectTypeOf(prompter).toMatchTypeOf<PromptEngine>();
+			expectTypeOf(prompter).toExtend<PromptEngine>();
 		});
 	});
 });
@@ -742,7 +742,7 @@ describe('resolvePromptConfig', () => {
 	it('returns correct type for resolved config', () => {
 		expectTypeOf(
 			resolvePromptConfig({ kind: 'confirm', message: 'q' }, undefined),
-		).toMatchTypeOf<ResolvedPromptConfig>();
+		).toExtend<ResolvedPromptConfig>();
 	});
 });
 
@@ -764,13 +764,13 @@ describe('type contracts', () => {
 	});
 
 	it('ResolvedSelectPromptConfig has non-empty choices', () => {
-		expectTypeOf<ResolvedSelectPromptConfig['choices']>().toMatchTypeOf<
+		expectTypeOf<ResolvedSelectPromptConfig['choices']>().toExtend<
 			readonly [{ value: string }, ...{ value: string }[]]
 		>();
 	});
 
 	it('ResolvedMultiselectPromptConfig has non-empty choices', () => {
-		expectTypeOf<ResolvedMultiselectPromptConfig['choices']>().toMatchTypeOf<
+		expectTypeOf<ResolvedMultiselectPromptConfig['choices']>().toExtend<
 			readonly [{ value: string }, ...{ value: string }[]]
 		>();
 	});

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -563,7 +563,7 @@ describe('type inference', () => {
 	it('third type parameter C defaults to Record<string, never>', () => {
 		// CommandBuilder with no middleware has C = Record<string, never>
 		const cmd = command('test');
-		expectTypeOf(cmd).toMatchTypeOf<CommandBuilder>();
+		expectTypeOf(cmd).toExtend<CommandBuilder>();
 		expectTypeOf(cmd._ctx).toEqualTypeOf<Record<string, never>>();
 	});
 
@@ -625,8 +625,8 @@ describe('CommandSchema', () => {
 		expectTypeOf(schema.aliases).toEqualTypeOf<readonly string[]>();
 		expectTypeOf(schema.hidden).toBeBoolean();
 		expectTypeOf(schema.examples).toEqualTypeOf<readonly CommandExample[]>();
-		expectTypeOf(schema.flags).toMatchTypeOf<Record<string, unknown>>();
-		expectTypeOf(schema.args).toMatchTypeOf<readonly CommandArgEntry[]>();
+		expectTypeOf(schema.flags).toExtend<Record<string, unknown>>();
+		expectTypeOf(schema.args).toExtend<readonly CommandArgEntry[]>();
 		expectTypeOf(schema.hasAction).toBeBoolean();
 		expectTypeOf(schema.commands).toEqualTypeOf<readonly CommandSchema[]>();
 	});

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -356,6 +356,7 @@ describe('full command composition', () => {
 			progress: vi.fn(),
 			stopActive: vi.fn(),
 			jsonMode: false,
+			verbosity: 'normal',
 			isTTY: false,
 			color: createColors(false),
 			isHyperlinkSupported: false,
@@ -587,13 +588,14 @@ describe('type inference', () => {
 		expectTypeOf<DefaultParams['ctx']>().toEqualTypeOf<Readonly<Record<string, never>>>();
 	});
 
-	it('out has log/info/warn/error methods', () => {
+	it('out exposes output methods and resolved verbosity', () => {
 		command('test').action(({ out }) => {
 			type Output = typeof out;
 			expectTypeOf<Output['log']>().toEqualTypeOf<(message: string) => void>();
 			expectTypeOf<Output['info']>().toEqualTypeOf<(message: string) => void>();
 			expectTypeOf<Output['warn']>().toEqualTypeOf<(message: string) => void>();
 			expectTypeOf<Output['error']>().toEqualTypeOf<(message: string) => void>();
+			expectTypeOf<Output['verbosity']>().toEqualTypeOf<'normal' | 'quiet'>();
 		});
 	});
 

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -10,6 +10,7 @@
  */
 import type { Colors } from 'ansispeck';
 import { CLIError } from '#internals/core/errors/index.ts';
+import type { Verbosity } from '#internals/core/output/contracts.ts';
 import type {
 	ProgressHandle,
 	ProgressOptions,
@@ -188,6 +189,18 @@ interface Out {
 	readonly jsonMode: boolean;
 
 	/**
+	 * Active output verbosity for this command execution.
+	 *
+	 * Root `--quiet`/`-q` resolves to `'quiet'`. Most handlers should emit
+	 * informational output through {@linkcode Out.info | info()},
+	 * {@linkcode Out.status | status()}, {@linkcode Out.spinner | spinner()},
+	 * or {@linkcode Out.progress | progress()} and let the channel suppress it
+	 * automatically. Read this property only when custom rendering or expensive
+	 * optional work genuinely depends on the active verbosity.
+	 */
+	readonly verbosity: Verbosity;
+
+	/**
 	 * Whether stdout is connected to a TTY (terminal).
 	 *
 	 * Handlers can check this to decide whether to emit decorative output
@@ -262,8 +275,8 @@ interface Out {
 	/**
 	 * Create a spinner for indeterminate progress feedback.
 	 *
-	 * Returns a handle for lifecycle control. In non-TTY/jsonMode,
-	 * returns a no-op handle (or static fallback if configured).
+	 * Returns a no-op handle in quiet or JSON mode. Otherwise, non-TTY output
+	 * uses a no-op handle or the configured static fallback.
 	 *
 	 * @param text    - Initial spinner text.
 	 * @param options - Fallback strategy for non-TTY environments.
@@ -274,7 +287,7 @@ interface Out {
 	/**
 	 * Create a progress bar for measured work.
 	 *
-	 * Returns a handle for updating progress. Pass `total` for
+	 * Returns a no-op handle in quiet or JSON mode. Otherwise, pass `total` for
 	 * determinate mode (percentage bar); omit for indeterminate (pulsing).
 	 *
 	 * @param options - Progress configuration (total, label, fallback).

--- a/src/core/schema/prompt.test.ts
+++ b/src/core/schema/prompt.test.ts
@@ -486,7 +486,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly flagKind: 'enum';
 			readonly elementEligible: false;
 		};
-		expectTypeOf<MultiselectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<EnumConfig>>();
+		expectTypeOf<MultiselectPromptConfig>().not.toExtend<AllowedPromptConfig<EnumConfig>>();
 	});
 
 	it('multiselect is not assignable to boolean flag prompt', () => {
@@ -497,7 +497,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly flagKind: 'boolean';
 			readonly elementEligible: false;
 		};
-		expectTypeOf<MultiselectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<BoolConfig>>();
+		expectTypeOf<MultiselectPromptConfig>().not.toExtend<AllowedPromptConfig<BoolConfig>>();
 	});
 
 	it('confirm is not assignable to string flag prompt', () => {
@@ -508,7 +508,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly flagKind: 'string';
 			readonly elementEligible: false;
 		};
-		expectTypeOf<ConfirmPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<StrConfig>>();
+		expectTypeOf<ConfirmPromptConfig>().not.toExtend<AllowedPromptConfig<StrConfig>>();
 	});
 
 	it('input is not assignable to boolean flag prompt', () => {
@@ -519,7 +519,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly flagKind: 'boolean';
 			readonly elementEligible: false;
 		};
-		expectTypeOf<InputPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<BoolConfig>>();
+		expectTypeOf<InputPromptConfig>().not.toExtend<AllowedPromptConfig<BoolConfig>>();
 	});
 
 	it('select is not assignable to array flag prompt', () => {
@@ -530,7 +530,7 @@ describe('AllowedPromptConfig type constraints', () => {
 			readonly flagKind: 'array';
 			readonly elementEligible: false;
 		};
-		expectTypeOf<SelectPromptConfig>().not.toMatchTypeOf<AllowedPromptConfig<ArrConfig>>();
+		expectTypeOf<SelectPromptConfig>().not.toExtend<AllowedPromptConfig<ArrConfig>>();
 	});
 
 	it('valid combinations accepted by FlagBuilder.prompt()', () => {

--- a/src/core/testkit/middleware-context-e2e.test.ts
+++ b/src/core/testkit/middleware-context-e2e.test.ts
@@ -149,7 +149,7 @@ describe('typed ctx in action handlers', () => {
 			.middleware(traceMiddleware)
 			.action(({ ctx }) => {
 				// Compile-time: ctx should have user, traceId, startTime
-				expectTypeOf(ctx.user).toMatchTypeOf<User>();
+				expectTypeOf(ctx.user).toExtend<User>();
 				expectTypeOf(ctx.traceId).toBeString();
 				expectTypeOf(ctx.startTime).toBeNumber();
 			});
@@ -165,8 +165,8 @@ describe('typed ctx in action handlers', () => {
 		command('test')
 			.middleware(authMiddleware)
 			.action(({ ctx }) => {
-				expectTypeOf(ctx.user).toMatchTypeOf<User>();
-				expectTypeOf(ctx.user.role).toMatchTypeOf<'admin' | 'user'>();
+				expectTypeOf(ctx.user).toExtend<User>();
+				expectTypeOf(ctx.user.role).toExtend<'admin' | 'user'>();
 			});
 	});
 
@@ -181,7 +181,7 @@ describe('typed ctx in action handlers', () => {
 				expectTypeOf(args.name).toBeString();
 				expectTypeOf(flags.force).toBeBoolean();
 				expectTypeOf(flags.count).toBeNumber();
-				expectTypeOf(ctx.user).toMatchTypeOf<User>();
+				expectTypeOf(ctx.user).toExtend<User>();
 				expectTypeOf(ctx.traceId).toBeString();
 			});
 	});


### PR DESCRIPTION
Closes #94.

- `resolveActivityRenderMode()` returns `noop` when `verbosity === 'quiet'`, before the TTY and static-fallback branches, so `--quiet` silences spinners and progress bars on interactive TTYs and static fallbacks alike. JSON mode, normal TTY, and fallback behavior unchanged.
- `Out.verbosity` (required, `'normal' | 'quiet'`) joins `jsonMode`/`isTTY` as a resolved rendering fact; `resolveRenderContext()` exposes the same decision with `--`-aware `--quiet`/`-q` detection.
- Capture semantics unchanged and now documented: `result.activity` records logical lifecycles regardless of verbosity; quiet governs rendered bytes. Contract key: `quietSuppressesRenderedActivity`.
- Two mechanical sweeps ride along as separate commits: `toMatchTypeOf` → `toExtend` (deprecated in expect-type), and the two `noDescendingSpecificity` CSS warnings in the docs theme.