### PR TITLE
refactor(schema)!: complete the `createFlagSchema` rename, drop the alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   type-checks where a schema is expected. Call `createFlagSchema()`,
   `createArgSchema()`, or `createCommandSchema()` with a definition object to
   obtain one; spreading a built schema keeps the brand, so
-  `{ ...schema, description }` still type-checks. `createSchema()` is deprecated
-  in favor of `createFlagSchema()` and keeps working for now.
+  `{ ...schema, description }` still type-checks. `createSchema()` was renamed
+  to `createFlagSchema()`, which validates its fields against the kind and
+  normalizes a nested `elementSchema`.
 
 - **Breaking: `CLISchema` and `ConfigSettings` are sealed** — both carry a
   private brand, so an object literal assembled by hand no longer type-checks

--- a/src/core/cli/cli-propagate.test.ts
+++ b/src/core/cli/cli-propagate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
-import { createSchema } from '#internals/core/schema/flag.ts';
+import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import { collectPropagatedFlags } from './propagate.ts';
 
 // --- Helpers — build minimal CommandSchema for testing
@@ -14,11 +14,11 @@ function makeSchema(overrides: Partial<CommandSchema> = {}): CommandSchema {
 }
 
 function propagatedFlag(kind: 'string' | 'boolean' | 'number' = 'boolean') {
-	return createSchema(kind, { propagate: true });
+	return createFlagSchema(kind, { propagate: true });
 }
 
 function localFlag(kind: 'string' | 'boolean' | 'number' = 'boolean') {
-	return createSchema(kind, { propagate: false });
+	return createFlagSchema(kind, { propagate: false });
 }
 
 // === collectPropagatedFlags

