### PR TITLE
refactor(cli)!: split execute/run options, move execution to executeCLI, prune dead exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   writers via `createCaptureOutput()` options or `OutputOptions.stdout`/
   `stderr` instead of replacing the channel wholesale.
 
+- **Breaking: `.execute()` takes `CLIExecuteOptions`**. The new root export
+  carries the process-free option surface and has no `adapter` member; passing
+  one to `.execute()` stops compiling. `CLIRunOptions` now extends
+  `CLIExecuteOptions` with `adapter`, and `.run()` remains the only method that
+  accepts it.
+
+- **Breaking: `CommandConfig` and the root `AnyCommandBuilder` export removed**.
+  `CommandConfig` described the builder's type-level accumulator shape but no
+  signature referenced it. `AnyCommandBuilder` is `@internal` erasure machinery
+  that appears only on `CommandBuilder`'s underscore members, so the package
+  root no longer exports the name.
+
 ### Fixed
 
 - **Quiet mode leaked spinner and progress output** — activity handles now

--- a/docs/reference/stability.md
+++ b/docs/reference/stability.md
@@ -9,10 +9,10 @@ counts as breaking for each category.
 | Category                 | Examples                                                | Minor releases may                                |
 | ------------------------ | ------------------------------------------------------- | ------------------------------------------------- |
 | Sealed framework values  | `Out`, `RenderContext`, `FlagSchema`, `ArgSchema`, `CommandSchema` | add readonly members                   |
-| Consumer input options   | `RunOptions`, `CLIRunOptions`, `OutputOptions`, `RenderContextOptions`, `HelpOptions` | add optional fields |
+| Consumer input options   | `RunOptions`, `CLIExecuteOptions`, `CLIRunOptions`, `OutputOptions`, `RenderContextOptions`, `HelpOptions` | add optional fields |
 | Implementer interfaces   | `RuntimeAdapter`, `PromptEngine`, `CLIPlugin`           | add optional hooks only                           |
 | Closed unions            | `Verbosity`, `ActivityEvent`, `OutputStream`            | change nothing                                    |
-| Internal surface         | underscore members (`_execute`, `_ctx`), `Internal*` option types | change anything, any release            |
+| Internal surface         | underscore members (`_from`, `_ctx`), `Internal*` option types | change anything, any release            |
 
 ## Sealed framework values
 

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -1,6 +1,6 @@
 # cli — CLIBuilder, multi-command dispatch, plugins
 
-`index.ts` (~2193 lines) — heavily split: 9 `@internal` extraction files.
+`index.ts` (~2214 lines) — heavily split: 9 `@internal` extraction files.
 
 ## KEY TYPES
 
@@ -10,8 +10,10 @@
 | `cli(name)`                | Factory function -> `CLIBuilder`                                        |
 | `isMainModule(meta)`       | Entrypoint guard for ambient `ImportMeta` compatibility                 |
 | `CLISchema`                | Runtime descriptor for the full CLI, execution graph excluded           |
-| `CLIRunOptions`            | Extends `RunOptions` with CLI-level settings                            |
+| `CLIExecuteOptions`        | Extends `RunOptions`; the process-free `.execute()` surface             |
+| `CLIRunOptions`            | Extends `CLIExecuteOptions` with the runtime `adapter`                  |
 | `ConfigSettings`           | Config file discovery settings for CLI                                  |
+| `executeCLI()`             | `@internal` — shared execution body behind `.execute()` and `.run()`    |
 | `CompiledCommand`          | `@internal` — handler, steps, and subcommand map for one command        |
 | `CompiledCLI`              | `@internal` — compiled commands, default command, and plugins           |
 | `formatRootHelp()`         | `@internal` — root-level help rendering (in `root-help.ts`)             |
@@ -22,7 +24,7 @@
 
 | File                   | Lines | Purpose                                                              |
 | ---------------------- | ----: | -------------------------------------------------------------------- |
-| `index.ts`             |  2193 | CLIBuilder class + cli() factory + JSON error handling               |
+| `index.ts`             |  2214 | CLIBuilder class + cli() factory + JSON error handling               |
 | `runtime-preflight.ts` |   488 | `@internal` — runtime adapter setup, env/config preflight            |
 | `planner.ts`           |   674 | `@internal` — execution planner, command resolution strategy         |
 | `dispatch.ts`          |   365 | `@internal` — command dispatch (value-flag-arity aware), levenshtein |
