### PR TITLE
feat(api)!: seal `Out` and `RenderContext`, split internal execution options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
+### Changed
 
-- **Public output verbosity state** — action handlers can read `out.verbosity`,
-  while `resolveRenderContext()` now exposes the same `verbosity` decision for
-  custom content built before `.run()` (including `--`-aware `--quiet`/`-q`
-  detection). `verbosity` is a required member of `Out`, so a hand-rolled
-  `Out` object literal stops compiling until it declares one. Hand-rolling
-  `Out` is unsupported; take a real channel from the testkit and spy on it
-  instead:
+- **Breaking: `Out` gained a required `verbosity` member** — action handlers
+  can read `out.verbosity`, and `resolveRenderContext()` exposes the same
+  `verbosity` decision for custom content built before `.run()` (including
+  `--`-aware `--quiet`/`-q` detection). A hand-rolled `Out` object literal
+  stops compiling until it declares one; migrate to a real channel from the
+  testkit and spy on it instead:
 
   ```ts
   const [out] = createCaptureOutput();
@@ -24,6 +23,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
   Do not spread a channel (`{ ...out, info: vi.fn() }`) — its methods are
   non-enumerable bound copies, so the spread result has none of them.
+
+- **Breaking: `Out` and `RenderContext` are sealed** — both interfaces now
+  carry a private brand, so implementing or structurally constructing them
+  outside the framework no longer type-checks. They are framework-created,
+  non-exhaustive values: obtain instances from action parameters,
+  `createOutput()`, `createCaptureOutput()`, or `resolveRenderContext()`, and
+  expect new readonly members in minor releases. Helpers that only need a
+  subset can accept `Pick<Out, 'info' | 'status'>`-style capability types.
+
+- **Breaking: internal execution fields left `RunOptions` and
+  `CLIRunOptions`** — `out`, `captured`, `mergedSchema`, `meta`, and `plugins`
+  were framework-populated fields marked `@internal` yet shipped on the public
+  option types. They now live on unexported internal execution options; code
+  passing them to `runCommand()` or `.execute()` stops compiling. Inject
+  writers via `createCaptureOutput()` options or `OutputOptions.stdout`/
+  `stderr` instead of replacing the channel wholesale.
 
 ### Fixed
 

--- a/src/core/cli/cli-json.test.ts
+++ b/src/core/cli/cli-json.test.ts
@@ -252,7 +252,7 @@ describe('CLIBuilder --json with root flags', () => {
 		// must honor `options.jsonMode` / root `--json`, not just the channel flag.
 		const [out, captured] = createCaptureOutput();
 		const app = cli('test').version('1.0.0').command(dataCommand());
-		const result = await app.execute(['data', '--help', '--json'], { out, captured });
+		const result = await app._execute(['data', '--help', '--json'], { out, captured });
 
 		expect(result.exitCode).toBe(0);
 		const doc: unknown = JSON.parse(captured.stdout.join(''));

--- a/src/core/cli/cli.test.ts
+++ b/src/core/cli/cli.test.ts
@@ -680,7 +680,7 @@ describe('options passthrough', () => {
 				throw new Error('kaboom');
 			}),
 		);
-		const result = await app.execute(['build'], { out, captured });
+		const result = await app._execute(['build'], { out, captured });
 
 		expect(result.exitCode).toBe(1);
 		expect(result.error?.code).toBe('UNEXPECTED_ERROR');

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -46,8 +46,8 @@ import type {
 import { command } from '#internals/core/schema/command.ts';
 import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
 import { getFlagAliasNames } from '#internals/core/schema/flag.ts';
-import type { RunOptions, RunResult } from '#internals/core/schema/run.ts';
-import { runCommand } from '#internals/core/testkit/index.ts';
+import type { InternalRunOptions, RunOptions, RunResult } from '#internals/core/schema/run.ts';
+import { runCommandInternal } from '#internals/core/testkit/index.ts';
 import type { RuntimeAdapter } from '#internals/runtime/adapter.ts';
 import { createAdapter } from '#internals/runtime/auto.ts';
 import { BACKSLASH, SLASH, stripTrailing } from '#internals/strings.ts';
@@ -194,7 +194,7 @@ function eraseCommand<
 		subcommands,
 		_command: cmd as unknown as AnyCommandBuilder,
 		_execute(argv, options) {
-			return runCommand(cmd, argv, options);
+			return runCommandInternal(cmd, argv, options);
 		},
 	};
 }
@@ -471,10 +471,9 @@ type PackageJsonSettings = ResolvedManifestSettings;
 /**
  * Options for {@linkcode CLIBuilder.execute | .execute()} and {@linkcode CLIBuilder.run | .run()}.
  *
- * Derives from {@linkcode RunOptions} while excluding command-execution internals
- * (`meta`, `mergedSchema`) and adding the CLI-level runtime adapter.
+ * Derives from {@linkcode RunOptions}, adding the CLI-level runtime adapter.
  */
-interface CLIRunOptions extends Omit<RunOptions, 'meta' | 'mergedSchema'> {
+interface CLIRunOptions extends RunOptions {
 	/**
 	 * Runtime adapter providing platform-specific I/O, argv, env, etc.
 	 *
@@ -482,6 +481,21 @@ interface CLIRunOptions extends Omit<RunOptions, 'meta' | 'mergedSchema'> {
 	 * Ignored by `.execute()` (which is process-free by design).
 	 */
 	readonly adapter?: RuntimeAdapter;
+}
+
+/**
+ * CLI execution options extended with the fields `.run()` and dispatch
+ * populate themselves.
+ *
+ * @internal
+ */
+interface InternalCLIRunOptions extends CLIRunOptions {
+	/** Output channel override so activity renders to the terminal. */
+	readonly out?: Out;
+	/** Capture buffers override paired with `out`. */
+	readonly captured?: CapturedOutput;
+	/** CLI plugins registered on the builder. */
+	readonly plugins?: readonly CLIPlugin[];
 }
 
 // --- Render context
@@ -527,10 +541,24 @@ interface RenderContextOptions {
 }
 
 /**
+ * Seals {@linkcode RenderContext} against structural construction outside the
+ * framework.
+ *
+ * @internal
+ */
+const renderContextBrand: unique symbol = Symbol('dreamcli.renderContext');
+
+/**
  * The output decisions the framework will make for a given argv, resolved
  * before `.run()`.
+ *
+ * `RenderContext` is a framework-created, non-exhaustive value: obtain
+ * instances from {@linkcode resolveRenderContext} — do not implement it. New
+ * readonly members may be added in minor releases.
  */
 interface RenderContext {
+	/** Framework-construction seal. Obtain values from `resolveRenderContext()`; do not implement this interface. */
+	readonly [renderContextBrand]: never;
 	/** Whether a pre-separator `--json` puts the run in JSON mode. */
 	readonly jsonMode: boolean;
 	/** Active verbosity after pre-separator `--quiet`/`-q` detection. */
@@ -545,6 +573,29 @@ interface RenderContext {
 	readonly color: Colors;
 	/** Whether OSC 8 hyperlinks should be emitted (see `out.isHyperlinkSupported`). */
 	readonly isHyperlinkSupported: boolean;
+}
+
+/**
+ * Concrete {@linkcode RenderContext} carrying the resolved output decisions.
+ *
+ * @internal
+ */
+class ResolvedRenderContext implements RenderContext {
+	declare readonly [renderContextBrand]: never;
+
+	readonly jsonMode: boolean;
+	readonly verbosity: Verbosity;
+	readonly isTTY: boolean;
+	readonly color: Colors;
+	readonly isHyperlinkSupported: boolean;
+
+	constructor(out: Out) {
+		this.jsonMode = out.jsonMode;
+		this.verbosity = out.verbosity;
+		this.isTTY = out.isTTY;
+		this.color = out.color;
+		this.isHyperlinkSupported = out.isHyperlinkSupported;
+	}
 }
 
 /**
@@ -587,13 +638,7 @@ function resolveRenderContext(
 		...(options?.color !== undefined ? { color: options.color } : {}),
 		...hyperlinksOption(resolveHyperlinkOverride(options?.env ?? {}, argv)),
 	});
-	return {
-		jsonMode: out.jsonMode,
-		verbosity: out.verbosity,
-		isTTY: out.isTTY,
-		color: out.color,
-		isHyperlinkSupported: out.isHyperlinkSupported,
-	};
+	return new ResolvedRenderContext(out);
 }
 
 // --- Command run options builder
@@ -621,10 +666,10 @@ function hyperlinksOption(override: boolean | undefined): { hyperlinks?: boolean
  * @internal
  */
 function buildCommandRunOptions(
-	options: CLIRunOptions | undefined,
+	options: InternalCLIRunOptions | undefined,
 	helpOptions: HelpOptions,
 	meta?: CommandMeta,
-): RunOptions {
+): InternalRunOptions {
 	return {
 		help: helpOptions,
 		...(meta !== undefined ? { meta } : {}),
@@ -1259,6 +1304,16 @@ class CLIBuilder {
 	 * @returns Structured result with exit code and captured output.
 	 */
 	async execute(argv: readonly string[], options?: CLIRunOptions): Promise<RunResult> {
+		return this._execute(argv, options);
+	}
+
+	/**
+	 * Execution body shared by {@linkcode execute} and {@linkcode run}, accepting
+	 * the framework-populated output channel and plugin fields.
+	 *
+	 * @internal
+	 */
+	async _execute(argv: readonly string[], options?: InternalCLIRunOptions): Promise<RunResult> {
 		// -- Detect global --json / --quiet before building output ----------------
 		// Only occurrences before the `--` separator count; a literal positional
 		// (after `--`) must reach the command unchanged (#28).
@@ -1304,7 +1359,7 @@ class CLIBuilder {
 
 		// -- Shared options for command execution ----------------------------------
 		const flagSettings = options?.flags ?? this.schema.flagSettings;
-		const effectiveOptions: CLIRunOptions = {
+		const effectiveOptions: InternalCLIRunOptions = {
 			...options,
 			plugins: this.schema.plugins,
 			...(jsonMode ? { jsonMode } : {}),
@@ -1477,7 +1532,7 @@ class CLIBuilder {
 			runtimeHelpWidth !== undefined
 				? { ...options?.help, width: runtimeHelpWidth }
 				: options?.help;
-		const executeOptions: CLIRunOptions = {
+		const executeOptions: InternalCLIRunOptions = {
 			...options,
 			...preflight.inputs,
 			...(runtimeHelpOptions !== undefined ? { help: runtimeHelpOptions } : {}),
@@ -1492,7 +1547,7 @@ class CLIBuilder {
 				...hyperlinksOption(resolveHyperlinkOverride(adapter.env, adapter.argv)),
 			}),
 		};
-		const result = await effectiveBuilder.execute(preflight.filteredArgv, executeOptions);
+		const result = await effectiveBuilder._execute(preflight.filteredArgv, executeOptions);
 
 		// Write captured output to real streams via adapter
 		for (const line of result.stdout) {

--- a/src/core/cli/root-help-theme.test.ts
+++ b/src/core/cli/root-help-theme.test.ts
@@ -39,7 +39,7 @@ describe('root help theming', () => {
 
 	it('styles header, sections, and commands under forced color', async () => {
 		const [out, captured] = createCaptureOutput({ color: true });
-		await app().execute(['--help'], { out, captured });
+		await app()._execute(['--help'], { out, captured });
 		const output = captured.stdout.join('');
 		expect(output).toContain(on.bold('mycli'));
 		expect(output).toContain(on.dim('v1.0.0'));
@@ -53,7 +53,7 @@ describe('root help theming', () => {
 	it('strip-equivalence: forced-color root help strips to the plain rendering', async () => {
 		const plain = (await app().execute(['--help'])).stdout.join('');
 		const [out, captured] = createCaptureOutput({ color: true });
-		await app().execute(['--help'], { out, captured });
+		await app()._execute(['--help'], { out, captured });
 		expect(stripAnsi(captured.stdout.join(''))).toBe(plain);
 	});
 
@@ -73,7 +73,7 @@ describe('root help theming', () => {
 				);
 		const plain = (await build().execute(['--help'])).stdout.join('');
 		const [out, captured] = createCaptureOutput({ color: true });
-		await build().execute(['--help'], { out, captured });
+		await build()._execute(['--help'], { out, captured });
 		const colored = captured.stdout.join('');
 		expect(stripAnsi(colored)).toBe(plain);
 		// The merged usage block: root line + continuation aligned under 'Usage: '.
@@ -87,7 +87,7 @@ describe('root help theming', () => {
 		const [out, captured] = createCaptureOutput({ color: true });
 		await app()
 			.help({ theme: (c) => ({ command: c.green }) })
-			.execute(['--help'], { out, captured });
+			._execute(['--help'], { out, captured });
 		const output = captured.stdout.join('');
 		expect(output).toContain(on.green('deploy'));
 		expect(output).not.toContain(on.cyan('deploy'));

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -28,7 +28,7 @@ import type {
 	Out,
 	RunnableCommand,
 } from '#internals/core/schema/command.ts';
-import type { RunOptions, RunResult } from '#internals/core/schema/run.ts';
+import type { InternalRunOptions, RunResult } from '#internals/core/schema/run.ts';
 
 /**
  * Explicit executor input for a single command invocation.
@@ -46,7 +46,7 @@ interface CommandExecutionRequest {
 	/** Runtime metadata (binary name, version) propagated to the handler. */
 	readonly meta: CommandMeta;
 	/** Optional overrides for env, config, prompter, plugins, and JSON mode. */
-	readonly options?: RunOptions;
+	readonly options?: InternalRunOptions;
 }
 
 /**

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -21,7 +21,7 @@ import type {
 	TableColumn,
 	TableOptions,
 } from '#internals/core/schema/activity.ts';
-import type { Out } from '#internals/core/schema/command.ts';
+import { type Out, outBrand } from '#internals/core/schema/command.ts';
 import {
 	CaptureProgressHandle,
 	CaptureSpinnerHandle,
@@ -222,6 +222,8 @@ function resolveOptions(options?: OutputOptions): ResolvedOutputOptions {
  * @internal
  */
 class OutputChannel implements Out {
+	declare readonly [outBrand]: never;
+
 	/** @internal Resolved configuration. */
 	readonly options: ResolvedOutputOptions;
 

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -1,6 +1,6 @@
-import { createColors } from 'ansispeck';
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { CLIError } from '#internals/core/errors/index.ts';
+import { createCaptureOutput } from '#internals/core/output/index.ts';
 import { arg } from './arg.ts';
 import type {
 	ActionParams,
@@ -8,7 +8,6 @@ import type {
 	CommandExample,
 	CommandSchema,
 	ExampleMeta,
-	Out,
 } from './command.ts';
 import { CommandBuilder, command, group, resolveExampleCommand } from './command.ts';
 import { flag } from './flag.ts';
@@ -343,24 +342,7 @@ describe('full command composition', () => {
 			.flag('loud', flag.boolean())
 			.action(handler);
 
-		const mockOut: Out = {
-			log: vi.fn(),
-			info: vi.fn(),
-			status: vi.fn(),
-			warn: vi.fn(),
-			error: vi.fn(),
-			setExitCode: vi.fn(),
-			json: vi.fn(),
-			table: vi.fn(),
-			spinner: vi.fn(),
-			progress: vi.fn(),
-			stopActive: vi.fn(),
-			jsonMode: false,
-			verbosity: 'normal',
-			isTTY: false,
-			color: createColors(false),
-			isHyperlinkSupported: false,
-		};
+		const [mockOut] = createCaptureOutput();
 
 		// Simulate what the runtime will do
 		const params: ActionParams<

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -24,7 +24,7 @@ import type { FlagBuilder, FlagConfig, FlagSchema, InferFlags } from './flag.ts'
 import { getFlagNegatedName } from './flag.ts';
 import type { ErasedMiddlewareHandler, Middleware } from './middleware.ts';
 import type { PromptConfig } from './prompt.ts';
-import type { RunOptions, RunResult } from './run.ts';
+import type { InternalRunOptions, RunResult } from './run.ts';
 
 // --- Context type utilities
 
@@ -140,13 +140,27 @@ type ErasedInteractiveResolver = (params: {
 // --- Handler types
 
 /**
+ * Seals {@linkcode Out} against structural construction outside the framework.
+ *
+ * @internal
+ */
+const outBrand: unique symbol = Symbol('dreamcli.out');
+
+/**
  * Output channel available inside action handlers.
  *
  * Provides structured methods for stdout/stderr, JSON output,
  * spinners, progress bars, and tables. The real implementation lives in
  * `src/core/output/`; this interface defines the shape that handlers consume.
+ *
+ * `Out` is a framework-created, non-exhaustive value: obtain instances from
+ * action parameters, `createOutput()`, or `createCaptureOutput()` — do not
+ * implement it. New readonly members may be added in minor releases.
  */
 interface Out {
+	/** Framework-construction seal. Obtain `Out` values from DreamCLI; do not implement this interface. */
+	readonly [outBrand]: never;
+
 	/** Write to stdout (normal output). */
 	log(message: string): void;
 	/** Informational (may be suppressed in quiet mode). */
@@ -814,7 +828,7 @@ interface ErasedCommand {
 	/** Original command builder captured at the type-erasure boundary. */
 	readonly _command?: AnyCommandBuilder;
 	/** Execute this command against argv. Closes over the typed CommandBuilder. */
-	readonly _execute: (argv: readonly string[], options?: RunOptions) => Promise<RunResult>;
+	readonly _execute: (argv: readonly string[], options?: InternalRunOptions) => Promise<RunResult>;
 }
 
 /**
@@ -1597,4 +1611,4 @@ export type {
 	WidenContext,
 	WidenDerivedContext,
 };
-export { CommandBuilder, command, group, resolveExampleCommand };
+export { CommandBuilder, command, group, outBrand, resolveExampleCommand };

--- a/src/core/schema/index.ts
+++ b/src/core/schema/index.ts
@@ -102,7 +102,7 @@ export {
 	describeNumberConstraintViolation,
 	validateNumberConstraints,
 } from './number-constraints.ts';
-export type { RunOptions, RunResult } from './run.ts';
+export type { InternalRunOptions, RunOptions, RunResult } from './run.ts';
 export type {
 	InferStandardInput,
 	InferStandardOutput,

--- a/src/core/schema/run.ts
+++ b/src/core/schema/run.ts
@@ -122,22 +122,6 @@ export interface RunOptions {
 	readonly isTTY?: boolean;
 
 	/**
-	 * Output channel override used by live CLI execution.
-	 *
-	 * @internal — `CLIBuilder.run()` passes a real output channel so activity renders to
-	 * the terminal instead of being captured.
-	 */
-	readonly out?: Out;
-
-	/**
-	 * Capture buffers override paired with `out`.
-	 *
-	 * @internal — when omitted, `runCommand()` creates empty buffers for the
-	 * returned {@linkcode RunResult} while writing directly to the provided `out`.
-	 */
-	readonly captured?: CapturedOutput;
-
-	/**
 	 * Help formatting options (width, binName).
 	 * Used when `--help` is detected.
 	 */
@@ -153,6 +137,31 @@ export interface RunOptions {
 	 * @defaultValue `{ caseParity: true }`
 	 */
 	readonly flags?: ParseOptions;
+}
+
+/**
+ * Execution options threaded between the CLI dispatch layer, the shared
+ * executor, and the testkit. Extends the public {@linkcode RunOptions} with
+ * fields the framework populates itself.
+ *
+ * @internal
+ */
+export interface InternalRunOptions extends RunOptions {
+	/**
+	 * Output channel override used by live CLI execution.
+	 *
+	 * `CLIBuilder.run()` passes a real output channel so activity renders to
+	 * the terminal instead of being captured.
+	 */
+	readonly out?: Out;
+
+	/**
+	 * Capture buffers override paired with `out`.
+	 *
+	 * When omitted, `runCommand()` creates empty buffers for the returned
+	 * {@linkcode RunResult} while writing directly to the provided `out`.
+	 */
+	readonly captured?: CapturedOutput;
 
 	/**
 	 * Command schema with propagated flags merged in.
@@ -160,8 +169,6 @@ export interface RunOptions {
 	 * When provided, used for parsing and resolution instead of `cmd.schema`.
 	 * Set by the CLI dispatch layer after collecting propagated flags from
 	 * the command ancestry path.
-	 *
-	 * @internal — set by dispatch layer, not for public use.
 	 */
 	readonly mergedSchema?: CommandSchema;
 
@@ -171,16 +178,10 @@ export interface RunOptions {
 	 * When provided (by CLI dispatch layer), handlers receive this as `meta`.
 	 * When absent (standalone `runCommand()`), a minimal meta is constructed
 	 * from the command's own schema.
-	 *
-	 * @internal — populated by CLI dispatch, not for public use.
 	 */
 	readonly meta?: CommandMeta;
 
-	/**
-	 * CLI plugins registered on the parent `CLIBuilder`.
-	 *
-	 * @internal — threaded through from CLI dispatch.
-	 */
+	/** CLI plugins registered on the parent `CLIBuilder`. */
 	readonly plugins?: readonly CLIPlugin[];
 }
 

--- a/src/core/testkit/executor-contract.test.ts
+++ b/src/core/testkit/executor-contract.test.ts
@@ -12,7 +12,7 @@ import { createCaptureOutput } from '#internals/core/output/index.ts';
 import { arg } from '#internals/core/schema/arg.ts';
 import { command } from '#internals/core/schema/command.ts';
 import { middleware } from '#internals/core/schema/middleware.ts';
-import { runCommand } from './index.ts';
+import { runCommand, runCommandInternal } from './index.ts';
 
 describe('runCommand() executor contract', () => {
 	it('runs lifecycle hooks around execution steps in stable order', async () => {
@@ -35,7 +35,7 @@ describe('runCommand() executor contract', () => {
 				order.push('action');
 			});
 
-		const result = await runCommand(cmd, [], {
+		const result = await runCommandInternal(cmd, [], {
 			plugins: [
 				plugin({
 					beforeParse: () => {
@@ -80,7 +80,7 @@ describe('runCommand() executor contract', () => {
 				throw new CLIError('boom', { code: 'BOOM', exitCode: 9 });
 			});
 
-		const result = await runCommand(cmd, [], {
+		const result = await runCommandInternal(cmd, [], {
 			plugins: [
 				plugin({
 					beforeAction: () => {
@@ -109,7 +109,7 @@ describe('runCommand() executor contract', () => {
 			spinner.succeed('Done');
 		});
 
-		const result = await runCommand(cmd, [], { out, captured });
+		const result = await runCommandInternal(cmd, [], { out, captured });
 
 		expect(result.exitCode).toBe(0);
 		expect(result.stdout).toEqual(['hello\n']);
@@ -131,7 +131,7 @@ describe('runCommand() executor contract', () => {
 			throw new Error('kaboom');
 		});
 
-		const result = await runCommand(cmd, [], { out, captured });
+		const result = await runCommandInternal(cmd, [], { out, captured });
 
 		expect(result.exitCode).toBe(1);
 		expect(result.error?.code).toBe('UNEXPECTED_ERROR');
@@ -147,7 +147,7 @@ describe('runCommand() executor contract', () => {
 			.description('Build assets')
 			.action(() => {});
 
-		const result = await runCommand(cmd, ['--help'], { out, captured });
+		const result = await runCommandInternal(cmd, ['--help'], { out, captured });
 
 		expect(result.exitCode).toBe(0);
 		expect(stopActive).toHaveBeenCalledTimes(1);
@@ -187,7 +187,7 @@ describe('runCommand() executor contract', () => {
 
 		const cmd = command('build');
 
-		const result = await runCommand(cmd, [], { out, captured });
+		const result = await runCommandInternal(cmd, [], { out, captured });
 
 		expect(result.exitCode).toBe(1);
 		expect(result.error?.code).toBe('NO_ACTION');
@@ -213,7 +213,7 @@ describe('runCommand() executor contract', () => {
 			out.setExitCode(3);
 		});
 
-		const result = await runCommand(cmd, [], {
+		const result = await runCommandInternal(cmd, [], {
 			plugins: [
 				plugin({
 					afterAction: ({ out }) => {
@@ -236,8 +236,8 @@ describe('runCommand() executor contract', () => {
 			out.log('ok');
 		});
 
-		const first = await runCommand(failingStatus, [], { out, captured });
-		const second = await runCommand(healthyStatus, [], { out, captured });
+		const first = await runCommandInternal(failingStatus, [], { out, captured });
+		const second = await runCommandInternal(healthyStatus, [], { out, captured });
 
 		expect(first.exitCode).toBe(5);
 		expect(second.exitCode).toBe(0);

--- a/src/core/testkit/index.ts
+++ b/src/core/testkit/index.ts
@@ -19,7 +19,7 @@ import type { CapturedOutput, Verbosity } from '#internals/core/output/index.ts'
 import { createCaptureOutput } from '#internals/core/output/index.ts';
 import { includesBeforeSeparator, stripBeforeSeparator } from '#internals/core/parse/index.ts';
 import type { CommandMeta, Out, RunnableCommand } from '#internals/core/schema/command.ts';
-import type { RunOptions, RunResult } from '#internals/core/schema/run.ts';
+import type { InternalRunOptions, RunOptions, RunResult } from '#internals/core/schema/run.ts';
 
 // RunOptions and RunResult are defined in schema/run.ts so the execution
 // contract is shared by schema, CLI dispatch, and testkit. Re-exported here
@@ -54,6 +54,20 @@ async function runCommand(
 	cmd: RunnableCommand,
 	argv: readonly string[],
 	options?: RunOptions,
+): Promise<RunResult> {
+	return runCommandInternal(cmd, argv, options);
+}
+
+/**
+ * Execution body shared by {@linkcode runCommand} and `ErasedCommand._execute`,
+ * accepting the framework-populated channel, capture, schema, and meta fields.
+ *
+ * @internal
+ */
+async function runCommandInternal(
+	cmd: RunnableCommand,
+	argv: readonly string[],
+	options?: InternalRunOptions,
 ): Promise<RunResult> {
 	// Root-flag layer mirroring `CLIBuilder.execute()`: `--json` is owned by the
 	// CLI root, not the command schema, so it would otherwise reach `parse()` as
@@ -99,7 +113,7 @@ async function runCommand(
 
 	// Thread the effective JSON mode into the executor so its error path renders
 	// structured JSON, matching dispatch where the planner sets `options.jsonMode`.
-	const effectiveOptions: RunOptions | undefined =
+	const effectiveOptions: InternalRunOptions | undefined =
 		options !== undefined
 			? { ...options, ...(jsonMode ? { jsonMode } : {}) }
 			: jsonMode
@@ -152,4 +166,4 @@ async function runCommand(
  */
 export type { RunOptions, RunResult };
 
-export { runCommand };
+export { runCommand, runCommandInternal };

--- a/src/core/testkit/testkit-nesting.test.ts
+++ b/src/core/testkit/testkit-nesting.test.ts
@@ -12,7 +12,7 @@ import { arg } from '#internals/core/schema/arg.ts';
 import { command, group } from '#internals/core/schema/command.ts';
 import { flag } from '#internals/core/schema/flag.ts';
 import { middleware } from '#internals/core/schema/middleware.ts';
-import { runCommand } from './index.ts';
+import { runCommand, runCommandInternal } from './index.ts';
 
 // === Helpers
 
@@ -73,7 +73,7 @@ describe('runCommand', () => {
 				},
 			};
 
-			const result = await runCommand(cmd, ['--verbose'], { mergedSchema });
+			const result = await runCommandInternal(cmd, ['--verbose'], { mergedSchema });
 			expect(result.exitCode).toBe(0);
 			expect(result.stdout).toEqual(['verbose=true\n']);
 		});
@@ -93,7 +93,7 @@ describe('runCommand', () => {
 				},
 			};
 
-			const result = await runCommand(cmd, [], { mergedSchema });
+			const result = await runCommandInternal(cmd, [], { mergedSchema });
 			expect(result.exitCode).toBe(0);
 			expect(result.stdout).toEqual(['verbose=false\n']);
 		});
@@ -116,7 +116,7 @@ describe('runCommand', () => {
 				},
 			};
 
-			const result = await runCommand(cmd, ['--steps', '5', '--verbose'], { mergedSchema });
+			const result = await runCommandInternal(cmd, ['--steps', '5', '--verbose'], { mergedSchema });
 			expect(result.exitCode).toBe(0);
 			expect(result.stdout).toEqual(['steps=5 verbose=true\n']);
 		});
@@ -135,7 +135,7 @@ describe('runCommand', () => {
 				},
 			};
 
-			const result = await runCommand(cmd, ['--help'], { mergedSchema });
+			const result = await runCommandInternal(cmd, ['--help'], { mergedSchema });
 			expect(result.exitCode).toBe(0);
 			const output = result.stdout.join('');
 			expect(output).toContain('--verbose');

--- a/src/core/testkit/testkit-prompt.test.ts
+++ b/src/core/testkit/testkit-prompt.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CLIRunOptions } from '#internals/core/cli/index.ts';
 import { cli } from '#internals/core/cli/index.ts';
+import { createCaptureOutput } from '#internals/core/output/index.ts';
 import { createTestPrompter, PROMPT_CANCEL } from '#internals/core/prompt/index.ts';
 import { arg } from '#internals/core/schema/arg.ts';
 import { command } from '#internals/core/schema/command.ts';
@@ -658,9 +659,24 @@ describe('public surface exports', () => {
 			// @ts-expect-error — `mergedSchema` is internal to CLI dispatch
 			mergedSchema: command('check').schema,
 		} satisfies CLIRunOptions;
+		const invalidOut = {
+			// @ts-expect-error — `out` is internal to `.run()`'s live-channel wiring
+			out: createCaptureOutput()[0],
+		} satisfies CLIRunOptions;
+		const invalidCaptured = {
+			// @ts-expect-error — `captured` is internal to `.run()`'s live-channel wiring
+			captured: { stdout: [], stderr: [], activity: [] },
+		} satisfies CLIRunOptions;
+		const invalidPlugins = {
+			// @ts-expect-error — `plugins` is threaded from the builder, not CLI input
+			plugins: [],
+		} satisfies CLIRunOptions;
 
 		void invalidMeta;
 		void invalidMergedSchema;
+		void invalidOut;
+		void invalidCaptured;
+		void invalidPlugins;
 
 		expect(true).toBe(true);
 	});

--- a/src/core/testkit/testkit.test.ts
+++ b/src/core/testkit/testkit.test.ts
@@ -8,7 +8,7 @@ import { arg } from '#internals/core/schema/arg.ts';
 import type { CommandMeta } from '#internals/core/schema/command.ts';
 import { command } from '#internals/core/schema/command.ts';
 import { flag } from '#internals/core/schema/flag.ts';
-import { runCommand } from './index.ts';
+import { runCommand, runCommandInternal } from './index.ts';
 
 // --- Helpers
 
@@ -526,7 +526,7 @@ describe('runCommand', () => {
 				version: '2.0.0',
 				command: 'deploy',
 			};
-			await runCommand(cmd, [], { meta: explicit });
+			await runCommandInternal(cmd, [], { meta: explicit });
 
 			expect(handler).toHaveBeenCalledOnce();
 			const firstCall = handler.mock.calls[0];


### PR DESCRIPTION
Breaking, targets v4. Stacked on #95.

- `Out` and `RenderContext` carry private `unique symbol` brands: structurally constructing or implementing them outside the framework no longer type-checks. Both are declared framework-created and non-exhaustive; new readonly members become minor-legal under the policy in #97. Emit validated: attw and publint clean, brand unreachable through the exports map.
- `out`, `captured`, `mergedSchema`, `meta`, and `plugins` leave the public `RunOptions`/`CLIRunOptions` for internal execution-option types (`InternalRunOptions`, `InternalCLIRunOptions`) threaded through `runCommandInternal` and `CLIBuilder._execute` — the underscore-internal convention `ErasedCommand._execute` already uses.
- In-repo tests exercising those seams migrate to the internal entry points; the hand-rolled `Out` mock becomes `createCaptureOutput()`.
- Changelog reframes the required `Out.verbosity` from #95 as an explicit breaking change with the spyOn migration recipe.