--- a/src/core/completion/completion.test.ts
+++ b/src/core/completion/completion.test.ts
@@ -39,7 +39,8 @@ type FlagDefOverrides = {
 
 /** Minimal FlagSchema with all required fields. */
 function flagSchema(overrides: FlagDefOverrides = {}): FlagSchema {
-	return createFlagSchema(overrides.kind ?? 'string', overrides);
+	const { kind = 'string', ...definition } = overrides;
+	return createFlagSchema(kind, definition);
 }
 
 /** Minimal CommandSchema with all required fields. */

--- a/src/core/completion/completion.test.ts
+++ b/src/core/completion/completion.test.ts
@@ -9,8 +9,9 @@ import { createCommandSchema } from '#internals/core/schema/command.ts';
 import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import type {
 	CommandSchema,
+	FlagDefinitionOverrides,
+	FlagKind,
 	FlagSchema,
-	FlagSchemaOverrides,
 } from '#internals/core/schema/index.ts';
 import {
 	extractBashRootWords,
@@ -31,8 +32,13 @@ import {
 
 // === Test helpers
 
+/** Definition fields for any flag kind, with the kind discriminator optional. */
+type FlagDefOverrides = {
+	[K in FlagKind]: FlagDefinitionOverrides<K> & { readonly kind?: K };
+}[FlagKind];
+
 /** Minimal FlagSchema with all required fields. */
-function flagSchema(overrides: FlagSchemaOverrides = {}): FlagSchema {
+function flagSchema(overrides: FlagDefOverrides = {}): FlagSchema {
 	return createFlagSchema(overrides.kind ?? 'string', overrides);
 }
 

--- a/src/core/help/help.test.ts
+++ b/src/core/help/help.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 
 import { arg, createArgSchema } from '#internals/core/schema/arg.ts';
 import { command } from '#internals/core/schema/command.ts';
-import { createSchema, flag } from '#internals/core/schema/flag.ts';
+import { createFlagSchema, flag } from '#internals/core/schema/flag.ts';
 
 import { formatHelp } from './index.ts';
 
@@ -304,7 +304,7 @@ describe('formatHelp', () => {
 			const nullHelp = formatHelp({
 				...base.schema,
 				flags: {
-					token: createSchema('string', {
+					token: createFlagSchema('string', {
 						presence: 'defaulted',
 						defaultValue: null,
 						description: 'Token',
@@ -314,7 +314,7 @@ describe('formatHelp', () => {
 			const undefinedHelp = formatHelp({
 				...base.schema,
 				flags: {
-					token: createSchema('string', {
+					token: createFlagSchema('string', {
 						presence: 'defaulted',
 						defaultValue: undefined,
 						description: 'Token',

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -11,15 +11,21 @@ import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import type {
 	CommandArgEntry,
 	CommandSchema,
+	FlagDefinitionOverrides,
+	FlagKind,
 	FlagSchema,
-	FlagSchemaOverrides,
 } from '#internals/core/schema/index.ts';
 import { definitionMetaSchema, generateInputSchema, generateSchema } from './index.ts';
 
 // === Test helpers
 
+/** Definition fields for any flag kind, with the kind discriminator optional. */
+type FlagDefOverrides = {
+	[K in FlagKind]: FlagDefinitionOverrides<K> & { readonly kind?: K };
+}[FlagKind];
+
 /** Minimal FlagSchema with all required fields. */
-function flagDef(overrides: FlagSchemaOverrides = {}): FlagSchema {
+function flagDef(overrides: FlagDefOverrides = {}): FlagSchema {
 	return createFlagSchema(overrides.kind ?? 'string', overrides);
 }
 

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -26,7 +26,8 @@ type FlagDefOverrides = {
 
 /** Minimal FlagSchema with all required fields. */
 function flagDef(overrides: FlagDefOverrides = {}): FlagSchema {
-	return createFlagSchema(overrides.kind ?? 'string', overrides);
+	const { kind = 'string', ...definition } = overrides;
+	return createFlagSchema(kind, definition);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/core/parse/parse.test.ts
+++ b/src/core/parse/parse.test.ts
@@ -4,8 +4,8 @@ import type { ArgDefinitionOverrides, ArgSchema } from '#internals/core/schema/a
 import { createArgSchema } from '#internals/core/schema/arg.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
-import type { FlagSchema } from '#internals/core/schema/flag.ts';
-import { createSchema } from '#internals/core/schema/flag.ts';
+import type { FlagDefinitionOverrides, FlagSchema } from '#internals/core/schema/flag.ts';
+import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import { includesBeforeSeparator, parse, tokenize } from './index.ts';
 
 // --- Helpers — build minimal CommandSchema for testing
@@ -91,7 +91,7 @@ describe('parse', () => {
 		it('parses long boolean flag', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			const result = parse(schema, ['--verbose']);
@@ -101,7 +101,7 @@ describe('parse', () => {
 		it('parses long boolean flag with explicit =true', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			const result = parse(schema, ['--verbose=true']);
@@ -111,7 +111,7 @@ describe('parse', () => {
 		it('parses long boolean flag with explicit =false', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			const result = parse(schema, ['--verbose=false']);
@@ -120,7 +120,7 @@ describe('parse', () => {
 
 		it('parses long string flag with space-separated value', () => {
 			const schema = makeSchema({
-				flags: { name: createSchema('string') },
+				flags: { name: createFlagSchema('string') },
 			});
 			const result = parse(schema, ['--name', 'alice']);
 			expect(result.flags.name).toBe('alice');
@@ -128,7 +128,7 @@ describe('parse', () => {
 
 		it('parses long string flag with inline value', () => {
 			const schema = makeSchema({
-				flags: { name: createSchema('string') },
+				flags: { name: createFlagSchema('string') },
 			});
 			const result = parse(schema, ['--name=bob']);
 			expect(result.flags.name).toBe('bob');
@@ -136,7 +136,7 @@ describe('parse', () => {
 
 		it('parses long number flag', () => {
 			const schema = makeSchema({
-				flags: { port: createSchema('number') },
+				flags: { port: createFlagSchema('number') },
 			});
 			const result = parse(schema, ['--port', '3000']);
 			expect(result.flags.port).toBe(3000);
@@ -144,7 +144,7 @@ describe('parse', () => {
 
 		it('parses long number flag with inline value', () => {
 			const schema = makeSchema({
-				flags: { port: createSchema('number') },
+				flags: { port: createFlagSchema('number') },
 			});
 			const result = parse(schema, ['--port=8080']);
 			expect(result.flags.port).toBe(8080);
@@ -152,7 +152,7 @@ describe('parse', () => {
 
 		it('parses enum flag with valid value', () => {
 			const schema = makeSchema({
-				flags: { region: createSchema('enum', { enumValues: ['us', 'eu', 'ap'] }) },
+				flags: { region: createFlagSchema('enum', { enumValues: ['us', 'eu', 'ap'] }) },
 			});
 			const result = parse(schema, ['--region', 'eu']);
 			expect(result.flags.region).toBe('eu');
@@ -161,8 +161,8 @@ describe('parse', () => {
 		it('parses array flag — multiple occurrences accumulate', () => {
 			const schema = makeSchema({
 				flags: {
-					tag: createSchema('array', {
-						elementSchema: createSchema('string'),
+					tag: createFlagSchema('array', {
+						elementSchema: createFlagSchema('string'),
 					}),
 				},
 			});
@@ -173,8 +173,8 @@ describe('parse', () => {
 		it('parses array flag with number elements', () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('array', {
-						elementSchema: createSchema('number'),
+					port: createFlagSchema('array', {
+						elementSchema: createFlagSchema('number'),
 					}),
 				},
 			});
@@ -185,7 +185,7 @@ describe('parse', () => {
 		it('resolves flag by alias', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', {
+					verbose: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['v'],
@@ -199,7 +199,7 @@ describe('parse', () => {
 		it('resolves flag by long alias', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', {
+					verbose: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['verb'],
@@ -213,7 +213,7 @@ describe('parse', () => {
 		it('resolves hidden long alias to the canonical key', () => {
 			const schema = makeSchema({
 				flags: {
-					'skip-pass': createSchema('boolean', {
+					'skip-pass': createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: [{ name: 'skipPass', hidden: true }],
@@ -227,7 +227,7 @@ describe('parse', () => {
 		it('no flags supplied returns empty flags object', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			const result = parse(schema, []);
@@ -241,7 +241,7 @@ describe('parse', () => {
 		it('single short boolean flag', () => {
 			const schema = makeSchema({
 				flags: {
-					force: createSchema('boolean', {
+					force: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['f'],
@@ -255,17 +255,17 @@ describe('parse', () => {
 		it('combined short boolean flags -abc', () => {
 			const schema = makeSchema({
 				flags: {
-					all: createSchema('boolean', {
+					all: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['a'],
 					}),
-					brief: createSchema('boolean', {
+					brief: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['b'],
 					}),
-					color: createSchema('boolean', {
+					color: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['c'],
@@ -280,7 +280,7 @@ describe('parse', () => {
 
 		it('short flag with value as next arg', () => {
 			const schema = makeSchema({
-				flags: { output: createSchema('string', { aliases: ['o'] }) },
+				flags: { output: createFlagSchema('string', { aliases: ['o'] }) },
 			});
 			const result = parse(schema, ['-o', 'file.txt']);
 			expect(result.flags.output).toBe('file.txt');
@@ -288,7 +288,7 @@ describe('parse', () => {
 
 		it('short flag with inline value -oFile', () => {
 			const schema = makeSchema({
-				flags: { output: createSchema('string', { aliases: ['o'] }) },
+				flags: { output: createFlagSchema('string', { aliases: ['o'] }) },
 			});
 			const result = parse(schema, ['-ofile.txt']);
 			expect(result.flags.output).toBe('file.txt');
@@ -297,12 +297,12 @@ describe('parse', () => {
 		it('combined short flags where last consumes value', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', {
+					verbose: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['v'],
 					}),
-					output: createSchema('string', { aliases: ['o'] }),
+					output: createFlagSchema('string', { aliases: ['o'] }),
 				},
 			});
 			const result = parse(schema, ['-vo', 'out.txt']);
@@ -313,8 +313,8 @@ describe('parse', () => {
 		it('combined short flags where middle flag consumes rest as value', () => {
 			const schema = makeSchema({
 				flags: {
-					output: createSchema('string', { aliases: ['o'] }),
-					verbose: createSchema('boolean', {
+					output: createFlagSchema('string', { aliases: ['o'] }),
+					verbose: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['v'],
@@ -464,12 +464,12 @@ describe('parse', () => {
 		it('flags and positionals interleaved', () => {
 			const schema = makeSchema({
 				flags: {
-					force: createSchema('boolean', {
+					force: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['f'],
 					}),
-					region: createSchema('string'),
+					region: createFlagSchema('string'),
 				},
 				args: [{ name: 'target', schema: createArgSchema('string') }],
 			});
@@ -482,7 +482,7 @@ describe('parse', () => {
 		it('separator (--) forces remaining as positionals', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 				args: [{ name: 'files', schema: createArgSchema('string', { variadic: true }) }],
 			});
@@ -515,7 +515,7 @@ describe('parse', () => {
 		it('unknown short flag in combined group throws', () => {
 			const schema = makeSchema({
 				flags: {
-					all: createSchema('boolean', {
+					all: createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: ['a'],
@@ -527,7 +527,7 @@ describe('parse', () => {
 
 		it('missing value for string flag throws MISSING_VALUE', () => {
 			const schema = makeSchema({
-				flags: { name: createSchema('string') },
+				flags: { name: createFlagSchema('string') },
 			});
 			expect(() => parse(schema, ['--name'])).toThrow(ParseError);
 			try {
@@ -540,7 +540,7 @@ describe('parse', () => {
 
 		it('missing value for short flag throws MISSING_VALUE', () => {
 			const schema = makeSchema({
-				flags: { output: createSchema('string', { aliases: ['o'] }) },
+				flags: { output: createFlagSchema('string', { aliases: ['o'] }) },
 			});
 			expect(() => parse(schema, ['-o'])).toThrow(ParseError);
 			try {
@@ -553,7 +553,7 @@ describe('parse', () => {
 
 		it('invalid number flag value throws INVALID_VALUE', () => {
 			const schema = makeSchema({
-				flags: { port: createSchema('number') },
+				flags: { port: createFlagSchema('number') },
 			});
 			expect(() => parse(schema, ['--port', 'abc'])).toThrow(ParseError);
 			try {
@@ -566,7 +566,7 @@ describe('parse', () => {
 
 		it('invalid enum flag value throws INVALID_VALUE', () => {
 			const schema = makeSchema({
-				flags: { region: createSchema('enum', { enumValues: ['us', 'eu'] }) },
+				flags: { region: createFlagSchema('enum', { enumValues: ['us', 'eu'] }) },
 			});
 			expect(() => parse(schema, ['--region', 'ap'])).toThrow(ParseError);
 			try {
@@ -580,7 +580,7 @@ describe('parse', () => {
 
 		it('malformed enum flag schema throws INVALID_SCHEMA', () => {
 			const malformed: FlagSchema = {
-				...createSchema('enum', { enumValues: ['us'] }),
+				...createFlagSchema('enum', { enumValues: ['us'] }),
 				enumValues: undefined,
 			};
 			const schema: CommandSchema = { ...makeSchema(), flags: { region: malformed } };
@@ -597,7 +597,7 @@ describe('parse', () => {
 		it('invalid boolean flag value throws INVALID_VALUE', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			expect(() => parse(schema, ['--verbose=maybe'])).toThrow(ParseError);
@@ -674,7 +674,7 @@ describe('parse', () => {
 		it('unknown flag includes "did you mean" suggestion for close match', () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			try {
@@ -689,7 +689,7 @@ describe('parse', () => {
 		it('unknown flag suggestions ignore hidden aliases', () => {
 			const schema = makeSchema({
 				flags: {
-					'skip-pass': createSchema('boolean', {
+					'skip-pass': createFlagSchema('boolean', {
 						presence: 'defaulted',
 						defaultValue: false,
 						aliases: [{ name: 'skipPass', hidden: true }],
@@ -723,7 +723,7 @@ describe('parse', () => {
 		it('custom flag invokes parseFn on the raw string', () => {
 			const schema = makeSchema({
 				flags: {
-					hex: createSchema('custom', {
+					hex: createFlagSchema('custom', {
 						parseFn: (raw: unknown) => Number.parseInt(String(raw), 16),
 					}),
 				},
@@ -735,7 +735,7 @@ describe('parse', () => {
 		it('custom flag with inline value', () => {
 			const schema = makeSchema({
 				flags: {
-					hex: createSchema('custom', {
+					hex: createFlagSchema('custom', {
 						parseFn: (raw: unknown) => Number.parseInt(String(raw), 16),
 					}),
 				},
@@ -747,7 +747,7 @@ describe('parse', () => {
 		it('custom flag parse failure throws INVALID_VALUE', () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('custom', {
+					port: createFlagSchema('custom', {
 						parseFn: (raw: unknown) => {
 							const n = Number(raw);
 							if (Number.isNaN(n) || n < 0 || n > 65535) throw new Error('Invalid port');
@@ -770,7 +770,7 @@ describe('parse', () => {
 		it('custom flag re-throws ParseError from parseFn as-is', () => {
 			const schema = makeSchema({
 				flags: {
-					value: createSchema('custom', {
+					value: createFlagSchema('custom', {
 						parseFn: () => {
 							throw new ParseError('Custom error', { code: 'INVALID_VALUE' });
 						},
@@ -788,7 +788,7 @@ describe('parse', () => {
 		it('custom flag with short alias', () => {
 			const schema = makeSchema({
 				flags: {
-					hex: createSchema('custom', {
+					hex: createFlagSchema('custom', {
 						aliases: ['x'],
 						parseFn: (raw: unknown) => Number.parseInt(String(raw), 16),
 					}),
@@ -801,7 +801,7 @@ describe('parse', () => {
 		it('custom flag without parseFn returns raw string', () => {
 			const schema = makeSchema({
 				flags: {
-					value: createSchema('custom'),
+					value: createFlagSchema('custom'),
 				},
 			});
 			const result = parse(schema, ['--value', 'hello']);
@@ -811,7 +811,7 @@ describe('parse', () => {
 		it('invalid values echo the typed long alias in the message', () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', {
+					port: createFlagSchema('number', {
 						aliases: [{ name: 'listenPort', hidden: false }],
 					}),
 				},
@@ -828,7 +828,7 @@ describe('parse', () => {
 		it('missing values echo the typed hidden alias in the message', () => {
 			const schema = makeSchema({
 				flags: {
-					output: createSchema('string', {
+					output: createFlagSchema('string', {
 						aliases: [{ name: 'oldOutput', hidden: true }],
 					}),
 				},
@@ -849,8 +849,8 @@ describe('parse', () => {
 		it('flag value that looks like a flag (--name --other)', () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string'),
-					other: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					name: createFlagSchema('string'),
+					other: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			// --name expects a value; --other is parsed as a separate token (not as value for --name)
@@ -860,7 +860,7 @@ describe('parse', () => {
 
 		it('empty string as flag value is allowed', () => {
 			const schema = makeSchema({
-				flags: { name: createSchema('string') },
+				flags: { name: createFlagSchema('string') },
 			});
 			const result = parse(schema, ['--name=']);
 			expect(result.flags.name).toBe('');
@@ -868,7 +868,7 @@ describe('parse', () => {
 
 		it('negative number as flag value', () => {
 			const schema = makeSchema({
-				flags: { offset: createSchema('number') },
+				flags: { offset: createFlagSchema('number') },
 			});
 			// -5 looks like a short flag; must use --offset=-5 or --offset -5 after --
 			// With inline value it works:
@@ -878,7 +878,7 @@ describe('parse', () => {
 
 		it('last flag overrides earlier occurrence', () => {
 			const schema = makeSchema({
-				flags: { region: createSchema('string') },
+				flags: { region: createFlagSchema('string') },
 			});
 			const result = parse(schema, ['--region', 'us', '--region', 'eu']);
 			expect(result.flags.region).toBe('eu');
@@ -887,7 +887,7 @@ describe('parse', () => {
 		it('boolean flag with 0/1 values', () => {
 			const schema = makeSchema({
 				flags: {
-					debug: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					debug: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			expect(parse(schema, ['--debug=1']).flags.debug).toBe(true);
@@ -931,8 +931,8 @@ describe('includesBeforeSeparator()', () => {
 // === Numeric constraints (parse boundary)
 
 describe('numeric constraints — flags', () => {
-	function numberFlagSchema(constraints?: Parameters<typeof createSchema>[1]) {
-		return makeSchema({ flags: { n: createSchema('number', constraints) } });
+	function numberFlagSchema(constraints?: FlagDefinitionOverrides<'number'>) {
+		return makeSchema({ flags: { n: createFlagSchema('number', constraints) } });
 	}
 
 	it('rejects Infinity by default (finite defaults true)', () => {

--- a/src/core/resolve/contracts.test.ts
+++ b/src/core/resolve/contracts.test.ts
@@ -5,7 +5,7 @@ import { createTestPrompter } from '#internals/core/prompt/index.ts';
 import { createArgSchema } from '#internals/core/schema/arg.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
-import { createSchema } from '#internals/core/schema/flag.ts';
+import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import { resolverContract } from './contracts.ts';
 import { resolve } from './index.ts';
 
@@ -66,7 +66,7 @@ describe('resolver contracts', () => {
 	describe('flag precedence matrix', () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('string', {
+				region: createFlagSchema('string', {
 					envVar: 'REGION',
 					configPath: 'deploy.region',
 					prompt: { kind: 'input', message: 'Region' },
@@ -222,7 +222,7 @@ describe('resolver contracts', () => {
 		it('prefers env flag errors over later sources', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', {
+					port: createFlagSchema('number', {
 						envVar: 'PORT',
 						configPath: 'deploy.port',
 						prompt: { kind: 'input', message: 'Port' },
@@ -282,7 +282,7 @@ describe('resolver contracts', () => {
 		it('aggregates independent flag and arg failures', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required', envVar: 'API_TOKEN' }),
+					token: createFlagSchema('string', { presence: 'required', envVar: 'API_TOKEN' }),
 				},
 				args: [
 					{

--- a/src/core/resolve/property.test.ts
+++ b/src/core/resolve/property.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createArgSchema } from '#internals/core/schema/arg.ts';
-import { createSchema } from '#internals/core/schema/flag.ts';
+import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import {
 	sharedPropertyModelContract,
 	toSharedArgPropertySchema,
@@ -28,14 +28,14 @@ describe('resolver shared property model', () => {
 
 	describe('schema adapters', () => {
 		it('keeps flag-only kinds outside the shared model', () => {
-			expect(toSharedFlagPropertySchema(createSchema('boolean'))).toBeUndefined();
-			expect(toSharedFlagPropertySchema(createSchema('array'))).toBeUndefined();
+			expect(toSharedFlagPropertySchema(createFlagSchema('boolean'))).toBeUndefined();
+			expect(toSharedFlagPropertySchema(createFlagSchema('array'))).toBeUndefined();
 		});
 
 		it('preserves shared enum metadata for flag coercion', () => {
 			expect(
 				toSharedFlagPropertySchema(
-					createSchema('enum', {
+					createFlagSchema('enum', {
 						enumValues: ['dev', 'prod'],
 					}),
 				),

--- a/src/core/resolve/resolve-aggregation.test.ts
+++ b/src/core/resolve/resolve-aggregation.test.ts
@@ -4,7 +4,7 @@ import type { ParseResult } from '#internals/core/parse/index.ts';
 import { createArgSchema } from '#internals/core/schema/arg.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
-import { createSchema } from '#internals/core/schema/flag.ts';
+import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import { resolve } from './index.ts';
 
 function makeSchema(overrides: Partial<CommandSchema> = {}): CommandSchema {
@@ -58,8 +58,8 @@ describe('resolve — aggregate diagnostics', () => {
 	it('summarizes mixed flag and arg failures with per-issue labels', async () => {
 		const schema = makeSchema({
 			flags: {
-				port: createSchema('number', { envVar: 'PORT' }),
-				region: createSchema('string', { presence: 'required' }),
+				port: createFlagSchema('number', { envVar: 'PORT' }),
+				region: createFlagSchema('string', { presence: 'required' }),
 			},
 			args: [
 				{
@@ -116,7 +116,7 @@ describe('resolve — aggregate diagnostics', () => {
 	it('keeps nested flag and arg aggregates flattened in summary details', async () => {
 		const schema = makeSchema({
 			flags: {
-				token: createSchema('string', { presence: 'required', envVar: 'API_TOKEN' }),
+				token: createFlagSchema('string', { presence: 'required', envVar: 'API_TOKEN' }),
 			},
 			args: [
 				{

--- a/src/core/resolve/resolve-config.test.ts
+++ b/src/core/resolve/resolve-config.test.ts
@@ -3,7 +3,7 @@ import { isValidationError, ValidationError } from '#internals/core/errors/index
 import type { ParseResult } from '#internals/core/parse/index.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
-import { createSchema } from '#internals/core/schema/flag.ts';
+import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import type { ResolveOptions } from './index.ts';
 import { resolve } from './index.ts';
 
@@ -30,7 +30,7 @@ describe('resolve', () => {
 		it('resolves string flag from config when CLI and env absent', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', { configPath: 'deploy.region' }),
+					region: createFlagSchema('string', { configPath: 'deploy.region' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -43,7 +43,7 @@ describe('resolve', () => {
 		it('resolves string flag from top-level config path', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', { configPath: 'name' }),
+					name: createFlagSchema('string', { configPath: 'name' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -56,7 +56,7 @@ describe('resolve', () => {
 		it('resolves deeply nested config path', async () => {
 			const schema = makeSchema({
 				flags: {
-					host: createSchema('string', { configPath: 'server.database.host' }),
+					host: createFlagSchema('string', { configPath: 'server.database.host' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -71,7 +71,7 @@ describe('resolve', () => {
 		it('ignores inherited nested config properties', async () => {
 			const schema = makeSchema({
 				flags: {
-					host: createSchema('string', { configPath: 'server.database.host' }),
+					host: createFlagSchema('string', { configPath: 'server.database.host' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -87,7 +87,7 @@ describe('resolve', () => {
 		it('coerces number to string from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					label: createSchema('string', { configPath: 'label' }),
+					label: createFlagSchema('string', { configPath: 'label' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -100,7 +100,7 @@ describe('resolve', () => {
 		it('coerces boolean to string from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					label: createSchema('string', { configPath: 'label' }),
+					label: createFlagSchema('string', { configPath: 'label' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -113,7 +113,7 @@ describe('resolve', () => {
 		it('throws for non-coercible string config value', async () => {
 			const schema = makeSchema({
 				flags: {
-					label: createSchema('string', { configPath: 'label' }),
+					label: createFlagSchema('string', { configPath: 'label' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -129,7 +129,7 @@ describe('resolve', () => {
 		it('resolves number directly from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { configPath: 'server.port' }),
+					port: createFlagSchema('number', { configPath: 'server.port' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -142,7 +142,7 @@ describe('resolve', () => {
 		it('coerces numeric string from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { configPath: 'port' }),
+					port: createFlagSchema('number', { configPath: 'port' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -155,7 +155,7 @@ describe('resolve', () => {
 		it('resolves float number from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					threshold: createSchema('number', { configPath: 'threshold' }),
+					threshold: createFlagSchema('number', { configPath: 'threshold' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -168,7 +168,7 @@ describe('resolve', () => {
 		it('throws for non-numeric config value', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { configPath: 'port' }),
+					port: createFlagSchema('number', { configPath: 'port' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -195,7 +195,7 @@ describe('resolve', () => {
 		it('throws for boolean config value when number expected', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { configPath: 'port' }),
+					port: createFlagSchema('number', { configPath: 'port' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -211,7 +211,7 @@ describe('resolve', () => {
 		it('resolves boolean true directly from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', {
+					verbose: createFlagSchema('boolean', {
 						configPath: 'verbose',
 						presence: 'defaulted',
 						defaultValue: false,
@@ -228,7 +228,7 @@ describe('resolve', () => {
 		it('resolves boolean false directly from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', {
+					verbose: createFlagSchema('boolean', {
 						configPath: 'verbose',
 						presence: 'defaulted',
 						defaultValue: true,
@@ -245,7 +245,7 @@ describe('resolve', () => {
 		it('coerces string "true" from config to boolean', async () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', {
+					verbose: createFlagSchema('boolean', {
 						configPath: 'verbose',
 						presence: 'defaulted',
 						defaultValue: false,
@@ -262,7 +262,7 @@ describe('resolve', () => {
 		it('throws for invalid boolean config value', async () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', {
+					verbose: createFlagSchema('boolean', {
 						configPath: 'verbose',
 						presence: 'defaulted',
 						defaultValue: false,
@@ -287,7 +287,7 @@ describe('resolve', () => {
 		it('throws for number config value when boolean expected', async () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', {
+					verbose: createFlagSchema('boolean', {
 						configPath: 'verbose',
 						presence: 'defaulted',
 						defaultValue: false,
@@ -307,7 +307,7 @@ describe('resolve', () => {
 		it('resolves valid enum value from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						configPath: 'deploy.region',
 						enumValues: ['us', 'eu', 'ap'],
 					}),
@@ -323,7 +323,7 @@ describe('resolve', () => {
 		it('throws for invalid enum config value', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						configPath: 'deploy.region',
 						enumValues: ['us', 'eu', 'ap'],
 					}),
@@ -353,7 +353,7 @@ describe('resolve', () => {
 		it('throws for non-string enum config value', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						configPath: 'region',
 						enumValues: ['us', 'eu', 'ap'],
 					}),
@@ -372,7 +372,7 @@ describe('resolve', () => {
 		it('resolves array directly from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { configPath: 'tags' }),
+					tags: createFlagSchema('array', { configPath: 'tags' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -385,7 +385,7 @@ describe('resolve', () => {
 		it('resolves empty array from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { configPath: 'tags' }),
+					tags: createFlagSchema('array', { configPath: 'tags' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -398,7 +398,7 @@ describe('resolve', () => {
 		it('resolves comma-separated string as array from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { configPath: 'tags' }),
+					tags: createFlagSchema('array', { configPath: 'tags' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -411,7 +411,7 @@ describe('resolve', () => {
 		it('resolves empty string as empty array from config', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { configPath: 'tags' }),
+					tags: createFlagSchema('array', { configPath: 'tags' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -424,9 +424,9 @@ describe('resolve', () => {
 		it('coerces array elements via element schema (number)', async () => {
 			const schema = makeSchema({
 				flags: {
-					ports: createSchema('array', {
+					ports: createFlagSchema('array', {
 						configPath: 'ports',
-						elementSchema: createSchema('number'),
+						elementSchema: createFlagSchema('number'),
 					}),
 				},
 			});
@@ -440,9 +440,9 @@ describe('resolve', () => {
 		it('throws for invalid array element in config', async () => {
 			const schema = makeSchema({
 				flags: {
-					ports: createSchema('array', {
+					ports: createFlagSchema('array', {
 						configPath: 'ports',
-						elementSchema: createSchema('number'),
+						elementSchema: createFlagSchema('number'),
 					}),
 				},
 			});
@@ -463,7 +463,7 @@ describe('resolve', () => {
 		it('throws for non-array non-string config value', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { configPath: 'tags' }),
+					tags: createFlagSchema('array', { configPath: 'tags' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -479,7 +479,7 @@ describe('resolve', () => {
 		it('resolves custom flag from config via parseFn (string value)', async () => {
 			const schema = makeSchema({
 				flags: {
-					hex: createSchema('custom', {
+					hex: createFlagSchema('custom', {
 						configPath: 'hex',
 						parseFn: (raw: unknown) => Number.parseInt(String(raw), 16),
 					}),
@@ -495,7 +495,7 @@ describe('resolve', () => {
 		it('passes non-string config value directly to parseFn', async () => {
 			const schema = makeSchema({
 				flags: {
-					doubled: createSchema('custom', {
+					doubled: createFlagSchema('custom', {
 						configPath: 'value',
 						parseFn: (raw: unknown) => Number(raw) * 2,
 					}),
@@ -511,7 +511,7 @@ describe('resolve', () => {
 		it('config custom flag parse failure produces validation error', async () => {
 			const schema = makeSchema({
 				flags: {
-					value: createSchema('custom', {
+					value: createFlagSchema('custom', {
 						configPath: 'value',
 						parseFn: () => {
 							throw new Error('Bad value');
@@ -541,7 +541,7 @@ describe('resolve', () => {
 		it('falls through when config path does not exist', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						configPath: 'deploy.region',
 						presence: 'defaulted',
 						defaultValue: 'us',
@@ -558,7 +558,7 @@ describe('resolve', () => {
 		it('falls through when intermediate path segment is missing', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						configPath: 'deploy.region',
 						presence: 'defaulted',
 						defaultValue: 'us',
@@ -575,7 +575,7 @@ describe('resolve', () => {
 		it('falls through when intermediate is a non-object', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						configPath: 'deploy.region',
 						presence: 'defaulted',
 						defaultValue: 'us',
@@ -592,7 +592,7 @@ describe('resolve', () => {
 		it('falls through when intermediate is null', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						configPath: 'deploy.region',
 						presence: 'defaulted',
 						defaultValue: 'us',
@@ -609,7 +609,7 @@ describe('resolve', () => {
 		it('ignores config when flag has no configPath declared', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', { presence: 'defaulted', defaultValue: 'us' }),
+					region: createFlagSchema('string', { presence: 'defaulted', defaultValue: 'us' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -626,7 +626,7 @@ describe('resolve', () => {
 		it('config value satisfies required flag', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required', configPath: 'auth.token' }),
+					token: createFlagSchema('string', { presence: 'required', configPath: 'auth.token' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -639,7 +639,7 @@ describe('resolve', () => {
 		it('throws when the required configPath value is absent', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required', configPath: 'auth.token' }),
+					token: createFlagSchema('string', { presence: 'required', configPath: 'auth.token' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -655,7 +655,7 @@ describe('resolve', () => {
 		it('CLI > env > config > default: CLI wins', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						envVar: 'REGION',
 						configPath: 'deploy.region',
 						presence: 'defaulted',
@@ -676,7 +676,7 @@ describe('resolve', () => {
 		it('CLI > env > config > default: env wins when CLI absent', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						envVar: 'REGION',
 						configPath: 'deploy.region',
 						presence: 'defaulted',
@@ -697,7 +697,7 @@ describe('resolve', () => {
 		it('CLI > env > config > default: config wins when CLI and env absent', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						envVar: 'REGION',
 						configPath: 'deploy.region',
 						presence: 'defaulted',
@@ -718,7 +718,7 @@ describe('resolve', () => {
 		it('CLI > env > config > default: default wins when all absent', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						envVar: 'REGION',
 						configPath: 'deploy.region',
 						presence: 'defaulted',
@@ -740,7 +740,7 @@ describe('resolve', () => {
 		it('works without config in options', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
+					port: createFlagSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
 				},
 			});
 			const parsed = makeParsed();
@@ -752,7 +752,7 @@ describe('resolve', () => {
 		it('works with empty config', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
+					port: createFlagSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
 				},
 			});
 			const parsed = makeParsed();
@@ -765,7 +765,7 @@ describe('resolve', () => {
 		it('env resolution still works alongside config', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { envVar: 'PORT', configPath: 'port' }),
+					port: createFlagSchema('number', { envVar: 'PORT', configPath: 'port' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -782,8 +782,8 @@ describe('resolve', () => {
 		it('aggregates config coercion error with missing required error', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { configPath: 'port' }),
-					token: createSchema('string', { presence: 'required' }),
+					port: createFlagSchema('number', { configPath: 'port' }),
+					token: createFlagSchema('string', { presence: 'required' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -805,8 +805,8 @@ describe('resolve', () => {
 		it('aggregates env and config errors together', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { envVar: 'PORT' }),
-					region: createSchema('enum', {
+					port: createFlagSchema('number', { envVar: 'PORT' }),
+					region: createFlagSchema('enum', {
 						configPath: 'region',
 						enumValues: ['us', 'eu'],
 					}),
@@ -838,25 +838,25 @@ describe('resolve', () => {
 		it('resolves mixed-source commands with config', async () => {
 			const schema = makeSchema({
 				flags: {
-					host: createSchema('string', {
+					host: createFlagSchema('string', {
 						envVar: 'HOST',
 						configPath: 'server.host',
 						presence: 'defaulted',
 						defaultValue: 'localhost',
 					}),
-					port: createSchema('number', { configPath: 'server.port' }),
-					verbose: createSchema('boolean', {
+					port: createFlagSchema('number', { configPath: 'server.port' }),
+					verbose: createFlagSchema('boolean', {
 						configPath: 'verbose',
 						presence: 'defaulted',
 						defaultValue: false,
 					}),
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						envVar: 'REGION',
 						configPath: 'deploy.region',
 						enumValues: ['us', 'eu', 'ap'],
 					}),
-					tags: createSchema('array', { configPath: 'tags' }),
-					output: createSchema('string'), // no env, no config, optional
+					tags: createFlagSchema('array', { configPath: 'tags' }),
+					output: createFlagSchema('string'), // no env, no config, optional
 				},
 			});
 			const parsed = makeParsed({ flags: { host: '0.0.0.0' } }); // CLI overrides host
@@ -884,7 +884,7 @@ describe('resolve', () => {
 		it('config with both env and config declared — env takes precedence', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', {
+					port: createFlagSchema('number', {
 						envVar: 'PORT',
 						configPath: 'port',
 					}),
@@ -908,7 +908,7 @@ describe('resolve — config numeric constraints', () => {
 	it('rejects out-of-range config number', async () => {
 		const schema = makeSchema({
 			flags: {
-				retries: createSchema('number', {
+				retries: createFlagSchema('number', {
 					configPath: 'retries',
 					numberConstraints: { int: true, min: 0, max: 5 },
 				}),
@@ -930,7 +930,7 @@ describe('resolve — config numeric constraints', () => {
 	it('rejects non-integer config number when int required', async () => {
 		const schema = makeSchema({
 			flags: {
-				retries: createSchema('number', {
+				retries: createFlagSchema('number', {
 					configPath: 'retries',
 					numberConstraints: { int: true },
 				}),
@@ -944,7 +944,7 @@ describe('resolve — config numeric constraints', () => {
 	it('accepts an in-range config number', async () => {
 		const schema = makeSchema({
 			flags: {
-				retries: createSchema('number', {
+				retries: createFlagSchema('number', {
 					configPath: 'retries',
 					numberConstraints: { int: true, min: 0, max: 5 },
 				}),

--- a/src/core/resolve/resolve-env.test.ts
+++ b/src/core/resolve/resolve-env.test.ts
@@ -3,7 +3,7 @@ import { isValidationError, ValidationError } from '#internals/core/errors/index
 import type { ParseResult } from '#internals/core/parse/index.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
-import { createSchema } from '#internals/core/schema/flag.ts';
+import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import type { ResolveOptions } from './index.ts';
 import { resolve } from './index.ts';
 
@@ -30,7 +30,7 @@ describe('resolve', () => {
 		it('resolves string flag from env when CLI absent', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', { envVar: 'DEPLOY_REGION' }),
+					region: createFlagSchema('string', { envVar: 'DEPLOY_REGION' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -43,7 +43,7 @@ describe('resolve', () => {
 		it('CLI value takes precedence over env', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', { envVar: 'DEPLOY_REGION' }),
+					region: createFlagSchema('string', { envVar: 'DEPLOY_REGION' }),
 				},
 			});
 			const parsed = makeParsed({ flags: { region: 'us' } });
@@ -56,7 +56,7 @@ describe('resolve', () => {
 		it('env takes precedence over default', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						envVar: 'DEPLOY_REGION',
 						presence: 'defaulted',
 						defaultValue: 'us',
@@ -73,7 +73,7 @@ describe('resolve', () => {
 		it('falls through to default when env var not set', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						envVar: 'DEPLOY_REGION',
 						presence: 'defaulted',
 						defaultValue: 'us',
@@ -90,7 +90,7 @@ describe('resolve', () => {
 		it('ignores env when flag has no envVar declared', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', { presence: 'defaulted', defaultValue: 'us' }),
+					region: createFlagSchema('string', { presence: 'defaulted', defaultValue: 'us' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -107,7 +107,7 @@ describe('resolve', () => {
 		it('coerces env string to number', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { envVar: 'PORT' }),
+					port: createFlagSchema('number', { envVar: 'PORT' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -120,7 +120,7 @@ describe('resolve', () => {
 		it('coerces env float string to number', async () => {
 			const schema = makeSchema({
 				flags: {
-					threshold: createSchema('number', { envVar: 'THRESHOLD' }),
+					threshold: createFlagSchema('number', { envVar: 'THRESHOLD' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -133,7 +133,7 @@ describe('resolve', () => {
 		it('throws ValidationError for non-numeric env value', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { envVar: 'PORT' }),
+					port: createFlagSchema('number', { envVar: 'PORT' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -145,7 +145,7 @@ describe('resolve', () => {
 		it('env number error has TYPE_MISMATCH code and details', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { envVar: 'PORT' }),
+					port: createFlagSchema('number', { envVar: 'PORT' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -193,7 +193,7 @@ describe('resolve', () => {
 			it(`coerces env '${input}' to ${String(expected)}`, async () => {
 				const schema = makeSchema({
 					flags: {
-						verbose: createSchema('boolean', {
+						verbose: createFlagSchema('boolean', {
 							envVar: 'VERBOSE',
 							presence: 'defaulted',
 							defaultValue: false,
@@ -211,7 +211,7 @@ describe('resolve', () => {
 		it('throws ValidationError for invalid boolean env value', async () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', {
+					verbose: createFlagSchema('boolean', {
 						envVar: 'VERBOSE',
 						presence: 'defaulted',
 						defaultValue: false,
@@ -240,7 +240,7 @@ describe('resolve', () => {
 		it('resolves valid enum value from env', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', { envVar: 'REGION', enumValues: ['us', 'eu', 'ap'] }),
+					region: createFlagSchema('enum', { envVar: 'REGION', enumValues: ['us', 'eu', 'ap'] }),
 				},
 			});
 			const parsed = makeParsed();
@@ -253,7 +253,7 @@ describe('resolve', () => {
 		it('throws ValidationError for invalid enum env value', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', { envVar: 'REGION', enumValues: ['us', 'eu', 'ap'] }),
+					region: createFlagSchema('enum', { envVar: 'REGION', enumValues: ['us', 'eu', 'ap'] }),
 				},
 			});
 			const parsed = makeParsed();
@@ -284,7 +284,7 @@ describe('resolve', () => {
 		it('resolves comma-separated env value to string array', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { envVar: 'TAGS' }),
+					tags: createFlagSchema('array', { envVar: 'TAGS' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -297,7 +297,7 @@ describe('resolve', () => {
 		it('resolves empty env string to empty array', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { envVar: 'TAGS' }),
+					tags: createFlagSchema('array', { envVar: 'TAGS' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -310,7 +310,7 @@ describe('resolve', () => {
 		it('resolves single-element env array', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { envVar: 'TAGS' }),
+					tags: createFlagSchema('array', { envVar: 'TAGS' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -323,9 +323,9 @@ describe('resolve', () => {
 		it('coerces array elements via element schema (number)', async () => {
 			const schema = makeSchema({
 				flags: {
-					ports: createSchema('array', {
+					ports: createFlagSchema('array', {
 						envVar: 'PORTS',
-						elementSchema: createSchema('number'),
+						elementSchema: createFlagSchema('number'),
 					}),
 				},
 			});
@@ -339,9 +339,9 @@ describe('resolve', () => {
 		it('throws for invalid array element value', async () => {
 			const schema = makeSchema({
 				flags: {
-					ports: createSchema('array', {
+					ports: createFlagSchema('array', {
 						envVar: 'PORTS',
-						elementSchema: createSchema('number'),
+						elementSchema: createFlagSchema('number'),
 					}),
 				},
 			});
@@ -366,7 +366,7 @@ describe('resolve', () => {
 		it('env value satisfies required flag', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required', envVar: 'TOKEN' }),
+					token: createFlagSchema('string', { presence: 'required', envVar: 'TOKEN' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -379,7 +379,7 @@ describe('resolve', () => {
 		it('still throws when required flag has envVar but env is not set', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required', envVar: 'TOKEN' }),
+					token: createFlagSchema('string', { presence: 'required', envVar: 'TOKEN' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -395,7 +395,7 @@ describe('resolve', () => {
 		it('works without options (v0.1 behavior)', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
+					port: createFlagSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
 				},
 			});
 			const parsed = makeParsed();
@@ -407,7 +407,7 @@ describe('resolve', () => {
 		it('works with empty options', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
+					port: createFlagSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
 				},
 			});
 			const parsed = makeParsed();
@@ -419,7 +419,7 @@ describe('resolve', () => {
 		it('works with no env key in options', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
+					port: createFlagSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
 				},
 			});
 			const parsed = makeParsed();
@@ -437,7 +437,7 @@ describe('resolve', () => {
 		it('CLI > env > default: CLI wins', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						envVar: 'REGION',
 						presence: 'defaulted',
 						defaultValue: 'us',
@@ -454,7 +454,7 @@ describe('resolve', () => {
 		it('CLI > env > default: env wins when CLI absent', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						envVar: 'REGION',
 						presence: 'defaulted',
 						defaultValue: 'us',
@@ -471,7 +471,7 @@ describe('resolve', () => {
 		it('CLI > env > default: default wins when both CLI and env absent', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', {
+					region: createFlagSchema('string', {
 						envVar: 'REGION',
 						presence: 'defaulted',
 						defaultValue: 'us',
@@ -492,8 +492,8 @@ describe('resolve', () => {
 		it('aggregates env coercion error with missing required error', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { envVar: 'PORT' }),
-					token: createSchema('string', { presence: 'required' }),
+					port: createFlagSchema('number', { envVar: 'PORT' }),
+					token: createFlagSchema('string', { presence: 'required' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -519,7 +519,7 @@ describe('resolve', () => {
 		it('resolves custom flag from env via parseFn', async () => {
 			const schema = makeSchema({
 				flags: {
-					hex: createSchema('custom', {
+					hex: createFlagSchema('custom', {
 						envVar: 'HEX_VALUE',
 						parseFn: (raw: unknown) => Number.parseInt(String(raw), 16),
 					}),
@@ -535,7 +535,7 @@ describe('resolve', () => {
 		it('env custom flag parse failure produces validation error', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('custom', {
+					port: createFlagSchema('custom', {
 						envVar: 'PORT',
 						parseFn: (raw: unknown) => {
 							const n = Number(raw);
@@ -563,7 +563,7 @@ describe('resolve', () => {
 		it('custom flag without parseFn passes raw env string through', async () => {
 			const schema = makeSchema({
 				flags: {
-					value: createSchema('custom', { envVar: 'VALUE' }),
+					value: createFlagSchema('custom', { envVar: 'VALUE' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -580,23 +580,23 @@ describe('resolve', () => {
 		it('resolves complex multi-flag command with mixed sources', async () => {
 			const schema = makeSchema({
 				flags: {
-					host: createSchema('string', {
+					host: createFlagSchema('string', {
 						envVar: 'HOST',
 						presence: 'defaulted',
 						defaultValue: 'localhost',
 					}),
-					port: createSchema('number', { envVar: 'PORT' }),
-					verbose: createSchema('boolean', {
+					port: createFlagSchema('number', { envVar: 'PORT' }),
+					verbose: createFlagSchema('boolean', {
 						envVar: 'VERBOSE',
 						presence: 'defaulted',
 						defaultValue: false,
 					}),
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						envVar: 'REGION',
 						enumValues: ['us', 'eu', 'ap'],
 					}),
-					tags: createSchema('array', { envVar: 'TAGS' }),
-					output: createSchema('string'), // no env, optional
+					tags: createFlagSchema('array', { envVar: 'TAGS' }),
+					output: createFlagSchema('string'), // no env, optional
 				},
 			});
 			const parsed = makeParsed({ flags: { host: '0.0.0.0' } }); // CLI overrides host
@@ -627,7 +627,7 @@ describe('resolve', () => {
 describe('resolve — env numeric constraints', () => {
 	it('rejects Infinity by default (finite)', async () => {
 		const schema = makeSchema({
-			flags: { count: createSchema('number', { envVar: 'COUNT' }) },
+			flags: { count: createFlagSchema('number', { envVar: 'COUNT' }) },
 		});
 		try {
 			await resolve(schema, makeParsed(), { env: { COUNT: 'Infinity' } });
@@ -645,7 +645,10 @@ describe('resolve — env numeric constraints', () => {
 	it('{ finite: false } allows Infinity from env', async () => {
 		const schema = makeSchema({
 			flags: {
-				count: createSchema('number', { envVar: 'COUNT', numberConstraints: { finite: false } }),
+				count: createFlagSchema('number', {
+					envVar: 'COUNT',
+					numberConstraints: { finite: false },
+				}),
 			},
 		});
 		const result = await resolve(schema, makeParsed(), { env: { COUNT: 'Infinity' } });
@@ -655,7 +658,7 @@ describe('resolve — env numeric constraints', () => {
 	it('{ int: true } rejects non-integer env value', async () => {
 		const schema = makeSchema({
 			flags: {
-				count: createSchema('number', { envVar: 'COUNT', numberConstraints: { int: true } }),
+				count: createFlagSchema('number', { envVar: 'COUNT', numberConstraints: { int: true } }),
 			},
 		});
 		await expect(resolve(schema, makeParsed(), { env: { COUNT: '3.7' } })).rejects.toThrow(
@@ -666,7 +669,7 @@ describe('resolve — env numeric constraints', () => {
 	it('{ min: 0, max: 100 } enforces inclusive bounds from env', async () => {
 		const schema = makeSchema({
 			flags: {
-				count: createSchema('number', {
+				count: createFlagSchema('number', {
 					envVar: 'COUNT',
 					numberConstraints: { min: 0, max: 100 },
 				}),
@@ -685,7 +688,7 @@ describe('resolve — env numeric constraints', () => {
 	it('includes the violated bound in env-path details (matches parse)', async () => {
 		const schema = makeSchema({
 			flags: {
-				count: createSchema('number', { envVar: 'COUNT', numberConstraints: { max: 100 } }),
+				count: createFlagSchema('number', { envVar: 'COUNT', numberConstraints: { max: 100 } }),
 			},
 		});
 		try {

--- a/src/core/resolve/resolve-errors.test.ts
+++ b/src/core/resolve/resolve-errors.test.ts
@@ -3,7 +3,7 @@ import { isValidationError, type ValidationError } from '#internals/core/errors/
 import type { ParseResult } from '#internals/core/parse/index.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
-import { createSchema } from '#internals/core/schema/flag.ts';
+import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import { resolve } from './index.ts';
 
 // --- Helpers
@@ -48,7 +48,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('suggests only --flag when no env or config configured', async () => {
 		const schema = makeSchema({
 			flags: {
-				token: createSchema('string', { presence: 'required' }),
+				token: createFlagSchema('string', { presence: 'required' }),
 			},
 		});
 		const err = await catchValidationError(schema, makeParsed());
@@ -58,7 +58,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('suggests only --flag for boolean (no <value> hint)', async () => {
 		const schema = makeSchema({
 			flags: {
-				confirm: createSchema('boolean', { presence: 'required' }),
+				confirm: createFlagSchema('boolean', { presence: 'required' }),
 			},
 		});
 		const err = await catchValidationError(schema, makeParsed());
@@ -70,7 +70,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('suggests --flag or env when envVar configured', async () => {
 		const schema = makeSchema({
 			flags: {
-				token: createSchema('string', {
+				token: createFlagSchema('string', {
 					presence: 'required',
 					envVar: 'API_TOKEN',
 				}),
@@ -85,7 +85,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('suggests --flag or config when configPath configured', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					presence: 'required',
 					enumValues: ['us', 'eu', 'ap'],
 					configPath: 'deploy.region',
@@ -101,7 +101,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('suggests all three sources when env and config configured', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					presence: 'required',
 					enumValues: ['us', 'eu', 'ap'],
 					envVar: 'DEPLOY_REGION',
@@ -118,7 +118,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('boolean with env and config lists all sources', async () => {
 		const schema = makeSchema({
 			flags: {
-				dryRun: createSchema('boolean', {
+				dryRun: createFlagSchema('boolean', {
 					presence: 'required',
 					envVar: 'DRY_RUN',
 					configPath: 'ci.dryRun',
@@ -134,7 +134,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('includes envVar in details when configured', async () => {
 		const schema = makeSchema({
 			flags: {
-				token: createSchema('string', {
+				token: createFlagSchema('string', {
 					presence: 'required',
 					envVar: 'API_TOKEN',
 				}),
@@ -151,7 +151,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('includes configPath in details when configured', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('string', {
+				region: createFlagSchema('string', {
 					presence: 'required',
 					configPath: 'deploy.region',
 				}),
@@ -168,7 +168,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('includes both envVar and configPath in details', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('string', {
+				region: createFlagSchema('string', {
 					presence: 'required',
 					envVar: 'DEPLOY_REGION',
 					configPath: 'deploy.region',
@@ -187,7 +187,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('omits envVar and configPath from details when not configured', async () => {
 		const schema = makeSchema({
 			flags: {
-				token: createSchema('string', { presence: 'required' }),
+				token: createFlagSchema('string', { presence: 'required' }),
 			},
 		});
 		const err = await catchValidationError(schema, makeParsed());
@@ -201,11 +201,11 @@ describe('resolve — required flag actionable hints', () => {
 	it('aggregated error preserves per-flag suggest with sources', async () => {
 		const schema = makeSchema({
 			flags: {
-				token: createSchema('string', {
+				token: createFlagSchema('string', {
 					presence: 'required',
 					envVar: 'API_TOKEN',
 				}),
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					presence: 'required',
 					enumValues: ['us', 'eu'],
 					envVar: 'DEPLOY_REGION',
@@ -239,7 +239,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('throws with sources when env record provided but var is missing', async () => {
 		const schema = makeSchema({
 			flags: {
-				token: createSchema('string', {
+				token: createFlagSchema('string', {
 					presence: 'required',
 					envVar: 'API_TOKEN',
 				}),
@@ -253,7 +253,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('throws with sources when config provided but path is missing', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('string', {
+				region: createFlagSchema('string', {
 					presence: 'required',
 					configPath: 'deploy.region',
 				}),
@@ -271,7 +271,7 @@ describe('resolve — required flag actionable hints', () => {
 	it('number flag required error includes env/config sources', async () => {
 		const schema = makeSchema({
 			flags: {
-				port: createSchema('number', {
+				port: createFlagSchema('number', {
 					presence: 'required',
 					envVar: 'PORT',
 					configPath: 'server.port',

--- a/src/core/resolve/resolve-interactive.test.ts
+++ b/src/core/resolve/resolve-interactive.test.ts
@@ -5,7 +5,7 @@ import { createTestPrompter, PROMPT_CANCEL } from '#internals/core/prompt/index.
 import type { CommandSchema, InteractiveParams } from '#internals/core/schema/command.ts';
 import { command, createCommandSchema } from '#internals/core/schema/command.ts';
 import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
-import { createSchema, flag } from '#internals/core/schema/flag.ts';
+import { createFlagSchema, flag } from '#internals/core/schema/flag.ts';
 import { resolve } from './index.ts';
 
 // --- Helpers
@@ -105,7 +105,7 @@ describe('resolve with interactive resolver', () => {
 	it('interactive resolver prompt config overrides per-flag prompt', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu', 'ap'],
 					prompt: { kind: 'select', message: 'Per-flag message' },
 				}),
@@ -129,8 +129,8 @@ describe('resolve with interactive resolver', () => {
 
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', { enumValues: ['us', 'eu'] }),
-				force: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+				region: createFlagSchema('enum', { enumValues: ['us', 'eu'] }),
+				force: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 			},
 			interactive: ({ flags }) => {
 				receivedFlags.push({ ...flags });
@@ -156,8 +156,8 @@ describe('resolve with interactive resolver', () => {
 
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', { enumValues: ['us', 'eu'], envVar: 'REGION' }),
-				name: createSchema('string'),
+				region: createFlagSchema('enum', { enumValues: ['us', 'eu'], envVar: 'REGION' }),
+				name: createFlagSchema('string'),
 			},
 			interactive: ({ flags }) => {
 				receivedFlags.push({ ...flags });
@@ -181,11 +181,11 @@ describe('resolve with interactive resolver', () => {
 
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu'],
 					configPath: 'deploy.region',
 				}),
-				name: createSchema('string'),
+				name: createFlagSchema('string'),
 			},
 			interactive: ({ flags }) => {
 				receivedFlags.push({ ...flags });
@@ -207,7 +207,7 @@ describe('resolve with interactive resolver', () => {
 	it('falsy return from interactive skips prompting for that flag', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu'],
 					prompt: { kind: 'select', message: 'Per-flag prompt' },
 				}),
@@ -227,7 +227,7 @@ describe('resolve with interactive resolver', () => {
 	it('undefined return from interactive falls back to per-flag prompt', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu'],
 					prompt: { kind: 'select', message: 'Per-flag prompt' },
 				}),
@@ -246,7 +246,7 @@ describe('resolve with interactive resolver', () => {
 	it('null return from interactive falls back to per-flag prompt', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu'],
 					prompt: { kind: 'select', message: 'Per-flag prompt' },
 				}),
@@ -269,7 +269,7 @@ describe('resolve with interactive resolver', () => {
 
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu'],
 					prompt: { kind: 'select', message: 'Per-flag' },
 				}),
@@ -289,11 +289,11 @@ describe('resolve with interactive resolver', () => {
 	it('mixes interactive, per-flag, and CLI sources', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', { enumValues: ['us', 'eu'] }),
-				name: createSchema('string', {
+				region: createFlagSchema('enum', { enumValues: ['us', 'eu'] }),
+				name: createFlagSchema('string', {
 					prompt: { kind: 'input', message: 'Per-flag name prompt' },
 				}),
-				force: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+				force: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 			},
 			interactive: ({ flags }) => ({
 				region: !flags.region && {
@@ -317,7 +317,7 @@ describe('resolve with interactive resolver', () => {
 	it('interactive prompt cancelled falls through to default', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu'],
 					defaultValue: 'us',
 				}),
@@ -336,7 +336,7 @@ describe('resolve with interactive resolver', () => {
 	it('interactive prompt cancelled on required flag throws', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu'],
 					presence: 'required',
 				}),
@@ -357,7 +357,7 @@ describe('resolve with interactive resolver', () => {
 
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu'],
 					defaultValue: 'us',
 				}),
@@ -376,7 +376,7 @@ describe('resolve with interactive resolver', () => {
 	it('interactive resolver for confirm prompt', async () => {
 		const schema = makeSchema({
 			flags: {
-				proceed: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+				proceed: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 			},
 			interactive: () => ({
 				proceed: { kind: 'confirm' as const, message: 'Continue?' },
@@ -392,7 +392,7 @@ describe('resolve with interactive resolver', () => {
 	it('interactive resolver for input prompt with number coercion', async () => {
 		const schema = makeSchema({
 			flags: {
-				port: createSchema('number'),
+				port: createFlagSchema('number'),
 			},
 			interactive: () => ({
 				port: { kind: 'input' as const, message: 'Port number' },
@@ -408,8 +408,8 @@ describe('resolve with interactive resolver', () => {
 	it('interactive resolver for multiselect prompt', async () => {
 		const schema = makeSchema({
 			flags: {
-				features: createSchema('array', {
-					elementSchema: createSchema('string'),
+				features: createFlagSchema('array', {
+					elementSchema: createFlagSchema('string'),
 				}),
 			},
 			interactive: () => ({
@@ -430,7 +430,7 @@ describe('resolve with interactive resolver', () => {
 	it('without interactive resolver, per-flag prompts work normally', async () => {
 		const schema = makeSchema({
 			flags: {
-				region: createSchema('enum', {
+				region: createFlagSchema('enum', {
 					enumValues: ['us', 'eu'],
 					prompt: { kind: 'select', message: 'Select region' },
 				}),
@@ -447,7 +447,7 @@ describe('resolve with interactive resolver', () => {
 	it('env error prevents prompting for that flag', async () => {
 		const schema = makeSchema({
 			flags: {
-				port: createSchema('number', { envVar: 'PORT' }),
+				port: createFlagSchema('number', { envVar: 'PORT' }),
 			},
 			interactive: () => ({
 				port: { kind: 'input' as const, message: 'Port?' },
@@ -466,14 +466,14 @@ describe('resolve with interactive resolver', () => {
 	it('full chain: CLI > env > config > interactive > per-flag > default', async () => {
 		const schema = makeSchema({
 			flags: {
-				a: createSchema('string'), // CLI
-				b: createSchema('string', { envVar: 'B_VAR' }), // env
-				c: createSchema('string', { configPath: 'c.val' }), // config
-				d: createSchema('string'), // interactive
-				e: createSchema('string', {
+				a: createFlagSchema('string'), // CLI
+				b: createFlagSchema('string', { envVar: 'B_VAR' }), // env
+				c: createFlagSchema('string', { configPath: 'c.val' }), // config
+				d: createFlagSchema('string'), // interactive
+				e: createFlagSchema('string', {
 					prompt: { kind: 'input', message: 'Per-flag E' },
 				}), // per-flag prompt
-				f: createSchema('string', { defaultValue: 'default-f' }), // default
+				f: createFlagSchema('string', { defaultValue: 'default-f' }), // default
 			},
 			interactive: ({ flags }) => ({
 				d: !flags.d && { kind: 'input' as const, message: 'Interactive D' },

--- a/src/core/resolve/resolve-path-checks.test.ts
+++ b/src/core/resolve/resolve-path-checks.test.ts
@@ -12,7 +12,7 @@ import type { ParseResult } from '#internals/core/parse/index.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { command, createCommandSchema } from '#internals/core/schema/command.ts';
 import type { InferFlag } from '#internals/core/schema/flag.ts';
-import { createSchema, flag } from '#internals/core/schema/flag.ts';
+import { createFlagSchema, flag } from '#internals/core/schema/flag.ts';
 import { runCommand } from '#internals/core/testkit/index.ts';
 import { resolve } from './index.ts';
 
@@ -151,7 +151,7 @@ describe('resolve() — path checks', () => {
 	it('passes when stat reports a file for mustExist', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', {
+				input: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: undefined, create: false },
 				}),
 			},
@@ -167,7 +167,7 @@ describe('resolve() — path checks', () => {
 	it('rejects a missing path with CONSTRAINT_VIOLATED', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', {
+				input: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: undefined, create: false },
 				}),
 			},
@@ -193,7 +193,7 @@ describe('resolve() — path checks', () => {
 	it('passes a missing path when mustExist is false', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: false, type: 'directory', create: false },
 				}),
 			},
@@ -209,7 +209,7 @@ describe('resolve() — path checks', () => {
 	it('rejects an existing wrong-type path even when mustExist is false', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: false, type: 'directory', create: false },
 				}),
 			},
@@ -237,7 +237,7 @@ describe('resolve() — path checks', () => {
 	it('creates a missing directory when create is set', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: 'directory', create: true },
 				}),
 			},
@@ -258,7 +258,7 @@ describe('resolve() — path checks', () => {
 	it('creates a missing directory when create is set and mustExist is false', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: false, type: 'directory', create: true },
 				}),
 			},
@@ -279,7 +279,7 @@ describe('resolve() — path checks', () => {
 	it('passes a missing path when create is set with mustExist false and no mkdir is available', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: false, type: 'directory', create: true },
 				}),
 			},
@@ -294,7 +294,7 @@ describe('resolve() — path checks', () => {
 	it('does not call mkdir when the directory already exists', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: 'directory', create: true },
 				}),
 			},
@@ -315,7 +315,7 @@ describe('resolve() — path checks', () => {
 	it('reports a failing mkdir as CONSTRAINT_VIOLATED', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: 'directory', create: true },
 				}),
 			},
@@ -346,7 +346,7 @@ describe('resolve() — path checks', () => {
 	it('falls back to existence rules when create is set but no mkdir is available', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: 'directory', create: true },
 				}),
 			},
@@ -372,7 +372,7 @@ describe('resolve() — path checks', () => {
 	it('still rejects an existing file when create is set', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: 'directory', create: true },
 				}),
 			},
@@ -405,7 +405,7 @@ describe('resolve() — path checks', () => {
 	it('rejects a file where a directory is expected', async () => {
 		const schema = makeSchema({
 			flags: {
-				outDir: createSchema('string', {
+				outDir: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: 'directory', create: false },
 				}),
 			},
@@ -437,7 +437,7 @@ describe('resolve() — path checks', () => {
 	it('rejects a directory where a file is expected', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', {
+				input: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: 'file', create: false },
 				}),
 			},
@@ -465,7 +465,7 @@ describe('resolve() — path checks', () => {
 	it('skips checks when no stat is provided', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', {
+				input: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: 'file', create: false },
 				}),
 			},
@@ -479,7 +479,7 @@ describe('resolve() — path checks', () => {
 	it('validates default values through path checks', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', {
+				input: createFlagSchema('string', {
 					presence: 'defaulted',
 					defaultValue: '/default/missing',
 					pathChecks: { mustExist: true, type: undefined, create: false },
@@ -505,7 +505,7 @@ describe('resolve() — path checks', () => {
 	it('does not call stat when the optional path flag is unresolved', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string', {
+				input: createFlagSchema('string', {
 					pathChecks: { mustExist: true, type: 'file', create: false },
 				}),
 			},
@@ -521,7 +521,7 @@ describe('resolve() — path checks', () => {
 	it('does not call stat when pathChecks is undefined', async () => {
 		const schema = makeSchema({
 			flags: {
-				input: createSchema('string'),
+				input: createFlagSchema('string'),
 			},
 		});
 		const parsed = makeParsed({ flags: { input: '/anywhere' } });

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -18,7 +18,7 @@ import {
 import { createCommandSchema } from '#internals/core/schema/command.ts';
 import { FLAG_KINDS } from '#internals/core/schema/flag.ts';
 import type { CommandSchema } from '#internals/core/schema/index.ts';
-import { createSchema } from '#internals/core/schema/index.ts';
+import { createFlagSchema } from '#internals/core/schema/index.ts';
 import { COMPATIBLE_PROMPT_KINDS } from './flags.ts';
 import type { ResolveOptions } from './index.ts';
 import { resolve } from './index.ts';
@@ -61,7 +61,7 @@ describe('resolve', () => {
 		it('resolves flag from prompt when no CLI/env/config value', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu', 'ap'],
 						prompt: { kind: 'select', message: 'Select region' },
 						presence: 'required',
@@ -78,7 +78,7 @@ describe('resolve', () => {
 		it('resolves confirm prompt as boolean', async () => {
 			const schema = makeSchema({
 				flags: {
-					force: createSchema('boolean', {
+					force: createFlagSchema('boolean', {
 						prompt: { kind: 'confirm', message: 'Force deploy?' },
 					}),
 				},
@@ -93,7 +93,7 @@ describe('resolve', () => {
 		it('resolves input prompt as string', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', {
+					name: createFlagSchema('string', {
 						prompt: { kind: 'input', message: 'Enter name' },
 					}),
 				},
@@ -108,7 +108,7 @@ describe('resolve', () => {
 		it('resolves multiselect prompt as array', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', {
+					tags: createFlagSchema('array', {
 						prompt: {
 							kind: 'multiselect',
 							message: 'Select tags',
@@ -127,7 +127,7 @@ describe('resolve', () => {
 		it('coerces input prompt value to number for number flags', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', {
+					port: createFlagSchema('number', {
 						prompt: { kind: 'input', message: 'Enter port' },
 					}),
 				},
@@ -146,7 +146,7 @@ describe('resolve', () => {
 		it('CLI value takes priority over prompt', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						prompt: { kind: 'select', message: 'Select region' },
 					}),
@@ -163,7 +163,7 @@ describe('resolve', () => {
 		it('env value takes priority over prompt', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						envVar: 'REGION',
 						prompt: { kind: 'select', message: 'Select region' },
@@ -183,7 +183,7 @@ describe('resolve', () => {
 		it('config value takes priority over prompt', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						configPath: 'deploy.region',
 						prompt: { kind: 'select', message: 'Select region' },
@@ -203,7 +203,7 @@ describe('resolve', () => {
 		it('prompt takes priority over default', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						defaultValue: 'us',
 						prompt: { kind: 'select', message: 'Select region' },
@@ -220,25 +220,25 @@ describe('resolve', () => {
 		it('full chain: CLI > env > config > prompt > default', async () => {
 			const schema = makeSchema({
 				flags: {
-					a: createSchema('string', {
+					a: createFlagSchema('string', {
 						prompt: { kind: 'input', message: 'Enter A' },
 						defaultValue: 'def-a',
 					}),
-					b: createSchema('string', {
+					b: createFlagSchema('string', {
 						envVar: 'B',
 						prompt: { kind: 'input', message: 'Enter B' },
 						defaultValue: 'def-b',
 					}),
-					c: createSchema('string', {
+					c: createFlagSchema('string', {
 						configPath: 'c',
 						prompt: { kind: 'input', message: 'Enter C' },
 						defaultValue: 'def-c',
 					}),
-					d: createSchema('string', {
+					d: createFlagSchema('string', {
 						prompt: { kind: 'input', message: 'Enter D' },
 						defaultValue: 'def-d',
 					}),
-					e: createSchema('string', {
+					e: createFlagSchema('string', {
 						defaultValue: 'def-e',
 					}),
 				},
@@ -268,7 +268,7 @@ describe('resolve', () => {
 		it('falls through to default when prompt is cancelled', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						defaultValue: 'us',
 						prompt: { kind: 'select', message: 'Select region' },
@@ -285,7 +285,7 @@ describe('resolve', () => {
 		it('throws for required flag when prompt is cancelled and no default', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						presence: 'required',
 						prompt: { kind: 'select', message: 'Select region' },
@@ -301,7 +301,7 @@ describe('resolve', () => {
 		it('resolves optional flags to undefined when prompts are cancelled', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', {
+					name: createFlagSchema('string', {
 						prompt: { kind: 'input', message: 'Enter name' },
 					}),
 				},
@@ -320,7 +320,7 @@ describe('resolve', () => {
 		it('empty input with no prompt-default falls through to flag .default() (#35)', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', {
+					name: createFlagSchema('string', {
 						defaultValue: 'Anonymous',
 						prompt: { kind: 'input', message: 'Name' },
 					}),
@@ -337,7 +337,7 @@ describe('resolve', () => {
 		it('empty test-prompter answer with no prompt-default falls through to flag .default()', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', {
+					name: createFlagSchema('string', {
 						defaultValue: 'Anonymous',
 						prompt: { kind: 'input', message: 'Name' },
 					}),
@@ -353,7 +353,7 @@ describe('resolve', () => {
 		it('blank (whitespace) input with no prompt-default falls through to flag .default()', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', {
+					name: createFlagSchema('string', {
 						defaultValue: 'Anonymous',
 						prompt: { kind: 'input', message: 'Name' },
 					}),
@@ -369,7 +369,7 @@ describe('resolve', () => {
 		it('empty input resolves to prompt-level default, overriding flag .default() (#34)', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', {
+					name: createFlagSchema('string', {
 						defaultValue: 'flag-default',
 						prompt: { kind: 'input', message: 'Name', default: 'prompt-default' },
 					}),
@@ -385,7 +385,7 @@ describe('resolve', () => {
 		it('empty input with no prompt-default and no flag default → optional flag undefined', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', {
+					name: createFlagSchema('string', {
 						prompt: { kind: 'input', message: 'Name' },
 					}),
 				},
@@ -400,7 +400,7 @@ describe('resolve', () => {
 		it('confirm prompt with default:false resolves empty Enter to false', async () => {
 			const schema = makeSchema({
 				flags: {
-					force: createSchema('boolean', {
+					force: createFlagSchema('boolean', {
 						prompt: { kind: 'confirm', message: 'Delete?', default: false },
 					}),
 				},
@@ -419,7 +419,7 @@ describe('resolve', () => {
 		it('skips prompt when no prompter provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						defaultValue: 'us',
 						prompt: { kind: 'select', message: 'Select region' },
@@ -436,7 +436,7 @@ describe('resolve', () => {
 		it('required flag with prompt but no prompter throws', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						presence: 'required',
 						prompt: { kind: 'select', message: 'Select region' },
@@ -452,7 +452,7 @@ describe('resolve', () => {
 		it('prompter provided but flag has no prompt config — skips', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						defaultValue: 'us',
 						// No prompt config
@@ -473,7 +473,7 @@ describe('resolve', () => {
 		it('throws for invalid number from prompt', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', {
+					port: createFlagSchema('number', {
 						prompt: { kind: 'input', message: 'Enter port' },
 						presence: 'required',
 					}),
@@ -488,7 +488,7 @@ describe('resolve', () => {
 		it('throws for invalid enum from prompt', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						prompt: { kind: 'select', message: 'Select region' },
 						presence: 'required',
@@ -511,7 +511,7 @@ describe('resolve', () => {
 			it('rejects multiselect on enum flag', async () => {
 				const schema = makeSchema({
 					flags: {
-						mood: createSchema('enum', {
+						mood: createFlagSchema('enum', {
 							enumValues: ['calm', 'happy'],
 							prompt: { kind: 'multiselect', message: 'Pick moods' },
 							presence: 'required',
@@ -527,7 +527,7 @@ describe('resolve', () => {
 			it('rejects input on boolean flag', async () => {
 				const schema = makeSchema({
 					flags: {
-						force: createSchema('boolean', {
+						force: createFlagSchema('boolean', {
 							prompt: { kind: 'input', message: 'Force?' },
 						}),
 					},
@@ -541,7 +541,7 @@ describe('resolve', () => {
 			it('rejects multiselect on boolean flag', async () => {
 				const schema = makeSchema({
 					flags: {
-						force: createSchema('boolean', {
+						force: createFlagSchema('boolean', {
 							prompt: { kind: 'multiselect', message: 'Force?' },
 						}),
 					},
@@ -555,7 +555,7 @@ describe('resolve', () => {
 			it('rejects confirm on string flag', async () => {
 				const schema = makeSchema({
 					flags: {
-						name: createSchema('string', {
+						name: createFlagSchema('string', {
 							prompt: { kind: 'confirm', message: 'Name?' },
 							presence: 'required',
 						}),
@@ -570,7 +570,7 @@ describe('resolve', () => {
 			it('rejects multiselect on number flag', async () => {
 				const schema = makeSchema({
 					flags: {
-						port: createSchema('number', {
+						port: createFlagSchema('number', {
 							prompt: { kind: 'multiselect', message: 'Port?' },
 							presence: 'required',
 						}),
@@ -585,7 +585,7 @@ describe('resolve', () => {
 			it('rejects confirm on number flag', async () => {
 				const schema = makeSchema({
 					flags: {
-						port: createSchema('number', {
+						port: createFlagSchema('number', {
 							prompt: { kind: 'confirm', message: 'Port?' },
 							presence: 'required',
 						}),
@@ -604,7 +604,7 @@ describe('resolve', () => {
 			it('includes flag name and suggested kind in error message', async () => {
 				const schema = makeSchema({
 					flags: {
-						mood: createSchema('enum', {
+						mood: createFlagSchema('enum', {
 							enumValues: ['calm', 'happy'],
 							prompt: { kind: 'multiselect', message: 'Pick moods' },
 							presence: 'required',
@@ -637,7 +637,7 @@ describe('resolve', () => {
 				};
 				const schema = makeSchema({
 					flags: {
-						mood: createSchema('enum', {
+						mood: createFlagSchema('enum', {
 							enumValues: ['calm', 'happy'],
 							prompt: { kind: 'multiselect', message: 'Pick moods' },
 							presence: 'required',
@@ -657,7 +657,7 @@ describe('resolve', () => {
 			it('accepts input on enum flag', async () => {
 				const schema = makeSchema({
 					flags: {
-						region: createSchema('enum', {
+						region: createFlagSchema('enum', {
 							enumValues: ['us', 'eu'],
 							prompt: { kind: 'input', message: 'Region?' },
 							presence: 'required',
@@ -674,7 +674,7 @@ describe('resolve', () => {
 			it('accepts select on string flag', async () => {
 				const schema = makeSchema({
 					flags: {
-						format: createSchema('string', {
+						format: createFlagSchema('string', {
 							prompt: {
 								kind: 'select',
 								message: 'Format?',
@@ -699,7 +699,7 @@ describe('resolve', () => {
 		it('works without options (sync-like behavior)', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', { defaultValue: 'world' }),
+					name: createFlagSchema('string', { defaultValue: 'world' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -711,7 +711,7 @@ describe('resolve', () => {
 		it('works with env/config but no prompter', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', { envVar: 'REGION' }),
+					region: createFlagSchema('string', { envVar: 'REGION' }),
 				},
 			});
 			const parsed = makeParsed();
@@ -728,16 +728,16 @@ describe('resolve', () => {
 		it('prompts multiple flags in schema order', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', {
+					name: createFlagSchema('string', {
 						prompt: { kind: 'input', message: 'Name?' },
 						presence: 'required',
 					}),
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						prompt: { kind: 'select', message: 'Region?' },
 						presence: 'required',
 					}),
-					force: createSchema('boolean', {
+					force: createFlagSchema('boolean', {
 						prompt: { kind: 'confirm', message: 'Force?' },
 					}),
 				},
@@ -756,11 +756,11 @@ describe('resolve', () => {
 		it('only prompts flags that need it (some resolved from CLI)', async () => {
 			const schema = makeSchema({
 				flags: {
-					name: createSchema('string', {
+					name: createFlagSchema('string', {
 						prompt: { kind: 'input', message: 'Name?' },
 						presence: 'required',
 					}),
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						enumValues: ['us', 'eu'],
 						prompt: { kind: 'select', message: 'Region?' },
 						presence: 'required',
@@ -782,7 +782,7 @@ describe('resolve', () => {
 		it('collects deprecations from prompt-resolved flags', async () => {
 			const schema = makeSchema({
 				flags: {
-					old: createSchema('string', {
+					old: createFlagSchema('string', {
 						deprecated: 'use --new',
 						prompt: { kind: 'input', message: 'Old value?' },
 					}),
@@ -800,7 +800,7 @@ describe('resolve', () => {
 		it('no deprecation when deprecated flag prompt is cancelled', async () => {
 			const schema = makeSchema({
 				flags: {
-					old: createSchema('string', {
+					old: createFlagSchema('string', {
 						deprecated: true,
 						prompt: { kind: 'input', message: 'Old?' },
 						presence: 'optional',

--- a/src/core/resolve/resolve-prompt.test.ts
+++ b/src/core/resolve/resolve-prompt.test.ts
@@ -16,9 +16,8 @@ import {
 	type ReadFn,
 } from '#internals/core/prompt/index.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
-import { FLAG_KINDS } from '#internals/core/schema/flag.ts';
+import { createFlagSchema, FLAG_KINDS } from '#internals/core/schema/flag.ts';
 import type { CommandSchema } from '#internals/core/schema/index.ts';
-import { createFlagSchema } from '#internals/core/schema/index.ts';
 import { COMPATIBLE_PROMPT_KINDS } from './flags.ts';
 import type { ResolveOptions } from './index.ts';
 import { resolve } from './index.ts';

--- a/src/core/resolve/resolve.test.ts
+++ b/src/core/resolve/resolve.test.ts
@@ -4,7 +4,7 @@ import type { ParseResult } from '#internals/core/parse/index.ts';
 import { createArgSchema } from '#internals/core/schema/arg.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
-import { createSchema } from '#internals/core/schema/flag.ts';
+import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import { resolve } from './index.ts';
 
 // --- Helpers — build minimal schemas and parse results
@@ -32,8 +32,8 @@ describe('resolve', () => {
 		it('passes through CLI-provided flag values', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number'),
-					host: createSchema('string'),
+					port: createFlagSchema('number'),
+					host: createFlagSchema('string'),
 				},
 			});
 			const parsed = makeParsed({ flags: { port: 8080, host: 'localhost' } });
@@ -45,7 +45,7 @@ describe('resolve', () => {
 		it('passes through boolean flag set to true', async () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			const parsed = makeParsed({ flags: { verbose: true } });
@@ -57,7 +57,7 @@ describe('resolve', () => {
 		it('passes through enum flag value', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', { enumValues: ['us', 'eu', 'ap'] }),
+					region: createFlagSchema('enum', { enumValues: ['us', 'eu', 'ap'] }),
 				},
 			});
 			const parsed = makeParsed({ flags: { region: 'eu' } });
@@ -69,7 +69,7 @@ describe('resolve', () => {
 		it('passes through array flag values', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array'),
+					tags: createFlagSchema('array'),
 				},
 			});
 			const parsed = makeParsed({ flags: { tags: ['v1', 'v2'] } });
@@ -81,7 +81,7 @@ describe('resolve', () => {
 		it('treats own undefined parsed flag as missing and applies default', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('string', { presence: 'defaulted', defaultValue: 'us' }),
+					region: createFlagSchema('string', { presence: 'defaulted', defaultValue: 'us' }),
 				},
 			});
 			const parsed = makeParsed({ flags: { region: undefined } });
@@ -93,7 +93,7 @@ describe('resolve', () => {
 		it('treats own undefined parsed required flag as missing', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required' }),
+					token: createFlagSchema('string', { presence: 'required' }),
 				},
 			});
 			const parsed = makeParsed({ flags: { token: undefined } });
@@ -104,7 +104,7 @@ describe('resolve', () => {
 		it('ignores prototype-inherited parsed flag values', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required' }),
+					token: createFlagSchema('string', { presence: 'required' }),
 				},
 			});
 			const protoFlags: Record<string, unknown> = {};
@@ -121,7 +121,7 @@ describe('resolve', () => {
 		it('applies schema default when flag not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
+					port: createFlagSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -133,7 +133,7 @@ describe('resolve', () => {
 		it('applies boolean default (false) when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -145,7 +145,7 @@ describe('resolve', () => {
 		it('applies string default when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					format: createSchema('string', { presence: 'defaulted', defaultValue: 'json' }),
+					format: createFlagSchema('string', { presence: 'defaulted', defaultValue: 'json' }),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -157,7 +157,7 @@ describe('resolve', () => {
 		it('applies enum default when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					region: createSchema('enum', {
+					region: createFlagSchema('enum', {
 						presence: 'defaulted',
 						defaultValue: 'us',
 						enumValues: ['us', 'eu'],
@@ -173,7 +173,7 @@ describe('resolve', () => {
 		it('CLI value takes precedence over default', async () => {
 			const schema = makeSchema({
 				flags: {
-					port: createSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
+					port: createFlagSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
 				},
 			});
 			const parsed = makeParsed({ flags: { port: 9090 } });
@@ -187,7 +187,7 @@ describe('resolve', () => {
 		it('array flag defaults to empty array when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array'),
+					tags: createFlagSchema('array'),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -199,7 +199,7 @@ describe('resolve', () => {
 		it('array flag uses explicit default when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { presence: 'defaulted', defaultValue: ['default'] }),
+					tags: createFlagSchema('array', { presence: 'defaulted', defaultValue: ['default'] }),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -213,7 +213,7 @@ describe('resolve', () => {
 		it('optional flag resolves to undefined when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					output: createSchema('string'), // default presence: 'optional'
+					output: createFlagSchema('string'), // default presence: 'optional'
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -225,7 +225,7 @@ describe('resolve', () => {
 		it('optional flag key exists in result even when undefined', async () => {
 			const schema = makeSchema({
 				flags: {
-					output: createSchema('string'),
+					output: createFlagSchema('string'),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -239,7 +239,7 @@ describe('resolve', () => {
 		it('throws ValidationError for missing required flag', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required' }),
+					token: createFlagSchema('string', { presence: 'required' }),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -250,7 +250,7 @@ describe('resolve', () => {
 		it('required flag error has REQUIRED_FLAG code', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required' }),
+					token: createFlagSchema('string', { presence: 'required' }),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -271,7 +271,7 @@ describe('resolve', () => {
 		it('required array flag errors when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					tags: createSchema('array', { presence: 'required' }),
+					tags: createFlagSchema('array', { presence: 'required' }),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -292,7 +292,7 @@ describe('resolve', () => {
 		it('required boolean flag suggest omits <value>', async () => {
 			const schema = makeSchema({
 				flags: {
-					confirm: createSchema('boolean', { presence: 'required' }),
+					confirm: createFlagSchema('boolean', { presence: 'required' }),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -310,8 +310,8 @@ describe('resolve', () => {
 		it('aggregates multiple missing required flags', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required' }),
-					region: createSchema('enum', {
+					token: createFlagSchema('string', { presence: 'required' }),
+					region: createFlagSchema('enum', {
 						presence: 'required',
 						enumValues: ['us', 'eu'],
 					}),
@@ -337,7 +337,7 @@ describe('resolve', () => {
 		it('required flag passes when CLI provides value', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required' }),
+					token: createFlagSchema('string', { presence: 'required' }),
 				},
 			});
 			const parsed = makeParsed({ flags: { token: 'abc123' } });
@@ -351,10 +351,10 @@ describe('resolve', () => {
 		it('resolves mix of provided, defaulted, optional, and required flags', async () => {
 			const schema = makeSchema({
 				flags: {
-					host: createSchema('string', { presence: 'defaulted', defaultValue: 'localhost' }),
-					port: createSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
-					verbose: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
-					output: createSchema('string'), // optional
+					host: createFlagSchema('string', { presence: 'defaulted', defaultValue: 'localhost' }),
+					port: createFlagSchema('number', { presence: 'defaulted', defaultValue: 3000 }),
+					verbose: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					output: createFlagSchema('string'), // optional
 				},
 			});
 			const parsed = makeParsed({ flags: { port: 8080, verbose: true } });
@@ -375,7 +375,7 @@ describe('resolve', () => {
 		it('passes through CLI-provided custom flag value', async () => {
 			const schema = makeSchema({
 				flags: {
-					hex: createSchema('custom', {
+					hex: createFlagSchema('custom', {
 						parseFn: (raw: unknown) => Number.parseInt(String(raw), 16),
 					}),
 				},
@@ -390,7 +390,7 @@ describe('resolve', () => {
 		it('applies default for optional custom flag when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					hex: createSchema('custom', {
+					hex: createFlagSchema('custom', {
 						parseFn: (raw: unknown) => Number.parseInt(String(raw), 16),
 						presence: 'defaulted',
 						defaultValue: 0,
@@ -406,7 +406,7 @@ describe('resolve', () => {
 		it('required custom flag throws when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					hex: createSchema('custom', {
+					hex: createFlagSchema('custom', {
 						parseFn: (raw: unknown) => Number.parseInt(String(raw), 16),
 						presence: 'required',
 					}),
@@ -420,7 +420,7 @@ describe('resolve', () => {
 		it('optional custom flag resolves to undefined when not provided', async () => {
 			const schema = makeSchema({
 				flags: {
-					hex: createSchema('custom', {
+					hex: createFlagSchema('custom', {
 						parseFn: (raw: unknown) => Number.parseInt(String(raw), 16),
 					}),
 				},
@@ -708,8 +708,8 @@ describe('resolve', () => {
 		it('resolves both flags and args together', async () => {
 			const schema = makeSchema({
 				flags: {
-					force: createSchema('boolean', { presence: 'defaulted', defaultValue: false }),
-					region: createSchema('enum', {
+					force: createFlagSchema('boolean', { presence: 'defaulted', defaultValue: false }),
+					region: createFlagSchema('enum', {
 						presence: 'defaulted',
 						defaultValue: 'us',
 						enumValues: ['us', 'eu'],
@@ -730,7 +730,7 @@ describe('resolve', () => {
 		it('throws for missing required flag but not missing optional arg', async () => {
 			const schema = makeSchema({
 				flags: {
-					token: createSchema('string', { presence: 'required' }),
+					token: createFlagSchema('string', { presence: 'required' }),
 				},
 				args: [
 					{
@@ -762,7 +762,7 @@ describe('resolve', () => {
 
 		it('result objects are readonly (frozen shape)', async () => {
 			const schema = makeSchema({
-				flags: { port: createSchema('number', { presence: 'defaulted', defaultValue: 3000 }) },
+				flags: { port: createFlagSchema('number', { presence: 'defaulted', defaultValue: 3000 }) },
 				args: [{ name: 'target', schema: createArgSchema('string') }],
 			});
 			const parsed = makeParsed({
@@ -783,7 +783,7 @@ describe('resolve', () => {
 	describe('error details', () => {
 		it('single missing flag throws directly (not aggregated)', async () => {
 			const schema = makeSchema({
-				flags: { token: createSchema('string', { presence: 'required' }) },
+				flags: { token: createFlagSchema('string', { presence: 'required' }) },
 			});
 			const parsed = makeParsed({ flags: {} });
 
@@ -818,9 +818,9 @@ describe('resolve', () => {
 		it('aggregated error includes all individual errors in details', async () => {
 			const schema = makeSchema({
 				flags: {
-					a: createSchema('string', { presence: 'required' }),
-					b: createSchema('number', { presence: 'required' }),
-					c: createSchema('string', { presence: 'required' }),
+					a: createFlagSchema('string', { presence: 'required' }),
+					b: createFlagSchema('number', { presence: 'required' }),
+					c: createFlagSchema('string', { presence: 'required' }),
 				},
 			});
 			const parsed = makeParsed({ flags: {} });
@@ -840,7 +840,7 @@ describe('resolve', () => {
 		it('preserves flag and arg phase errors', async () => {
 			// Flag errors throw first (flag resolution runs before arg resolution)
 			const schema = makeSchema({
-				flags: { token: createSchema('string', { presence: 'required' }) },
+				flags: { token: createFlagSchema('string', { presence: 'required' }) },
 				args: [{ name: 'file', schema: createArgSchema('string') }],
 			});
 			const parsed = makeParsed({ flags: {}, args: {} });
@@ -863,7 +863,7 @@ describe('resolve', () => {
 		describe('flags', () => {
 			it('collects deprecations from CLI input', async () => {
 				const schema = makeSchema({
-					flags: { old: createSchema('string', { deprecated: true }) },
+					flags: { old: createFlagSchema('string', { deprecated: true }) },
 				});
 				const parsed = makeParsed({ flags: { old: 'value' } });
 				const result = await resolve(schema, parsed);
@@ -873,7 +873,7 @@ describe('resolve', () => {
 
 			it('includes the message', async () => {
 				const schema = makeSchema({
-					flags: { old: createSchema('string', { deprecated: 'use --new instead' }) },
+					flags: { old: createFlagSchema('string', { deprecated: 'use --new instead' }) },
 				});
 				const parsed = makeParsed({ flags: { old: 'value' } });
 				const result = await resolve(schema, parsed);
@@ -886,7 +886,7 @@ describe('resolve', () => {
 
 			it('skips deprecated flags that are not provided', async () => {
 				const schema = makeSchema({
-					flags: { old: createSchema('string', { deprecated: true }) },
+					flags: { old: createFlagSchema('string', { deprecated: true }) },
 				});
 				const parsed = makeParsed({ flags: {} });
 				const result = await resolve(schema, parsed);
@@ -895,7 +895,7 @@ describe('resolve', () => {
 
 			it('skips non-deprecated flags', async () => {
 				const schema = makeSchema({
-					flags: { active: createSchema('string') },
+					flags: { active: createFlagSchema('string') },
 				});
 				const parsed = makeParsed({ flags: { active: 'value' } });
 				const result = await resolve(schema, parsed);
@@ -904,7 +904,7 @@ describe('resolve', () => {
 
 			it('collects deprecations from env', async () => {
 				const schema = makeSchema({
-					flags: { old: createSchema('string', { deprecated: true, envVar: 'OLD_VAR' }) },
+					flags: { old: createFlagSchema('string', { deprecated: true, envVar: 'OLD_VAR' }) },
 				});
 				const parsed = makeParsed({ flags: {} });
 				const result = await resolve(schema, parsed, { env: { OLD_VAR: 'value' } });
@@ -914,7 +914,7 @@ describe('resolve', () => {
 
 			it('collects deprecations from config', async () => {
 				const schema = makeSchema({
-					flags: { old: createSchema('string', { deprecated: true, configPath: 'old' }) },
+					flags: { old: createFlagSchema('string', { deprecated: true, configPath: 'old' }) },
 				});
 				const parsed = makeParsed({ flags: {} });
 				const result = await resolve(schema, parsed, { config: { old: 'value' } });
@@ -925,7 +925,7 @@ describe('resolve', () => {
 			it('skips deprecated flags that fall through to defaults', async () => {
 				const schema = makeSchema({
 					flags: {
-						old: createSchema('string', {
+						old: createFlagSchema('string', {
 							deprecated: true,
 							presence: 'defaulted',
 							defaultValue: 'x',
@@ -986,8 +986,8 @@ describe('resolve', () => {
 			it('collects them for multiple deprecated flags', async () => {
 				const schema = makeSchema({
 					flags: {
-						old1: createSchema('string', { deprecated: true }),
-						old2: createSchema('number', { deprecated: 'removed in v2' }),
+						old1: createFlagSchema('string', { deprecated: true }),
+						old2: createFlagSchema('number', { deprecated: 'removed in v2' }),
 					},
 				});
 				const parsed = makeParsed({ flags: { old1: 'a', old2: 42 } });
@@ -1003,7 +1003,7 @@ describe('resolve', () => {
 
 			it('collects them for deprecated flags and args together', async () => {
 				const schema = makeSchema({
-					flags: { old: createSchema('string', { deprecated: true }) },
+					flags: { old: createFlagSchema('string', { deprecated: true }) },
 					args: [{ name: 'target', schema: createArgSchema('string', { deprecated: true }) }],
 				});
 				const parsed = makeParsed({ flags: { old: 'x' }, args: { target: 'prod' } });
@@ -1015,7 +1015,7 @@ describe('resolve', () => {
 		describe('resolution', () => {
 			it('still resolves deprecated flags', async () => {
 				const schema = makeSchema({
-					flags: { old: createSchema('string', { deprecated: true }) },
+					flags: { old: createFlagSchema('string', { deprecated: true }) },
 				});
 				const parsed = makeParsed({ flags: { old: 'value' } });
 				const result = await resolve(schema, parsed);

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -410,16 +410,6 @@ interface FlagSchema<K extends FlagKind = FlagKind> {
 	readonly duplicates: DuplicatePolicy;
 }
 
-/**
- * Low-level overrides accepted by {@link createSchema}.
- *
- * `aliases` accepts both legacy string input and structured {@link FlagAlias}
- * objects so tests and internal fixtures can be migrated incrementally.
- */
-type FlagSchemaOverrides = Omit<Partial<FlagSchema>, 'aliases'> & {
-	readonly aliases?: readonly (string | FlagAlias)[];
-};
-
 /** Every {@link FlagSchema} field except the brand and the kind discriminator. */
 type FlagSchemaFields = Omit<FlagSchema, typeof schemaBrand | 'kind'>;
 
@@ -966,30 +956,6 @@ function createFlagSchema(
 	const { kind, ...fields } = kindOrDefinition;
 	assertValidFlagDefinition(kind, fields);
 	return buildFlagSchema(kind, normalizeFlagDefinitionFields(fields));
-}
-
-/**
- * Create a raw {@link FlagSchema} object with sensible defaults.
- *
- * `overrides` are shallow-merged on top of the default shape without kind
- * validation and without element normalization.
- *
- * @param kind - Discriminator for the value type this flag accepts.
- * @param overrides - Partial {@link FlagSchema} fields merged onto defaults.
- * @returns A fully populated {@link FlagSchema}.
- *
- * @deprecated Renamed to {@link createFlagSchema}.
- *
- * @example
- * ```ts
- * const schema = createSchema('enum', {
- *   enumValues: ['us', 'eu', 'ap'],
- *   description: 'Deployment region',
- * });
- * ```
- */
-function createSchema(kind: FlagKind, overrides?: FlagSchemaOverrides): FlagSchema {
-	return buildFlagSchema(kind, overrides);
 }
 
 // --- FlagBuilder — immutable builder with type-level tracking
@@ -1892,7 +1858,10 @@ const flag: FlagFactory = {
 			assertStringConstraints(constraints);
 		}
 		return new FlagBuilder(
-			createSchema('string', constraints !== undefined ? { stringConstraints: constraints } : {}),
+			createFlagSchema(
+				'string',
+				constraints !== undefined ? { stringConstraints: constraints } : {},
+			),
 		);
 	},
 
@@ -1907,7 +1876,10 @@ const flag: FlagFactory = {
 			assertNumberConstraints(constraints);
 		}
 		return new FlagBuilder(
-			createSchema('number', constraints !== undefined ? { numberConstraints: constraints } : {}),
+			createFlagSchema(
+				'number',
+				constraints !== undefined ? { numberConstraints: constraints } : {},
+			),
 		);
 	},
 
@@ -1919,7 +1891,7 @@ const flag: FlagFactory = {
 		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(
-			createSchema('boolean', {
+			createFlagSchema('boolean', {
 				presence: 'defaulted',
 				defaultValue: false,
 			}),
@@ -1935,7 +1907,7 @@ const flag: FlagFactory = {
 		readonly flagKind: 'enum';
 		readonly elementEligible: true;
 	}> {
-		return new FlagBuilder(createSchema('enum', { enumValues: values }));
+		return new FlagBuilder(createFlagSchema('enum', { enumValues: values }));
 	},
 
 	array<E extends FlagConfig & { readonly elementEligible: true }>(
@@ -1947,7 +1919,7 @@ const flag: FlagFactory = {
 		readonly flagKind: 'array';
 		readonly elementEligible: false;
 	}> {
-		return new FlagBuilder(createSchema('array', { elementSchema: element.schema }));
+		return new FlagBuilder(createFlagSchema('array', { elementSchema: element.schema }));
 	},
 
 	custom<A extends FlagParseFn<unknown> | StandardSchemaV1>(
@@ -1960,9 +1932,9 @@ const flag: FlagFactory = {
 		readonly elementEligible: true;
 	}> {
 		if (isStandardSchemaV1(parseFnOrSchema)) {
-			return new FlagBuilder(createSchema('custom', { standard: parseFnOrSchema }));
+			return new FlagBuilder(createFlagSchema('custom', { standard: parseFnOrSchema }));
 		}
-		return new FlagBuilder(createSchema('custom', { parseFn: parseFnOrSchema }));
+		return new FlagBuilder(createFlagSchema('custom', { parseFn: parseFnOrSchema }));
 	},
 
 	url(options?: UrlFlagOptions): FlagBuilder<{
@@ -1973,7 +1945,7 @@ const flag: FlagFactory = {
 		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(
-			createSchema('custom', {
+			createFlagSchema('custom', {
 				parseFn: (raw: unknown) => parseUrlValue(raw, options),
 				valueHint: 'url',
 			}),
@@ -1995,7 +1967,7 @@ const flag: FlagFactory = {
 						create: options.type === 'directory' && options.create === true,
 					}
 				: undefined;
-		return new FlagBuilder(createSchema('string', { pathChecks, valueHint: 'path' }));
+		return new FlagBuilder(createFlagSchema('string', { pathChecks, valueHint: 'path' }));
 	},
 
 	date(options?: DateFlagOptions): FlagBuilder<{
@@ -2006,7 +1978,7 @@ const flag: FlagFactory = {
 		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(
-			createSchema('custom', {
+			createFlagSchema('custom', {
 				parseFn: (raw: unknown) => parseDateValue(raw, options),
 				valueHint: 'date',
 			}),
@@ -2021,7 +1993,7 @@ const flag: FlagFactory = {
 		readonly elementEligible: true;
 	}> {
 		return new FlagBuilder(
-			createSchema('custom', { parseFn: parseDurationValue, valueHint: 'duration' }),
+			createFlagSchema('custom', { parseFn: parseDurationValue, valueHint: 'duration' }),
 		);
 	},
 
@@ -2032,7 +2004,9 @@ const flag: FlagFactory = {
 		readonly flagKind: 'custom';
 		readonly elementEligible: true;
 	}> {
-		return new FlagBuilder(createSchema('custom', { parseFn: parseBytesValue, valueHint: 'size' }));
+		return new FlagBuilder(
+			createFlagSchema('custom', { parseFn: parseBytesValue, valueHint: 'size' }),
+		);
 	},
 
 	count(): FlagBuilder<{
@@ -2043,7 +2017,7 @@ const flag: FlagFactory = {
 		readonly elementEligible: false;
 	}> {
 		return new FlagBuilder(
-			createSchema('count', {
+			createFlagSchema('count', {
 				presence: 'defaulted',
 				defaultValue: 0,
 			}),
@@ -2057,7 +2031,7 @@ const flag: FlagFactory = {
 		readonly flagKind: 'keyValue';
 		readonly elementEligible: false;
 	}> {
-		return new FlagBuilder(createSchema('keyValue', { valueHint: 'key=value' }));
+		return new FlagBuilder(createFlagSchema('keyValue', { valueHint: 'key=value' }));
 	},
 };
 
@@ -2098,7 +2072,6 @@ export type {
 	FlagParseFn,
 	FlagPresence,
 	FlagSchema,
-	FlagSchemaOverrides,
 	InferFlag,
 	InferFlags,
 	KeyValueFlagDefinition,
@@ -2114,7 +2087,6 @@ export type {
 };
 export {
 	createFlagSchema,
-	createSchema,
 	FLAG_KINDS,
 	FLAG_PRESENCES,
 	FlagBuilder,

--- a/src/core/schema/index.ts
+++ b/src/core/schema/index.ts
@@ -86,7 +86,6 @@ export type {
 	FlagParseFn,
 	FlagPresence,
 	FlagSchema,
-	FlagSchemaOverrides,
 	InferFlag,
 	InferFlags,
 	InputPromptConfig,
@@ -108,7 +107,6 @@ export type {
 } from './flag.ts';
 export {
 	createFlagSchema,
-	createSchema,
 	FLAG_KINDS,
 	FLAG_PRESENCES,
 	FlagBuilder,

--- a/src/core/schema/prompt.test.ts
+++ b/src/core/schema/prompt.test.ts
@@ -143,7 +143,7 @@ describe('PromptResult types', () => {
 // --- FlagSchema.prompt field
 
 describe('FlagSchema.prompt', () => {
-	it('defaults to undefined in createSchema', () => {
+	it('defaults to undefined in createFlagSchema', () => {
 		const f = flag.string();
 		expect(f.schema.prompt).toBeUndefined();
 	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,7 +242,6 @@ export {
 	createArgSchema,
 	createCommandSchema,
 	createFlagSchema,
-	createSchema,
 	FlagBuilder,
 	flag,
 	getFlagNegatedName,


### PR DESCRIPTION
Breaking, targets v4. Stacked on #101. Implements L4 of the approved v4 plan.

- All 346 remaining `createSchema(` call sites (13 test files + the 14 internal `flag.*()` factory calls) renamed to `createFlagSchema(`; the deprecated alias and `FlagSchemaOverrides` deleted from the exports.
- Internal factory calls now pass through kind validation and element normalization (previously the alias bypassed both); element identity preserved via the normalized-schema passthrough.
- One deliberately-malformed enum fixture (parse.test.ts) converts to the brand-carrying spread pattern, keeping its runtime `INVALID_SCHEMA` branch covered; `numberFlagSchema` and the two kind-widened helpers retype to `FlagDefinitionOverrides` variants.
- Review verified the sweep by reverse-applying the rename over every added line and diffing added-vs-deleted: everything cancels except the four pre-declared structural conversions. Repo-wide `createSchema` hits after: exactly one (the changelog's rename sentence).

Gates: typecheck exit 0, lint clean, fmt clean, 2981/2981 tests, build (attw+publint) clean.