### PR TITLE
feat(schema)!: remove the write-only `CommandSchema.middleware` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Breaking: `CommandSchema.middleware` removed** — the executor builds the
+  handler chain from the builder's ordered execution steps, so registration
+  order, handler identity, and runtime behavior are unchanged.
+  `CommandDefinition` no longer accepts a `middleware` key, and
+  `createCommandSchema()` no longer emits one.
+
 - **Breaking: `FlagSchema`, `ArgSchema`, and `CommandSchema` are sealed** — all
   three carry a private brand, so an object literal assembled by hand no longer
   type-checks where a schema is expected. Call `createFlagSchema()`,

--- a/dreamcli.schema.json
+++ b/dreamcli.schema.json
@@ -97,7 +97,7 @@
         "args",
         "commands"
       ],
-      "description": "Runtime descriptor produced by CommandBuilder.\n\nConsumers (parser, help generator, CLI dispatcher) read this to\nunderstand the command's shape — flags, args, aliases, subcommands,\nmiddleware, and interactive resolver."
+      "description": "Runtime descriptor produced by CommandBuilder.\n\nConsumers (parser, help generator, CLI dispatcher) read this to\nunderstand the command's shape — flags, args, aliases, subcommands,\nand interactive resolver."
     },
     "flag": {
       "type": "object",

--- a/src/core/json-schema/AGENTS.md
+++ b/src/core/json-schema/AGENTS.md
@@ -25,8 +25,8 @@ output.
 
 ## CONVENTIONS
 
-- Output must stay JSON-serializable; runtime handlers, middleware, and interactive functions are
-  omitted by design
+- Output must stay JSON-serializable; runtime handlers and interactive functions are omitted by
+  design
 - `includeHidden` and `includePrompts` are the public switches; preserve their semantics across
   both schema generators
 - `@internal` JSDoc tags matter: docs and meta-description tooling filter on them

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -111,8 +111,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  *
  * Walks the full command tree and produces a plain JSON-serializable object
  * representing all commands, subcommands, flags, args, and metadata.
- * Non-serializable runtime values (parse functions, middleware handlers,
- * interactive resolvers) are omitted.
+ * Non-serializable runtime values (parse functions, interactive resolvers)
+ * are omitted.
  *
  * @param schema - The CLI schema from `CLIBuilder.schema`.
  * @param options - Generation options.
@@ -547,11 +547,11 @@ function generateInputSchema(
  * Discriminate between CLISchema and CommandSchema at runtime.
  *
  * Use a command-only field combination rather than a single shape check:
- * command schemas always carry flags, args, middleware, and hasAction, while
- * the CLI root schema does not expose that execution surface.
+ * command schemas always carry flags, args, and hasAction, while the CLI root
+ * schema does not expose that execution surface.
  */
 function isCommandSchema(schema: CLISchema | CommandSchema): schema is CommandSchema {
-	return 'flags' in schema && 'args' in schema && 'middleware' in schema && 'hasAction' in schema;
+	return 'flags' in schema && 'args' in schema && 'hasAction' in schema;
 }
 
 /** Recursively collect input schema branches for all invocable commands. */

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -709,20 +709,18 @@ describe('generateSchema — definition metadata', () => {
 	// Non-serializable fields omitted
 	// -------------------------------------------------------------------
 
-	it('omits parseFn, interactive, middleware from output', () => {
+	it('omits parseFn and interactive from output', () => {
 		const cmd = commandDef({
 			name: 'test',
 			flags: {
 				custom: flagDef({ kind: 'custom', parseFn: (v) => String(v) }),
 			},
 			interactive: () => ({}),
-			middleware: [() => Promise.resolve()],
 		});
 		const result = generateSchema(minimalCLI({ commands: [erased(cmd)] }));
 		const output = JSON.stringify(result);
 		expect(output).not.toContain('parseFn');
 		expect(output).not.toContain('interactive');
-		expect(output).not.toContain('middleware');
 		expect(output).not.toContain('_execute');
 		expect(output).not.toContain('hasAction');
 	});

--- a/src/core/json-schema/meta-descriptions.generated.ts
+++ b/src/core/json-schema/meta-descriptions.generated.ts
@@ -30,7 +30,7 @@ const definitionMetaSchemaDescriptions = {
 	defs: {
 		command: {
 			description:
-				"Runtime descriptor produced by CommandBuilder.\n\nConsumers (parser, help generator, CLI dispatcher) read this to\nunderstand the command's shape — flags, args, aliases, subcommands,\nmiddleware, and interactive resolver.",
+				"Runtime descriptor produced by CommandBuilder.\n\nConsumers (parser, help generator, CLI dispatcher) read this to\nunderstand the command's shape — flags, args, aliases, subcommands,\nand interactive resolver.",
 			properties: {
 				name: {
 					description: "The command name (used for dispatch, e.g. `'deploy'`).",

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -527,7 +527,7 @@ function resolveExampleCommand(command: ExampleCommand, meta: ExampleMeta): stri
  *
  * Consumers (parser, help generator, CLI dispatcher) read this to
  * understand the command's shape — flags, args, aliases, subcommands,
- * middleware, and interactive resolver.
+ * and interactive resolver.
  */
 interface CommandSchema {
 	/** Type-only seal produced by {@link createCommandSchema}. */
@@ -559,15 +559,6 @@ interface CommandSchema {
 	 * @see InteractiveResolver
 	 */
 	readonly interactive: ErasedInteractiveResolver | undefined;
-	/**
-	 * Middleware handlers to run before the action handler.
-	 *
-	 * Executed in registration order — first middleware registered runs
-	 * first and calls `next()` to proceed to subsequent middleware,
-	 * ending with the action handler. Context accumulates via intersection
-	 * at the type level and via object spread at runtime.
-	 */
-	readonly middleware: readonly ErasedMiddlewareHandler[];
 	/**
 	 * Nested subcommand schemas (for help rendering and completion).
 	 *
@@ -652,11 +643,6 @@ interface CommandDefinition {
 	 */
 	readonly interactive?: ErasedInteractiveResolver | undefined;
 	/**
-	 * Middleware handlers to run before the action handler, in registration order.
-	 * @defaultValue `[]`
-	 */
-	readonly middleware?: readonly ErasedMiddlewareHandler[] | undefined;
-	/**
 	 * Nested subcommand definitions or built schemas.
 	 * @defaultValue `[]`
 	 */
@@ -704,7 +690,6 @@ function buildCommandSchema(definition: CommandDefinition): CommandSchema {
 		args,
 		hasAction: definition.hasAction ?? false,
 		interactive: definition.interactive,
-		middleware: definition.middleware ?? [],
 		commands: (definition.commands ?? []).map((child) => buildCommandSchema(child)),
 	};
 
@@ -1096,11 +1081,9 @@ class CommandBuilder<
 	readonly _subcommands: readonly AnyCommandBuilder[];
 
 	/**
-	 * @internal Execution steps in registration order.
+	 * @internal Derive and middleware steps in registration order.
 	 *
-	 * Distinct from `schema.middleware`: middleware handlers remain in schema
-	 * for backward compatibility, while derives stay command-local and builder-
-	 * scoped so future shared/global middleware can compose cleanly.
+	 * The executor builds the handler chain from this list.
 	 */
 	readonly _executionSteps: readonly ExecutionStep[];
 
@@ -1301,7 +1284,6 @@ class CommandBuilder<
 		return new CommandBuilder(
 			{
 				...this.schema,
-				middleware: [...this.schema.middleware, m._handler],
 				hasAction: false,
 			},
 			// Handler intentionally dropped — C changed, invalidating handler signature.

--- a/src/core/schema/derive.test.ts
+++ b/src/core/schema/derive.test.ts
@@ -88,9 +88,10 @@ describe('CommandBuilder.derive()', () => {
 	// --- runtime
 
 	describe('runtime', () => {
-		it('does not add handlers to schema.middleware', () => {
+		it('records a derive execution step, not a middleware one', () => {
 			const cmd = command('deploy').derive(() => ({ token: 'abc' }));
-			expect(cmd.schema.middleware).toEqual([]);
+			expect(cmd._executionSteps).toHaveLength(1);
+			expect(cmd._executionSteps[0]?.kind).toBe('derive');
 		});
 
 		it('drops handler when derive added', () => {

--- a/src/core/schema/middleware.test.ts
+++ b/src/core/schema/middleware.test.ts
@@ -71,19 +71,20 @@ describe('CommandBuilder.middleware()', () => {
 	// --- runtime
 
 	describe('runtime', () => {
-		it('adds middleware handler to schema', () => {
+		it('adds a middleware execution step', () => {
 			const m = middleware(async ({ next }) => next({}));
 			const cmd = command('test').middleware(m);
-			expect(cmd.schema.middleware).toHaveLength(1);
+			expect(cmd._executionSteps).toEqual([{ kind: 'middleware', handler: m._handler }]);
 		});
 
 		it('accumulates multiple middleware in order', () => {
 			const first = middleware(async ({ next }) => next({ a: 1 }));
 			const second = middleware(async ({ next }) => next({ b: 2 }));
 			const cmd = command('test').middleware(first).middleware(second);
-			expect(cmd.schema.middleware).toHaveLength(2);
-			expect(cmd.schema.middleware[0]).toBe(first._handler);
-			expect(cmd.schema.middleware[1]).toBe(second._handler);
+			expect(cmd._executionSteps).toEqual([
+				{ kind: 'middleware', handler: first._handler },
+				{ kind: 'middleware', handler: second._handler },
+			]);
 		});
 
 		it('returns a new builder (immutability)', () => {
@@ -91,7 +92,7 @@ describe('CommandBuilder.middleware()', () => {
 			const a = command('test');
 			const b = a.middleware(m);
 			expect(a).not.toBe(b);
-			expect(a.schema.middleware).toEqual([]);
+			expect(a._executionSteps).toEqual([]);
 		});
 
 		it('drops handler when middleware added (type safety)', () => {
@@ -119,9 +120,26 @@ describe('CommandBuilder.middleware()', () => {
 			expect(cmd.schema.flags.force).toBeDefined();
 		});
 
-		it('empty middleware array by default', () => {
+		it('keeps the execution step across every later builder call', () => {
+			const m = middleware(async ({ next }) => next({}));
+			const cmd = command('deploy')
+				.middleware(m)
+				.description('Deploy')
+				.alias('d')
+				.hidden()
+				.example('deploy prod')
+				.flag('force', flag.boolean())
+				.arg('target', arg.string())
+				.command(command('status'))
+				.interactive(() => ({}))
+				.action(() => {});
+
+			expect(cmd._executionSteps).toEqual([{ kind: 'middleware', handler: m._handler }]);
+		});
+
+		it('no execution steps by default', () => {
 			const cmd = command('test');
-			expect(cmd.schema.middleware).toEqual([]);
+			expect(cmd._executionSteps).toEqual([]);
 		});
 	});
 

--- a/src/core/schema/middleware.ts
+++ b/src/core/schema/middleware.ts
@@ -49,7 +49,7 @@ interface MiddlewareParams {
 // --- Handler types
 
 /**
- * Type-erased middleware handler stored on `CommandSchema`.
+ * Type-erased middleware handler stored on the command builder.
  *
  * At runtime, all middleware handlers have this signature. The phantom
  * `Output` type on {@linkcode Middleware} is erased.

--- a/src/core/schema/schema-sealing.test.ts
+++ b/src/core/schema/schema-sealing.test.ts
@@ -3,11 +3,10 @@ import { CLIError } from '#internals/core/errors/index.ts';
 import type { ArgSchema } from './arg.ts';
 import { createArgSchema } from './arg.ts';
 import type { schemaBrand } from './brand.ts';
-import type { CommandSchema } from './command.ts';
+import type { CommandSchema, ErasedInteractiveResolver } from './command.ts';
 import { createCommandSchema } from './command.ts';
 import type { FlagSchema } from './flag.ts';
 import { createFlagSchema } from './flag.ts';
-import type { ErasedMiddlewareHandler } from './middleware.ts';
 
 /** {@link FlagSchema} with the type-only brand removed. */
 type UnbrandedFlagSchema = Omit<FlagSchema, typeof schemaBrand>;
@@ -68,7 +67,6 @@ const spelledCommandFields: UnbrandedCommandSchema = {
 	args: [],
 	hasAction: false,
 	interactive: undefined,
-	middleware: [],
 	commands: [],
 };
 
@@ -182,15 +180,16 @@ describe('schema sealing', () => {
 			expect(createCommandSchema(built)).toEqual(built);
 		});
 
-		it('rebuilds a deep-equal command schema carrying middleware', () => {
-			const handler: ErasedMiddlewareHandler = ({ next }) => next({});
+		it('rebuilds a deep-equal command schema carrying nested commands and interactive', () => {
+			const resolver: ErasedInteractiveResolver = () => ({});
 			const built = createCommandSchema({
 				name: 'deploy',
-				middleware: [handler],
-				commands: [{ name: 'status', middleware: [handler] }],
+				interactive: resolver,
+				commands: [{ name: 'status', interactive: resolver }],
 			});
 
-			expect(built.middleware).toEqual([handler]);
+			expect(built.interactive).toBe(resolver);
+			expect(built.commands[0]?.interactive).toBe(resolver);
 			expect(createCommandSchema(built)).toEqual(built);
 		});
 


### PR DESCRIPTION
Breaking, targets v4. Stacked on #99. Implements L2 of the approved v4 plan.

- `CommandSchema.middleware` and `CommandDefinition.middleware` removed. `CommandBuilder.middleware()` wrote handlers into the schema, but the executor has always read `_executionSteps` (derives and middleware interleave in registration order) — the schema copy was write-only weight.
- `isCommandSchema()` discriminates on `flags`/`args`/`hasAction`; verified disjoint from `CLISchema`'s key set.
- Middleware tests moved to the execution-step array: order + handler identity via `toEqual`, plus a new test pinning step survival across every later builder call (previously untested threading).
- Review pass caught and fixed: a stale generated definition-schema artifact (implementer claimed a regeneration that hadn't happened), three stale TSDoc claims, and a changelog bullet that contradicted the sniff's old middleware-key read.

Gates: typecheck, lint, fmt, 2959/2959 tests, build (attw+publint), docs build, meta-descriptions all green.