@@ -43,10 +45,12 @@ argv -> strip --json flag (before --) -> match subcommand (nested) -> resolve ->
 
 Nested dispatch: `group('db').command(migrate).command(seed)` -> `mycli db migrate --force`
 
-## `execute()` METHOD
+## `executeCLI()`
 
-Handles 6 concerns sequentially: `--json` extraction, `--version`, `--help`, no-commands error,
-command map building, 3-way dispatch result (`unknown` / `needs-subcommand` / `match`).
+Module-level function taking the builder as its first parameter; `.execute()` and `.run()` both
+delegate to it. Handles 6 concerns sequentially: `--json` extraction, `--version`, `--help`,
+no-commands error, command map building, 3-way dispatch result (`unknown` / `needs-subcommand` /
+`match`).
 
 ## `--json` MODE
 

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -48,9 +48,10 @@ Nested dispatch: `group('db').command(migrate).command(seed)` -> `mycli db migra
 ## `executeCLI()`
 
 Module-level function taking the builder as its first parameter; `.execute()` and `.run()` both
-delegate to it. Handles 6 concerns sequentially: `--json` extraction, `--version`, `--help`,
-no-commands error, command map building, 3-way dispatch result (`unknown` / `needs-subcommand` /
-`match`).
+delegate to it. It detects root `--json` / `--quiet`, builds or adopts the output channel, resolves
+help options, then calls `planInvocation()` and renders the plan. `planner.ts` owns command map
+building and the no-commands error; `executeCLI()` renders the six plan kinds: `root-version`,
+`root-completions`, `root-help`, `dispatch-error`, `needs-subcommand`, and `match`.
 
 ## `--json` MODE
 

--- a/src/core/cli/cli-json.test.ts
+++ b/src/core/cli/cli-json.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { executeCLI } from '#internals/core/cli/index.ts';
 import { CLIError } from '#internals/core/errors/index.ts';
 import { createCaptureOutput } from '#internals/core/output/index.ts';
 import { command } from '#internals/core/schema/command.ts';
@@ -252,7 +253,7 @@ describe('CLIBuilder --json with root flags', () => {
 		// must honor `options.jsonMode` / root `--json`, not just the channel flag.
 		const [out, captured] = createCaptureOutput();
 		const app = cli('test').version('1.0.0').command(dataCommand());
-		const result = await app._execute(['data', '--help', '--json'], { out, captured });
+		const result = await executeCLI(app, ['data', '--help', '--json'], { out, captured });
 
 		expect(result.exitCode).toBe(0);
 		const doc: unknown = JSON.parse(captured.stdout.join(''));

--- a/src/core/cli/cli.test.ts
+++ b/src/core/cli/cli.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { executeCLI } from '#internals/core/cli/index.ts';
 import { ParseError } from '#internals/core/errors/index.ts';
 import { createCaptureOutput } from '#internals/core/output/index.ts';
 import { arg } from '#internals/core/schema/arg.ts';
@@ -681,7 +682,7 @@ describe('options passthrough', () => {
 				throw new Error('kaboom');
 			}),
 		);
-		const result = await app._execute(['build'], { out, captured });
+		const result = await executeCLI(app, ['build'], { out, captured });
 
 		expect(result.exitCode).toBe(1);
 		expect(result.error?.code).toBe('UNEXPECTED_ERROR');

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -658,16 +658,23 @@ function createCLISchema(definition: CLIDefinition): CLISchema {
 // --- Options for execute/run
 
 /**
- * Options for {@linkcode CLIBuilder.execute | .execute()} and {@linkcode CLIBuilder.run | .run()}.
+ * Options for {@linkcode CLIBuilder.execute | .execute()}, the process-free
+ * execution surface.
  *
- * Derives from {@linkcode RunOptions}, adding the CLI-level runtime adapter.
+ * Derives from {@linkcode RunOptions} with every input injected explicitly.
  */
-interface CLIRunOptions extends RunOptions {
+interface CLIExecuteOptions extends RunOptions {}
+
+/**
+ * Options for {@linkcode CLIBuilder.run | .run()}.
+ *
+ * Derives from {@linkcode CLIExecuteOptions}, adding the CLI-level runtime adapter.
+ */
+interface CLIRunOptions extends CLIExecuteOptions {
 	/**
 	 * Runtime adapter providing platform-specific I/O, argv, env, etc.
 	 *
-	 * When provided to `.run()`, replaces the default Node adapter.
-	 * Ignored by `.execute()` (which is process-free by design).
+	 * Replaces the default Node adapter.
 	 */
 	readonly adapter?: RuntimeAdapter;
 }
@@ -678,7 +685,7 @@ interface CLIRunOptions extends RunOptions {
  *
  * @internal
  */
-interface InternalCLIRunOptions extends CLIRunOptions {
+interface InternalCLIExecuteOptions extends CLIExecuteOptions {
 	/** Output channel override so activity renders to the terminal. */
 	readonly out?: Out;
 	/** Capture buffers override paired with `out`. */
@@ -844,7 +851,7 @@ function hyperlinksOption(override: boolean | undefined): { hyperlinks?: boolean
 }
 
 /**
- * Build {@linkcode RunOptions} from {@linkcode CLIRunOptions}, conditionally spreading each
+ * Build {@linkcode RunOptions} from {@linkcode CLIExecuteOptions}, conditionally spreading each
  * field to satisfy `exactOptionalPropertyTypes`.
  *
  * @param options - CLI-level run options (may be `undefined` for defaults).
@@ -855,7 +862,7 @@ function hyperlinksOption(override: boolean | undefined): { hyperlinks?: boolean
  * @internal
  */
 function buildCommandRunOptions(
-	options: InternalCLIRunOptions | undefined,
+	options: InternalCLIExecuteOptions | undefined,
 	helpOptions: HelpOptions,
 	meta?: CommandMeta,
 ): InternalRunOptions {
@@ -1525,182 +1532,8 @@ class CLIBuilder {
 	 * @param options - Injectable runtime state.
 	 * @returns Structured result with exit code and captured output.
 	 */
-	async execute(argv: readonly string[], options?: CLIRunOptions): Promise<RunResult> {
-		return this._execute(argv, options);
-	}
-
-	/**
-	 * Execution body shared by {@linkcode execute} and {@linkcode run}, accepting
-	 * the framework-populated output channel and plugin fields.
-	 *
-	 * @internal
-	 */
-	async _execute(argv: readonly string[], options?: InternalCLIRunOptions): Promise<RunResult> {
-		// -- Detect global --json / --quiet before building output ----------------
-		// Only occurrences before the `--` separator count; a literal positional
-		// (after `--`) must reach the command unchanged (#28).
-		const hasJsonFlag = includesBeforeSeparator(argv, '--json');
-		const jsonMode = hasJsonFlag || options?.jsonMode === true;
-		const hasQuietFlag =
-			includesBeforeSeparator(argv, '--quiet') || includesBeforeSeparator(argv, '-q');
-		const verbosity: Verbosity | undefined = hasQuietFlag ? 'quiet' : options?.verbosity;
-
-		const captureOptions = {
-			...(verbosity !== undefined ? { verbosity } : {}),
-			...(jsonMode ? { jsonMode } : {}),
-			...(options?.isTTY !== undefined ? { isTTY: options.isTTY } : {}),
-			...hyperlinksOption(resolveHyperlinkOverride(options?.env ?? {}, argv)),
-		};
-		let out: Out;
-		let captured: CapturedOutput;
-		if (options?.out !== undefined) {
-			out = options.out;
-			captured = options.captured ?? { stdout: [], stderr: [], activity: [] };
-		} else {
-			[out, captured] = createCaptureOutput(
-				Object.keys(captureOptions).length > 0 ? captureOptions : undefined,
-			);
-		}
-		clearRequestedExitCode(out);
-
-		// Resolve help options — builder-level `.help()` config under runtime
-		// `options.help` (runtime wins), then default binName to the CLI program
-		// name, hyperlinks to the channel's resolved support (NO_HYPERLINKS/
-		// FORCE_HYPERLINKS honored, else TTY), and colors to the output
-		// channel's gated palette (escapes never leak into piped output).
-		const resolvedVersion = options?.help?.version ?? this.schema.version;
-		const helpOptions: HelpOptions = {
-			...this.schema.helpConfig,
-			...options?.help,
-			binName: options?.help?.binName ?? this.schema.name,
-			hyperlinks:
-				options?.help?.hyperlinks ?? this.schema.helpConfig?.hyperlinks ?? out.isHyperlinkSupported,
-			colors: options?.help?.colors ?? out.color,
-			...(resolvedVersion !== undefined ? { version: resolvedVersion } : {}),
-		};
-
-		// -- Shared options for command execution ----------------------------------
-		const compiled = compiledStateOf(this);
-		const flagSettings = options?.flags ?? this.schema.flagSettings;
-		const effectiveOptions: InternalCLIRunOptions = {
-			...options,
-			plugins: compiled.plugins,
-			...(jsonMode ? { jsonMode } : {}),
-			...(verbosity !== undefined ? { verbosity } : {}),
-			...(flagSettings !== undefined ? { flags: flagSettings } : {}),
-		};
-		const output: OutputPolicy = {
-			jsonMode,
-			isTTY: out.isTTY,
-			verbosity: verbosity ?? 'normal',
-		};
-		// The planner scans flag arity during dispatch, so it must see the same
-		// merged flag settings (runtime override wins) that command parsing uses.
-		const planSchema =
-			options?.flags !== undefined ? { ...this.schema, flagSettings } : this.schema;
-		const planned = planInvocation({
-			schema: planSchema,
-			compiled,
-			argv,
-			help: helpOptions,
-			output,
-		});
-
-		switch (planned.kind) {
-			case 'root-version':
-				out.log(planned.version);
-				return buildRunResult({ exitCode: 0, error: undefined }, captured);
-
-			case 'root-completions': {
-				const shell = planned.shell ?? detectShell(options?.env ?? {});
-				if (shell === undefined) {
-					const error = new CLIError('Could not detect shell', {
-						code: 'MISSING_VALUE',
-						suggest: `Pass one explicitly, e.g. '${helpOptions.binName} --completions zsh'`,
-					});
-					if (jsonMode) {
-						out.json({ error: error.toJSON() });
-					} else {
-						out.error(error.message);
-						out.error(`Suggestion: ${error.suggest}`);
-					}
-					return buildRunResult({ exitCode: error.exitCode, error }, captured);
-				}
-				const completionSchema =
-					helpOptions.binName === undefined || helpOptions.binName === this.schema.name
-						? this.schema
-						: { ...this.schema, name: helpOptions.binName };
-				const script = generateCompletion(completionSchema, shell, planned.options);
-				if (jsonMode) {
-					out.json({ shell, script });
-				} else {
-					out.log(script);
-				}
-				return buildRunResult({ exitCode: 0, error: undefined }, captured);
-			}
-
-			case 'root-help': {
-				if (jsonMode) {
-					out.json(
-						generateSchema(this.schema, undefined, {
-							name: planned.help.binName ?? this.schema.name,
-							version: planned.help.version ?? this.schema.version,
-						}),
-					);
-				} else {
-					const helpText = formatRootHelp(resolveHelpLinksSchema(this.schema), planned.help);
-					out.log(helpText);
-				}
-				return buildRunResult({ exitCode: 0, error: undefined }, captured);
-			}
-
-			case 'dispatch-error': {
-				if (jsonMode) {
-					out.json({ error: planned.error.toJSON() });
-				} else {
-					out.error(planned.error.message);
-					if (planned.error.suggest !== undefined && planned.error.code !== 'NO_ACTION') {
-						out.error(`Suggestion: ${planned.error.suggest}`);
-					}
-				}
-				return buildRunResult({ exitCode: planned.error.exitCode, error: planned.error }, captured);
-			}
-
-			case 'needs-subcommand': {
-				if (jsonMode) {
-					out.json(
-						generateCommandSchema(planned.command.schema, undefined, {
-							name: planned.help.binName ?? planned.command.schema.name,
-							version: planned.help.version,
-						}),
-					);
-				} else {
-					const helpText = formatHelp(planned.command.schema, planned.help);
-					out.log(helpText);
-				}
-				return buildRunResult({ exitCode: 0, error: undefined }, captured);
-			}
-
-			case 'match': {
-				const commandRunOptions = buildCommandRunOptions(
-					effectiveOptions,
-					planned.plan.help ?? helpOptions,
-					planned.plan.meta,
-				);
-				const result = await executeCommand({
-					command: {
-						handler: planned.plan.command.handler,
-						steps: planned.plan.command.steps,
-					},
-					argv: planned.plan.argv,
-					out,
-					schema: planned.plan.mergedSchema,
-					meta: planned.plan.meta,
-					options: commandRunOptions,
-				});
-				return buildRunResult(result, captured);
-			}
-		}
+	async execute(argv: readonly string[], options?: CLIExecuteOptions): Promise<RunResult> {
+		return executeCLI(this, argv, options);
 	}
 
 	/**
@@ -1757,7 +1590,7 @@ class CLIBuilder {
 			runtimeHelpWidth !== undefined
 				? { ...options?.help, width: runtimeHelpWidth }
 				: options?.help;
-		const executeOptions: InternalCLIRunOptions = {
+		const executeOptions: InternalCLIExecuteOptions = {
 			...options,
 			...preflight.inputs,
 			...(runtimeHelpOptions !== undefined ? { help: runtimeHelpOptions } : {}),
@@ -1772,7 +1605,7 @@ class CLIBuilder {
 				...hyperlinksOption(resolveHyperlinkOverride(adapter.env, adapter.argv)),
 			}),
 		};
-		const result = await effectiveBuilder._execute(preflight.filteredArgv, executeOptions);
+		const result = await executeCLI(effectiveBuilder, preflight.filteredArgv, executeOptions);
 
 		// Write captured output to real streams via adapter
 		for (const line of result.stdout) {
@@ -1785,6 +1618,192 @@ class CLIBuilder {
 		return adapter.exit(result.exitCode);
 	}
 }
+
+/**
+ * Execution body shared by {@linkcode CLIBuilder.execute} and {@linkcode CLIBuilder.run},
+ * accepting the framework-populated output channel and plugin fields.
+ *
+ * @param builder - Builder supplying the schema and compiled command graph.
+ * @param argv - Raw argv tokens (NOT including the binary/script path).
+ * @param options - Injectable runtime state plus framework-populated fields.
+ * @returns Structured result with exit code and captured output.
+ *
+ * @internal
+ */
+async function executeCLI(
+	builder: CLIBuilder,
+	argv: readonly string[],
+	options?: InternalCLIExecuteOptions,
+): Promise<RunResult> {
+	// -- Detect global --json / --quiet before building output ----------------
+	// Only occurrences before the `--` separator count; a literal positional
+	// (after `--`) must reach the command unchanged (#28).
+	const hasJsonFlag = includesBeforeSeparator(argv, '--json');
+	const jsonMode = hasJsonFlag || options?.jsonMode === true;
+	const hasQuietFlag =
+		includesBeforeSeparator(argv, '--quiet') || includesBeforeSeparator(argv, '-q');
+	const verbosity: Verbosity | undefined = hasQuietFlag ? 'quiet' : options?.verbosity;
+
+	const captureOptions = {
+		...(verbosity !== undefined ? { verbosity } : {}),
+		...(jsonMode ? { jsonMode } : {}),
+		...(options?.isTTY !== undefined ? { isTTY: options.isTTY } : {}),
+		...hyperlinksOption(resolveHyperlinkOverride(options?.env ?? {}, argv)),
+	};
+	let out: Out;
+	let captured: CapturedOutput;
+	if (options?.out !== undefined) {
+		out = options.out;
+		captured = options.captured ?? { stdout: [], stderr: [], activity: [] };
+	} else {
+		[out, captured] = createCaptureOutput(
+			Object.keys(captureOptions).length > 0 ? captureOptions : undefined,
+		);
+	}
+	clearRequestedExitCode(out);
+
+	// Resolve help options — builder-level `.help()` config under runtime
+	// `options.help` (runtime wins), then default binName to the CLI program
+	// name, hyperlinks to the channel's resolved support (NO_HYPERLINKS/
+	// FORCE_HYPERLINKS honored, else TTY), and colors to the output
+	// channel's gated palette (escapes never leak into piped output).
+	const resolvedVersion = options?.help?.version ?? builder.schema.version;
+	const helpOptions: HelpOptions = {
+		...builder.schema.helpConfig,
+		...options?.help,
+		binName: options?.help?.binName ?? builder.schema.name,
+		hyperlinks:
+			options?.help?.hyperlinks ??
+			builder.schema.helpConfig?.hyperlinks ??
+			out.isHyperlinkSupported,
+		colors: options?.help?.colors ?? out.color,
+		...(resolvedVersion !== undefined ? { version: resolvedVersion } : {}),
+	};
+
+	// -- Shared options for command execution ----------------------------------
+	const compiled = compiledStateOf(builder);
+	const flagSettings = options?.flags ?? builder.schema.flagSettings;
+	const effectiveOptions: InternalCLIExecuteOptions = {
+		...options,
+		plugins: compiled.plugins,
+		...(jsonMode ? { jsonMode } : {}),
+		...(verbosity !== undefined ? { verbosity } : {}),
+		...(flagSettings !== undefined ? { flags: flagSettings } : {}),
+	};
+	const output: OutputPolicy = {
+		jsonMode,
+		isTTY: out.isTTY,
+		verbosity: verbosity ?? 'normal',
+	};
+	// The planner scans flag arity during dispatch, so it must see the same
+	// merged flag settings (runtime override wins) that command parsing uses.
+	const planSchema =
+		options?.flags !== undefined ? { ...builder.schema, flagSettings } : builder.schema;
+	const planned = planInvocation({
+		schema: planSchema,
+		compiled,
+		argv,
+		help: helpOptions,
+		output,
+	});
+
+	switch (planned.kind) {
+		case 'root-version':
+			out.log(planned.version);
+			return buildRunResult({ exitCode: 0, error: undefined }, captured);
+
+		case 'root-completions': {
+			const shell = planned.shell ?? detectShell(options?.env ?? {});
+			if (shell === undefined) {
+				const error = new CLIError('Could not detect shell', {
+					code: 'MISSING_VALUE',
+					suggest: `Pass one explicitly, e.g. '${helpOptions.binName} --completions zsh'`,
+				});
+				if (jsonMode) {
+					out.json({ error: error.toJSON() });
+				} else {
+					out.error(error.message);
+					out.error(`Suggestion: ${error.suggest}`);
+				}
+				return buildRunResult({ exitCode: error.exitCode, error }, captured);
+			}
+			const completionSchema =
+				helpOptions.binName === undefined || helpOptions.binName === builder.schema.name
+					? builder.schema
+					: { ...builder.schema, name: helpOptions.binName };
+			const script = generateCompletion(completionSchema, shell, planned.options);
+			if (jsonMode) {
+				out.json({ shell, script });
+			} else {
+				out.log(script);
+			}
+			return buildRunResult({ exitCode: 0, error: undefined }, captured);
+		}
+
+		case 'root-help': {
+			if (jsonMode) {
+				out.json(
+					generateSchema(builder.schema, undefined, {
+						name: planned.help.binName ?? builder.schema.name,
+						version: planned.help.version ?? builder.schema.version,
+					}),
+				);
+			} else {
+				const helpText = formatRootHelp(resolveHelpLinksSchema(builder.schema), planned.help);
+				out.log(helpText);
+			}
+			return buildRunResult({ exitCode: 0, error: undefined }, captured);
+		}
+
+		case 'dispatch-error': {
+			if (jsonMode) {
+				out.json({ error: planned.error.toJSON() });
+			} else {
+				out.error(planned.error.message);
+				if (planned.error.suggest !== undefined && planned.error.code !== 'NO_ACTION') {
+					out.error(`Suggestion: ${planned.error.suggest}`);
+				}
+			}
+			return buildRunResult({ exitCode: planned.error.exitCode, error: planned.error }, captured);
+		}
+
+		case 'needs-subcommand': {
+			if (jsonMode) {
+				out.json(
+					generateCommandSchema(planned.command.schema, undefined, {
+						name: planned.help.binName ?? planned.command.schema.name,
+						version: planned.help.version,
+					}),
+				);
+			} else {
+				const helpText = formatHelp(planned.command.schema, planned.help);
+				out.log(helpText);
+			}
+			return buildRunResult({ exitCode: 0, error: undefined }, captured);
+		}
+
+		case 'match': {
+			const commandRunOptions = buildCommandRunOptions(
+				effectiveOptions,
+				planned.plan.help ?? helpOptions,
+				planned.plan.meta,
+			);
+			const result = await executeCommand({
+				command: {
+					handler: planned.plan.command.handler,
+					steps: planned.plan.command.steps,
+				},
+				argv: planned.plan.argv,
+				out,
+				schema: planned.plan.mergedSchema,
+				meta: planned.plan.meta,
+				options: commandRunOptions,
+			});
+			return buildRunResult(result, captured);
+		}
+	}
+}
+
 const RUNTIME_BINARIES = new Set(['bun', 'deno', 'node', 'tsx']);
 
 /**
@@ -2176,6 +2195,7 @@ export type {
 } from './plugin.ts';
 export type {
 	CLIDefinition,
+	CLIExecuteOptions,
 	CLIOptions,
 	CLIRunOptions,
 	CLISchema,
@@ -2197,6 +2217,7 @@ export {
 	cli,
 	compiledStateOf,
 	createCLISchema,
+	executeCLI,
 	isMainModule,
 	plugin,
 	resolveRenderContext,

--- a/src/core/cli/root-help-theme.test.ts
+++ b/src/core/cli/root-help-theme.test.ts
@@ -7,6 +7,7 @@
 import { createColors } from 'ansispeck';
 import { describe, expect, it } from 'vitest';
 
+import { executeCLI } from '#internals/core/cli/index.ts';
 import { stripAnsi } from '#internals/core/help/ansi.ts';
 import { createCaptureOutput } from '#internals/core/output/index.ts';
 import { command } from '#internals/core/schema/command.ts';
@@ -39,7 +40,7 @@ describe('root help theming', () => {
 
 	it('styles header, sections, and commands under forced color', async () => {
 		const [out, captured] = createCaptureOutput({ color: true });
-		await app()._execute(['--help'], { out, captured });
+		await executeCLI(app(), ['--help'], { out, captured });
 		const output = captured.stdout.join('');
 		expect(output).toContain(on.bold('mycli'));
 		expect(output).toContain(on.dim('v1.0.0'));
@@ -53,7 +54,7 @@ describe('root help theming', () => {
 	it('strip-equivalence: forced-color root help strips to the plain rendering', async () => {
 		const plain = (await app().execute(['--help'])).stdout.join('');
 		const [out, captured] = createCaptureOutput({ color: true });
-		await app()._execute(['--help'], { out, captured });
+		await executeCLI(app(), ['--help'], { out, captured });
 		expect(stripAnsi(captured.stdout.join(''))).toBe(plain);
 	});
 
@@ -73,7 +74,7 @@ describe('root help theming', () => {
 				);
 		const plain = (await build().execute(['--help'])).stdout.join('');
 		const [out, captured] = createCaptureOutput({ color: true });
-		await build()._execute(['--help'], { out, captured });
+		await executeCLI(build(), ['--help'], { out, captured });
 		const colored = captured.stdout.join('');
 		expect(stripAnsi(colored)).toBe(plain);
 		// The merged usage block: root line + continuation aligned under 'Usage: '.
@@ -85,9 +86,10 @@ describe('root help theming', () => {
 
 	it('threads .help({ theme }) overrides into root help', async () => {
 		const [out, captured] = createCaptureOutput({ color: true });
-		await app()
-			.help({ theme: (c) => ({ command: c.green }) })
-			._execute(['--help'], { out, captured });
+		await executeCLI(app().help({ theme: (c) => ({ command: c.green }) }), ['--help'], {
+			out,
+			captured,
+		});
 		const output = captured.stdout.join('');
 		expect(output).toContain(on.green('deploy'));
 		expect(output).not.toContain(on.cyan('deploy'));

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -53,21 +53,6 @@ type WidenContext<C extends Record<string, unknown>, Output extends Record<strin
 type WidenDerivedContext<C extends Record<string, unknown>, Output> =
 	Awaited<Output> extends Record<string, unknown> ? WidenContext<C, Awaited<Output>> : C;
 
-// --- Type-level configuration (phantom state tracked through the chain)
-
-/**
- * Compile-time state carried through the command builder chain.
- *
- * `F` accumulates named flag builders; `A` accumulates named arg builders.
- * Both start empty (`{}`) and grow as `.flag()` / `.arg()` are called.
- */
-interface CommandConfig {
-	/** Accumulated flag builders keyed by flag name. */
-	readonly flags: Record<string, FlagBuilder<FlagConfig>>;
-	/** Accumulated arg builders keyed by arg name. */
-	readonly args: Record<string, ArgBuilder<ArgConfig>>;
-}
-
 // --- Interactive resolver types
 
 /**
@@ -1676,7 +1661,6 @@ export type {
 	AnyCommandBuilder,
 	CommandArgEntry,
 	CommandArgEntryDefinition,
-	CommandConfig,
 	CommandDefinition,
 	CommandExample,
 	CommandMeta,

--- a/src/core/schema/index.ts
+++ b/src/core/schema/index.ts
@@ -44,7 +44,6 @@ export type {
 	AnyCommandBuilder,
 	CommandArgEntry,
 	CommandArgEntryDefinition,
-	CommandConfig,
 	CommandDefinition,
 	CommandExample,
 	CommandMeta,

--- a/src/core/testkit/testkit-prompt.test.ts
+++ b/src/core/testkit/testkit-prompt.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { CLIRunOptions } from '#internals/core/cli/index.ts';
+import type { CLIExecuteOptions, CLIRunOptions } from '#internals/core/cli/index.ts';
 import { cli } from '#internals/core/cli/index.ts';
 import { createCaptureOutput } from '#internals/core/output/index.ts';
 import { createTestPrompter, PROMPT_CANCEL } from '#internals/core/prompt/index.ts';
@@ -677,6 +677,18 @@ describe('public surface exports', () => {
 		void invalidOut;
 		void invalidCaptured;
 		void invalidPlugins;
+
+		expect(true).toBe(true);
+	});
+
+	it('CLIExecuteOptions excludes the runtime adapter', () => {
+		const runOnly: Pick<CLIRunOptions, 'adapter'> = {};
+		const invalidAdapter = {
+			// @ts-expect-error — `adapter` reaches `.run()` only; `.execute()` is process-free
+			adapter: runOnly.adapter,
+		} satisfies CLIExecuteOptions;
+
+		void invalidAdapter;
 
 		expect(true).toBe(true);
 	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export type { Colors } from 'ansispeck';
 export type {
 	BeforeParseParams,
 	CLIDefinition,
+	CLIExecuteOptions,
 	CLIOptions,
 	CLIPlugin,
 	CLIPluginHooks,
@@ -133,7 +134,6 @@ export type {
 	ActionHandler,
 	ActionParams,
 	ActivityEvent,
-	AnyCommandBuilder,
 	ArgConfig,
 	ArgDefinition,
 	ArgDefinitionBase,
@@ -148,7 +148,6 @@ export type {
 	BooleanFlagDefinition,
 	CommandArgEntry,
 	CommandArgEntryDefinition,
-	CommandConfig,
 	CommandDefinition,
 	CommandExample,
 	CommandMeta,


### PR DESCRIPTION
Breaking, targets v4. Stacked on #102. Implements L5 of the approved v4 plan.

- `CLIExecuteOptions extends RunOptions` is the process-free `execute()` surface; `CLIRunOptions extends CLIExecuteOptions` holds only `adapter`. `execute()` stops accepting an option it always ignored. New type test pins the exclusion.
- `CLIBuilder._execute` becomes the internal module function `executeCLI(builder, argv, options)` (token-diff-verified identical body); the class declaration surface is now exactly `schema`, private constructor, `_from`, and the builder methods. `InternalCLIExecuteOptions` no longer appears in the class d.ts.
- Dead `CommandConfig` deleted (three hits repo-wide: definition + two export lines); `AnyCommandBuilder` leaves the root export list (stays module-exported for the erasure machinery's public signatures — d.ts resolution verified in dist).
- Review fixed a factually wrong changelog claim (the `./schema` subpath serves the JSON meta-schema, not a module) and two stale AGENTS.md rows.

Gates: typecheck exit 0, lint clean, fmt clean, 2982/2982 tests, build (attw+publint) clean, docs build clean, knip no-delta.