### PR TITLE
feat(cli)!: remove the 2.5-era deprecated manifest API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ specs/                      # planning/design docs
 | Fix argv parsing                              | `src/core/parse/`               | tokenizer + parser live in one file        |
 | Fix resolution precedence                     | `src/core/resolve/`             | argv -> env -> config -> prompt -> default |
 | Change help text formatting                   | `src/core/help/`                | width-aware text formatter                 |
-| Change config discovery or `packageJson()`    | `src/core/config/`              | config loaders + package metadata walk-up  |
+| Change config discovery or `manifest()`       | `src/core/config/`              | config loaders + package metadata walk-up  |
 | Change prompt UX or test prompts              | `src/core/prompt/`              | prompt engines and sentinels               |
 | Change JSON Schema output                     | `src/core/json-schema/`         | definition schema + input schema           |
 | Change output, spinner, or progress           | `src/core/output/`              | stdout/stderr and activity handles         |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   that appears only on `CommandBuilder`'s underscore members, so the package
   root no longer exports the name.
 
+### Removed
+
+- **Breaking: `.packageJson()`** — deprecated since 2.5. Use `.manifest()`,
+  which defaults to `files: ['package.json']` and accepts the same pre-loaded
+  data object.
+
+- **Breaking: `.denoJson()`** — deprecated since 2.5. Use
+  `.manifest({ files: ['deno.json', 'deno.jsonc', 'jsr.json'] })`.
+
+- **Breaking: `ManifestPresetSettings`** — the settings type of the two removed
+  presets. Use `ManifestSettings`, which adds `files`.
+
+- **Breaking: `PackageJsonSettings`** — the deprecated alias for
+  `ResolvedManifestSettings`, the shape stored in
+  `CLISchema.packageJsonSettings`. The schema field itself is unchanged.
+
+- **Breaking: `discoverPackageJson()`** — deprecated since 2.5. Use
+  `discoverManifest(adapter, { startDir, files: ['package.json'] })`; `files`
+  already defaults to `['package.json']`.
+
 ### Fixed
 
 - **Quiet mode leaked spinner and progress output** — activity handles now

--- a/docs/reference/main.md
+++ b/docs/reference/main.md
@@ -93,9 +93,9 @@ cli('mycli')
 Source the CLI's `version` and `description` (and optionally its name) from a manifest file —
 `package.json`, `deno.json`, or `jsr.json`. There are two complementary forms.
 
-> `.packageJson()` and `.denoJson()` are **deprecated** thin presets over `.manifest()` (pinning
-> `files` to `['package.json']` and `['deno.json', 'deno.jsonc', 'jsr.json']` respectively). Prefer
-> `.manifest()`.
+> `.packageJson()` and `.denoJson()` were **removed in v4**. Use `.manifest()`: it defaults to
+> `files: ['package.json']`, and `.denoJson()` becomes
+> `.manifest({ files: ['deno.json', 'deno.jsonc', 'jsr.json'] })`.
 
 **Discovery (`settings`) form.** During `.run()`, dreamcli walks up from the current working
 directory and reads the nearest manifest among `files` (default `['package.json']`); the nearest
@@ -564,7 +564,7 @@ const own = await discoverManifest(adapter, {
 });
 ```
 
-> `discoverPackageJson(adapter, startDir?)` is a **deprecated** alias that delegates to
+> `discoverPackageJson(adapter, startDir?)` was **removed in v4**. Use
 > `discoverManifest(adapter, { startDir, files: ['package.json'] })`.
 
 ### `inferCliName(pkg, options?)`

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -118,7 +118,7 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
 | `cli-config.test.ts`              | Config discovery integration            |
 | `cli-propagate.test.ts`           | Flag propagation through command tree   |
 | `cli-plugin.test.ts`              | Plugin system tests                     |
-| `cli-package-json.test.ts`        | Package.json metadata integration       |
+| `cli-manifest.test.ts`            | Manifest metadata integration           |
 | `cli-links.test.ts`               | Help link derivation and overrides      |
 | `cli-examples.test.ts`            | Example rendering in help               |
 | `cli-flag-order.test.ts`          | Flag ordering in help output            |

--- a/src/core/cli/cli-links.test.ts
+++ b/src/core/cli/cli-links.test.ts
@@ -1,9 +1,9 @@
 /**
  * Integration tests for OSC 8 hyperlinks in the root-help header.
  *
- * Tests the .links() builder method, TTY gating, derivation from
- * package.json metadata (repository/homepage, discovery and pre-loaded
- * data), and that escapes never leak outside the header line.
+ * Tests the .links() builder method, TTY gating, derivation from manifest
+ * metadata (repository/homepage, discovery and pre-loaded data), and that
+ * escapes never leak outside the header line.
  */
 import { describe, expect, it } from 'vitest';
 import { osc8 } from '#internals/core/help/index.ts';
@@ -16,6 +16,9 @@ import { formatRootHelp } from './root-help.ts';
 
 const ESC = '\u001B';
 const REPO = 'https://github.com/me/mytool';
+
+/** Deno manifest filenames in discovery priority order. */
+const DENO_FILES: readonly string[] = ['deno.json', 'deno.jsonc', 'jsr.json'];
 
 /** Command with a description for the commands table. */
 function deployCommand() {
@@ -211,12 +214,12 @@ describe('root help — explicit links', () => {
 	});
 });
 
-// === Root help — links derived from package.json data
+// === Root help — links derived from pre-loaded manifest data
 
-describe('root help — links derived from .packageJson(data)', () => {
+describe('root help — links derived from .manifest(data)', () => {
 	it('derives name from repository and version from the GitHub release tag', async () => {
 		const app = cli('mytool')
-			.packageJson({ version: '2.5.0', repository: `git+${REPO}.git` })
+			.manifest({ version: '2.5.0', repository: `git+${REPO}.git` })
 			.links()
 			.command(deployCommand());
 
@@ -228,10 +231,10 @@ describe('root help — links derived from .packageJson(data)', () => {
 		);
 	});
 
-	it('derives links when .links() is called before .packageJson(data)', async () => {
+	it('derives links when .links() is called before .manifest(data)', async () => {
 		const app = cli('mytool')
 			.links()
-			.packageJson({ version: '2.5.0', repository: REPO })
+			.manifest({ version: '2.5.0', repository: REPO })
 			.command(deployCommand());
 
 		const result = await app.execute(['--help'], { isTTY: true });
@@ -241,7 +244,7 @@ describe('root help — links derived from .packageJson(data)', () => {
 
 	it('falls back to homepage for the name when no repository exists', async () => {
 		const app = cli('mytool')
-			.packageJson({ version: '1.0.0', homepage: 'https://mytool.dev' })
+			.manifest({ version: '1.0.0', homepage: 'https://mytool.dev' })
 			.links()
 			.command(deployCommand());
 
@@ -256,7 +259,7 @@ describe('root help — links derived from .packageJson(data)', () => {
 	it('uses the GitLab release route for gitlab.com repositories', async () => {
 		const repo = 'https://gitlab.com/me/mytool';
 		const app = cli('mytool')
-			.packageJson({ version: '1.0.0', repository: `git+${repo}.git` })
+			.manifest({ version: '1.0.0', repository: `git+${repo}.git` })
 			.links()
 			.command(deployCommand());
 
@@ -267,7 +270,7 @@ describe('root help — links derived from .packageJson(data)', () => {
 
 	it('explicit URLs win over derived ones', async () => {
 		const app = cli('mytool')
-			.packageJson({ version: '1.0.0', repository: REPO, homepage: 'https://mytool.dev' })
+			.manifest({ version: '1.0.0', repository: REPO, homepage: 'https://mytool.dev' })
 			.links({ name: 'https://docs.mytool.dev' })
 			.command(deployCommand());
 
@@ -281,7 +284,7 @@ describe('root help — links derived from .packageJson(data)', () => {
 	it('explicit .version() is used for the derived release tag', async () => {
 		const app = cli('mytool')
 			.version('9.9.9')
-			.packageJson({ version: '1.0.0', repository: REPO })
+			.manifest({ version: '1.0.0', repository: REPO })
 			.links()
 			.command(deployCommand());
 
@@ -290,8 +293,8 @@ describe('root help — links derived from .packageJson(data)', () => {
 		expect(result.stdout.join('')).toContain(osc8(`${REPO}/releases/tag/v9.9.9`, 'v9.9.9'));
 	});
 
-	it('renders a plain header when package.json has no link metadata', async () => {
-		const app = cli('mytool').packageJson({ version: '1.0.0' }).links().command(deployCommand());
+	it('renders a plain header when the manifest has no link metadata', async () => {
+		const app = cli('mytool').manifest({ version: '1.0.0' }).links().command(deployCommand());
 
 		const result = await app.execute(['--help'], { isTTY: true });
 
@@ -312,7 +315,7 @@ describe('root help — links derived from package.json discovery in .run()', ()
 	};
 
 	it('derives links from the discovered package.json on a TTY', async () => {
-		const app = cli('mytool').packageJson().links().command(deployCommand());
+		const app = cli('mytool').manifest().links().command(deployCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], { files, isTTY: true });
 
@@ -323,7 +326,7 @@ describe('root help — links derived from package.json discovery in .run()', ()
 	});
 
 	it('stays plain when stdout is not a TTY', async () => {
-		const app = cli('mytool').packageJson().links().command(deployCommand());
+		const app = cli('mytool').manifest().links().command(deployCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], { files });
 
@@ -332,7 +335,7 @@ describe('root help — links derived from package.json discovery in .run()', ()
 		expect(output).toContain('mytool v3.0.0');
 	});
 
-	it('explicit links work in .run() without .packageJson()', async () => {
+	it('explicit links work in .run() without .manifest()', async () => {
 		const app = cli('mytool').version('1.0.0').links({ name: REPO }).command(deployCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], { isTTY: true });
@@ -345,7 +348,7 @@ describe('root help — links derived from package.json discovery in .run()', ()
 
 describe('root help — links derived from deno.json / jsr.json discovery in .run()', () => {
 	it('derives name + release link from a discovered deno.json on a TTY', async () => {
-		const app = cli('mytool').denoJson().links().command(deployCommand());
+		const app = cli('mytool').manifest({ files: DENO_FILES }).links().command(deployCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			files: {
@@ -364,7 +367,7 @@ describe('root help — links derived from deno.json / jsr.json discovery in .ru
 	});
 
 	it('derives links from jsr.json when deno.json is absent', async () => {
-		const app = cli('mytool').denoJson().links().command(deployCommand());
+		const app = cli('mytool').manifest({ files: DENO_FILES }).links().command(deployCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			files: {
@@ -382,7 +385,7 @@ describe('root help — links derived from deno.json / jsr.json discovery in .ru
 	it('surfaces the repository link from a deno.json carrying only repository', async () => {
 		// manifestHasMetadata accepts a repository-only manifest; prove that link
 		// reaches the header end-to-end (no version → name link only, no release).
-		const app = cli('mytool').denoJson().links().command(deployCommand());
+		const app = cli('mytool').manifest({ files: DENO_FILES }).links().command(deployCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			files: { '/test/deno.json': JSON.stringify({ repository: `git+${REPO}.git` }) },
@@ -395,24 +398,10 @@ describe('root help — links derived from deno.json / jsr.json discovery in .ru
 		expect(output).not.toContain('/releases/tag/');
 	});
 
-	it('.manifest({ files }) discovery derives links the same way', async () => {
-		const app = cli('mytool')
-			.manifest({ files: ['deno.json', 'jsr.json'] })
-			.links()
-			.command(deployCommand());
-
-		const { stdout } = await runWithAdapter(app, ['--help'], {
-			files: { '/test/jsr.json': JSON.stringify({ version: '2.0.0', repository: REPO }) },
-			isTTY: true,
-		});
-
-		expect(stdout.join('')).toContain(osc8(`${REPO}/releases/tag/v2.0.0`, 'v2.0.0'));
-	});
-
 	it('derives links from jsr.json when a sibling deno.json is config-only', async () => {
 		// Marquee Deno shape: config-only deno.json (tasks/imports, no metadata) must
 		// NOT shadow jsr.json for the help-link channel — links come from jsr.json.
-		const app = cli('mytool').denoJson().links().command(deployCommand());
+		const app = cli('mytool').manifest({ files: DENO_FILES }).links().command(deployCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			files: {
@@ -432,7 +421,7 @@ describe('root help — links derived from deno.json / jsr.json discovery in .ru
 		// inferName + .links() together: the OSC-8 name link's display text is the
 		// inferred schema name, so scope:'keep' must surface the scoped name in the link.
 		const app = cli('placeholder')
-			.denoJson({ inferName: { scope: 'keep' } })
+			.manifest({ files: DENO_FILES, inferName: { scope: 'keep' } })
 			.links()
 			.command(deployCommand());
 
@@ -452,22 +441,6 @@ describe('root help — links derived from deno.json / jsr.json discovery in .ru
 			`${osc8(REPO, '@scope/realtool')} ${osc8(`${REPO}/releases/tag/v6.0.0`, 'v6.0.0')}`,
 		);
 		expect(output).not.toContain('placeholder');
-	});
-});
-
-describe('root help — links derived from .denoJson(data)', () => {
-	it('derives name from repository and version from the release tag', async () => {
-		const app = cli('mytool')
-			.denoJson({ version: '2.5.0', repository: `git+${REPO}.git` })
-			.links()
-			.command(deployCommand());
-
-		const result = await app.execute(['--help'], { isTTY: true });
-
-		const output = result.stdout.join('');
-		expect(output).toContain(
-			`${osc8(REPO, 'mytool')} ${osc8(`${REPO}/releases/tag/v2.5.0`, 'v2.5.0')}`,
-		);
 	});
 });
 

--- a/src/core/cli/cli-manifest.test.ts
+++ b/src/core/cli/cli-manifest.test.ts
@@ -1,14 +1,13 @@
 /**
- * Integration tests for package.json auto-discovery wired through CLIBuilder.run().
+ * Integration tests for manifest auto-discovery wired through CLIBuilder.run().
  *
- * Tests the .packageJson() builder method, auto-fill of version/description,
+ * Tests the .manifest() builder method, auto-fill of version/description,
  * name inference, precedence (explicit wins), and completions skip.
  */
 import { describe, expect, it } from 'vitest';
 import { command } from '#internals/core/schema/command.ts';
 import { flag } from '#internals/core/schema/flag.ts';
 import { createTestAdapter, ExitError } from '#internals/runtime/index.ts';
-import type { ManifestSettings } from './index.ts';
 import { cli, isMainModule } from './index.ts';
 
 // === Test helpers
@@ -22,6 +21,9 @@ function infoCommand() {
 			out.json({ ok: true });
 		});
 }
+
+/** Deno-family manifest candidates, in discovery priority order. */
+const DENO_FILES: readonly string[] = ['deno.json', 'deno.jsonc', 'jsr.json'];
 
 /** Helper: run app via .run() with adapter, capture stdout/stderr. */
 async function runWithAdapter(
@@ -55,110 +57,22 @@ async function runWithAdapter(
 	return { stdout: stdoutLines, stderr: stderrLines, exitCode };
 }
 
-// === CLIBuilder.packageJson() — builder method
+// === CLIBuilder.manifest() — builder method
 
-describe('CLIBuilder.packageJson() — builder method', () => {
+describe('CLIBuilder.manifest() — builder method', () => {
 	it('returns a new CLIBuilder (immutability)', () => {
 		const a = cli('myapp');
-		const b = a.packageJson();
+		const b = a.manifest();
 		expect(a).not.toBe(b);
 		expect(a.schema.packageJsonSettings).toBeUndefined();
 		expect(b.schema.packageJsonSettings).toBeDefined();
 	});
 
-	it('stores default settings (inferName: false)', () => {
-		const app = cli('myapp').packageJson();
-		expect(app.schema.packageJsonSettings).toEqual({
-			inferName: false,
-			stripScope: true,
-			from: undefined,
-			files: ['package.json'],
-			data: undefined,
-		});
-	});
-
-	it('stores inferName: true', () => {
-		const app = cli('myapp').packageJson({ inferName: true });
-		expect(app.schema.packageJsonSettings).toEqual({
-			inferName: true,
-			stripScope: true,
-			from: undefined,
-			files: ['package.json'],
-			data: undefined,
-		});
-	});
-
-	it('packageJsonSettings is undefined when .packageJson() not called', () => {
+	it('packageJsonSettings is undefined when .manifest() not called', () => {
 		const app = cli('myapp');
 		expect(app.schema.packageJsonSettings).toBeUndefined();
 	});
 
-	it('stores from as a plain string path', () => {
-		const app = cli('myapp').packageJson({ from: '/anchor' });
-		expect(app.schema.packageJsonSettings).toEqual({
-			inferName: false,
-			stripScope: true,
-			from: '/anchor',
-			files: ['package.json'],
-			data: undefined,
-		});
-	});
-
-	it('normalizes a file: URL string in from', () => {
-		const app = cli('myapp').packageJson({ from: 'file:///anchor/cli.js' });
-		expect(app.schema.packageJsonSettings?.from).toBe('/anchor/cli.js');
-	});
-
-	it('normalizes a URL instance in from', () => {
-		const app = cli('myapp').packageJson({ from: new URL('file:///anchor/cli.js') });
-		expect(app.schema.packageJsonSettings?.from).toBe('/anchor/cli.js');
-	});
-
-	it('stores data and hardcodes inferName false / from undefined', () => {
-		const app = cli('myapp').packageJson({ version: '5.5.5' });
-		expect(app.schema.packageJsonSettings).toEqual({
-			inferName: false,
-			stripScope: true,
-			from: undefined,
-			files: ['package.json'],
-			data: { version: '5.5.5' },
-		});
-	});
-
-	it('empty object falls through to the settings overload (not data)', () => {
-		const app = cli('myapp').packageJson({});
-		expect(app.schema.packageJsonSettings).toEqual({
-			inferName: false,
-			stripScope: true,
-			from: undefined,
-			files: ['package.json'],
-			data: undefined,
-		});
-	});
-
-	it('routes name/bin objects to the data path', () => {
-		expect(cli('x').packageJson({ name: 'pkg' }).schema.packageJsonSettings?.data).toEqual({
-			name: 'pkg',
-		});
-		expect(
-			cli('x').packageJson({ bin: { tool: './c.js' } }).schema.packageJsonSettings?.data,
-		).toEqual({ bin: { tool: './c.js' } });
-	});
-
-	it('routes non-object / array inputs to the settings overload', () => {
-		// Defensive: the public overloads forbid these, but the runtime guard
-		// must not misclassify them as data (covers the null / Array.isArray paths).
-		const callPackageJson = (value: unknown): ReturnType<typeof cli> =>
-			(cli('x').packageJson as (v: unknown) => ReturnType<typeof cli>)(value);
-
-		expect(callPackageJson(null).schema.packageJsonSettings?.data).toBeUndefined();
-		expect(callPackageJson([1]).schema.packageJsonSettings?.data).toBeUndefined();
-	});
-});
-
-// === CLIBuilder.manifest() / .denoJson() — builder methods
-
-describe('CLIBuilder.manifest() — builder method', () => {
 	it('defaults files to package.json', () => {
 		const app = cli('myapp').manifest();
 		expect(app.schema.packageJsonSettings).toEqual({
@@ -187,13 +101,13 @@ describe('CLIBuilder.manifest() — builder method', () => {
 
 	it('inferName: true strips scope by default', () => {
 		const app = cli('myapp').manifest({ inferName: true });
-		expect(app.schema.packageJsonSettings).toMatchObject({ inferName: true, stripScope: true });
-	});
-
-	it('data overload merges version immediately', () => {
-		const app = cli('myapp').manifest({ version: '9.9.9' });
-		expect(app.schema.version).toBe('9.9.9');
-		expect(app.schema.packageJsonSettings?.data).toEqual({ version: '9.9.9' });
+		expect(app.schema.packageJsonSettings).toEqual({
+			inferName: true,
+			stripScope: true,
+			from: undefined,
+			files: ['package.json'],
+			data: undefined,
+		});
 	});
 
 	it('explicit inferName: false resolves to no inference, scope strip default', () => {
@@ -207,6 +121,59 @@ describe('CLIBuilder.manifest() — builder method', () => {
 		});
 	});
 
+	it('empty object falls through to the settings overload (not data)', () => {
+		const app = cli('myapp').manifest({});
+		expect(app.schema.packageJsonSettings).toEqual({
+			inferName: false,
+			stripScope: true,
+			from: undefined,
+			files: ['package.json'],
+			data: undefined,
+		});
+	});
+
+	it('stores from as a plain string path', () => {
+		const app = cli('myapp').manifest({ from: '/anchor' });
+		expect(app.schema.packageJsonSettings).toEqual({
+			inferName: false,
+			stripScope: true,
+			from: '/anchor',
+			files: ['package.json'],
+			data: undefined,
+		});
+	});
+
+	it('normalizes a file: URL string in from', () => {
+		const app = cli('myapp').manifest({ from: 'file:///anchor/cli.js' });
+		expect(app.schema.packageJsonSettings?.from).toBe('/anchor/cli.js');
+	});
+
+	it('normalizes a URL instance in from', () => {
+		const app = cli('myapp').manifest({ from: new URL('file:///anchor/cli.js') });
+		expect(app.schema.packageJsonSettings?.from).toBe('/anchor/cli.js');
+	});
+
+	it('data overload merges version and hardcodes inferName false / from undefined', () => {
+		const app = cli('myapp').manifest({ version: '9.9.9' });
+		expect(app.schema.version).toBe('9.9.9');
+		expect(app.schema.packageJsonSettings).toEqual({
+			inferName: false,
+			stripScope: true,
+			from: undefined,
+			files: ['package.json'],
+			data: { version: '9.9.9' },
+		});
+	});
+
+	it('routes name/bin objects to the data overload', () => {
+		expect(cli('x').manifest({ name: 'pkg' }).schema.packageJsonSettings?.data).toEqual({
+			name: 'pkg',
+		});
+		expect(cli('x').manifest({ bin: { tool: './c.js' } }).schema.packageJsonSettings?.data).toEqual(
+			{ bin: { tool: './c.js' } },
+		);
+	});
+
 	it('routes homepage-only and repository-only objects to the data overload', () => {
 		// isPackageJsonData recognizes homepage/repository, so these are data, not settings.
 		expect(
@@ -216,31 +183,15 @@ describe('CLIBuilder.manifest() — builder method', () => {
 			cli('y').manifest({ repository: 'github:me/y' }).schema.packageJsonSettings?.data,
 		).toEqual({ repository: 'github:me/y' });
 	});
-});
 
-describe('CLIBuilder.denoJson() — builder method', () => {
-	it('stores deno.json, deno.jsonc, then jsr.json as candidate files', () => {
-		const app = cli('myapp').denoJson();
-		expect(app.schema.packageJsonSettings).toEqual({
-			inferName: false,
-			stripScope: true,
-			from: undefined,
-			files: ['deno.json', 'deno.jsonc', 'jsr.json'],
-			data: undefined,
-		});
-	});
+	it('routes non-object / array inputs to the settings overload', () => {
+		// Defensive: the public overloads forbid these, but the runtime guard
+		// must not misclassify them as data (covers the null / Array.isArray paths).
+		const callManifest = (value: unknown): ReturnType<typeof cli> =>
+			(cli('x').manifest as (v: unknown) => ReturnType<typeof cli>)(value);
 
-	it('normalizes from and honours inferName scope', () => {
-		const app = cli('myapp').denoJson({
-			from: 'file:///lib/cli.js',
-			inferName: { scope: 'keep' },
-		});
-		expect(app.schema.packageJsonSettings).toMatchObject({
-			from: '/lib/cli.js',
-			inferName: true,
-			stripScope: false,
-			files: ['deno.json', 'deno.jsonc', 'jsr.json'],
-		});
+		expect(callManifest(null).schema.packageJsonSettings?.data).toBeUndefined();
+		expect(callManifest([1]).schema.packageJsonSettings?.data).toBeUndefined();
 	});
 });
 
@@ -248,7 +199,7 @@ describe('CLIBuilder.denoJson() — builder method', () => {
 
 describe('CLIBuilder.run() — package.json version', () => {
 	it('fills version from package.json', async () => {
-		const app = cli('myapp').packageJson().command(infoCommand());
+		const app = cli('myapp').manifest().command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
 			'/test/package.json': '{"version":"3.2.1"}',
@@ -258,7 +209,7 @@ describe('CLIBuilder.run() — package.json version', () => {
 	});
 
 	it('explicit .version() wins over discovered', async () => {
-		const app = cli('myapp').packageJson().version('9.9.9').command(infoCommand());
+		const app = cli('myapp').manifest().version('9.9.9').command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
 			'/test/package.json': '{"version":"1.0.0"}',
@@ -268,7 +219,7 @@ describe('CLIBuilder.run() — package.json version', () => {
 	});
 
 	it('rejects --version when neither explicit nor discovered', async () => {
-		const app = cli('myapp').packageJson().command(infoCommand());
+		const app = cli('myapp').manifest().command(infoCommand());
 
 		const { exitCode, stderr } = await runWithAdapter(app, ['--version']);
 
@@ -278,11 +229,11 @@ describe('CLIBuilder.run() — package.json version', () => {
 	});
 });
 
-// === CLIBuilder.run() — deno.json / manifest discovery
+// === CLIBuilder.run() — deno-family manifest discovery
 
-describe('CLIBuilder.run() — deno.json discovery', () => {
-	it('.denoJson() fills version from deno.json', async () => {
-		const app = cli('myapp').denoJson().command(infoCommand());
+describe('CLIBuilder.run() — deno-family manifest discovery', () => {
+	it('fills version from deno.json', async () => {
+		const app = cli('myapp').manifest({ files: DENO_FILES }).command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
 			'/test/deno.json': '{"name":"@scope/myapp","version":"4.5.6"}',
@@ -291,8 +242,8 @@ describe('CLIBuilder.run() — deno.json discovery', () => {
 		expect(stdout.join('')).toBe('4.5.6\n');
 	});
 
-	it('.denoJson() falls back to jsr.json when deno.json is absent', async () => {
-		const app = cli('myapp').denoJson().command(infoCommand());
+	it('falls back to jsr.json when deno.json is absent', async () => {
+		const app = cli('myapp').manifest({ files: DENO_FILES }).command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
 			'/test/jsr.json': '{"version":"7.8.9"}',
@@ -301,8 +252,8 @@ describe('CLIBuilder.run() — deno.json discovery', () => {
 		expect(stdout.join('')).toBe('7.8.9\n');
 	});
 
-	it('.denoJson() discovers a deno.jsonc file (with comments)', async () => {
-		const app = cli('myapp').denoJson().command(infoCommand());
+	it('discovers a deno.jsonc file (with comments)', async () => {
+		const app = cli('myapp').manifest({ files: DENO_FILES }).command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
 			'/test/deno.jsonc': '{\n  // pinned\n  "version": "6.6.6"\n}',
@@ -325,7 +276,7 @@ describe('CLIBuilder.run() — deno.json discovery', () => {
 
 	it('inferName keeps the scope when scope: "keep"', async () => {
 		const app = cli('placeholder')
-			.denoJson({ inferName: { scope: 'keep' } })
+			.manifest({ files: DENO_FILES, inferName: { scope: 'keep' } })
 			.command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
@@ -337,7 +288,9 @@ describe('CLIBuilder.run() — deno.json discovery', () => {
 	});
 
 	it('inferName strips the scope by default', async () => {
-		const app = cli('placeholder').denoJson({ inferName: true }).command(infoCommand());
+		const app = cli('placeholder')
+			.manifest({ files: DENO_FILES, inferName: true })
+			.command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			'/test/deno.json': '{"name":"@scope/realname","version":"1.0.0"}',
@@ -385,11 +338,11 @@ describe('CLIBuilder.run() — deno.json discovery', () => {
 		expect(stdout.join('')).toContain('@scope/right');
 	});
 
-	it('.denoJson() skips a config-only deno.json and uses jsr.json version', async () => {
-		// Headline Deno shape through the public preset: deno.json kept as a
-		// tasks/imports config file, publish metadata lives in jsr.json. The
-		// config-only deno.json must NOT shadow the sibling jsr.json.
-		const app = cli('myapp').denoJson().command(infoCommand());
+	it('skips a config-only deno.json and uses jsr.json version', async () => {
+		// Headline Deno shape: deno.json kept as a tasks/imports config file,
+		// publish metadata lives in jsr.json. The config-only deno.json must NOT
+		// shadow the sibling jsr.json.
+		const app = cli('myapp').manifest({ files: DENO_FILES }).command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
 			'/test/deno.json': '{"tasks":{"dev":"deno run main.ts"},"imports":{}}',
@@ -403,7 +356,9 @@ describe('CLIBuilder.run() — deno.json discovery', () => {
 		// deno.json carries a version but no `name` and no `bin`, so inferCliName
 		// returns undefined — the configured cli('placeholder') name must survive
 		// (not be clobbered with an empty/undefined value).
-		const app = cli('placeholder').denoJson({ inferName: true }).command(infoCommand());
+		const app = cli('placeholder')
+			.manifest({ files: DENO_FILES, inferName: true })
+			.command(infoCommand());
 
 		const files = { '/test/deno.json': '{"version":"1.0.0"}' };
 
@@ -419,7 +374,7 @@ describe('CLIBuilder.run() — deno.json discovery', () => {
 
 describe('CLIBuilder.run() — package.json description', () => {
 	it('fills description from package.json into help', async () => {
-		const app = cli('myapp').packageJson().command(infoCommand());
+		const app = cli('myapp').manifest().command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			'/test/package.json': '{"description":"My awesome CLI tool"}',
@@ -429,7 +384,7 @@ describe('CLIBuilder.run() — package.json description', () => {
 	});
 
 	it('explicit .description() wins over discovered', async () => {
-		const app = cli('myapp').packageJson().description('Explicit desc').command(infoCommand());
+		const app = cli('myapp').manifest().description('Explicit desc').command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			'/test/package.json': '{"description":"Package desc"}',
@@ -444,7 +399,7 @@ describe('CLIBuilder.run() — package.json description', () => {
 
 describe('CLIBuilder.run() — package.json name inference', () => {
 	it('infers name from bin key when inferName: true', async () => {
-		const app = cli('placeholder').packageJson({ inferName: true }).command(infoCommand());
+		const app = cli('placeholder').manifest({ inferName: true }).command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			'/test/package.json': JSON.stringify({
@@ -458,7 +413,7 @@ describe('CLIBuilder.run() — package.json name inference', () => {
 	});
 
 	it('infers name from package name (scope stripped) when no bin', async () => {
-		const app = cli('placeholder').packageJson({ inferName: true }).command(infoCommand());
+		const app = cli('placeholder').manifest({ inferName: true }).command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			'/test/package.json': '{"name":"@scope/my-tool"}',
@@ -467,8 +422,8 @@ describe('CLIBuilder.run() — package.json name inference', () => {
 		expect(stdout.join('')).toContain('my-tool');
 	});
 
-	it('does not infer name when inferName is false (default)', async () => {
-		const app = cli('myapp').packageJson().command(infoCommand());
+	it('does not infer name when inferName is omitted (default)', async () => {
+		const app = cli('myapp').manifest().command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			'/test/package.json': JSON.stringify({
@@ -502,7 +457,7 @@ describe('CLIBuilder.run() — package.json name inference', () => {
 
 describe('CLIBuilder.run() — package.json walk-up', () => {
 	it('walks up to find package.json in parent directory', async () => {
-		const app = cli('myapp').packageJson().command(infoCommand());
+		const app = cli('myapp').manifest().command(infoCommand());
 
 		const { stdout } = await runWithAdapter(
 			app,
@@ -523,7 +478,7 @@ describe('CLIBuilder.run() — walk-up past a metadata-less package.json', () =>
 		// leaf package.json — e.g. a monorepo root with only private/workspaces —
 		// no longer halts the walk-up. The nearest ancestor carrying real metadata
 		// wins, so its version surfaces where the old behavior resolved to {}.
-		const app = cli('myapp').packageJson().command(infoCommand());
+		const app = cli('myapp').manifest().command(infoCommand());
 
 		const { stdout } = await runWithAdapter(
 			app,
@@ -541,8 +496,8 @@ describe('CLIBuilder.run() — walk-up past a metadata-less package.json', () =>
 
 // === CLIBuilder.run() — no discovery when not opted in
 
-describe('CLIBuilder.run() — no discovery without .packageJson()', () => {
-	it('does not read package.json when .packageJson() not called', async () => {
+describe('CLIBuilder.run() — no discovery without .manifest()', () => {
+	it('does not read package.json when .manifest() not called', async () => {
 		let readCalled = false;
 		const stdoutLines: string[] = [];
 		const adapter = createTestAdapter({
@@ -567,7 +522,7 @@ describe('CLIBuilder.run() — no discovery without .packageJson()', () => {
 	});
 });
 
-// === CLIBuilder.run() — completions skip package.json
+// === CLIBuilder.run() — completions skip manifest discovery
 
 describe('CLIBuilder.run() — completions skip package.json', () => {
 	it('completions subcommand does not trigger package.json loading', async () => {
@@ -582,7 +537,7 @@ describe('CLIBuilder.run() — completions skip package.json', () => {
 			},
 		});
 
-		const app = cli('myapp').packageJson().command(infoCommand()).completions();
+		const app = cli('myapp').manifest().command(infoCommand()).completions();
 
 		try {
 			await app.run({ adapter });
@@ -599,7 +554,7 @@ describe('CLIBuilder.run() — completions skip package.json', () => {
 
 describe('CLIBuilder.run() — package.json error resilience', () => {
 	it('malformed package.json is silently ignored', async () => {
-		const app = cli('myapp').packageJson().version('1.0.0').command(infoCommand());
+		const app = cli('myapp').manifest().version('1.0.0').command(infoCommand());
 
 		const { stdout, exitCode } = await runWithAdapter(app, ['--version'], {
 			'/test/package.json': '{bad json',
@@ -610,7 +565,7 @@ describe('CLIBuilder.run() — package.json error resilience', () => {
 	});
 
 	it('no package.json found is silently ignored', async () => {
-		const app = cli('myapp').packageJson().command(infoCommand());
+		const app = cli('myapp').manifest().command(infoCommand());
 
 		const { exitCode } = await runWithAdapter(app, ['info']);
 
@@ -621,9 +576,9 @@ describe('CLIBuilder.run() — package.json error resilience', () => {
 // === CLIBuilder.run() — combined with .config()
 
 describe('CLIBuilder.run() — package.json combined with config', () => {
-	it('both .packageJson() and .config() work together', async () => {
+	it('both .manifest() and .config() work together', async () => {
 		const app = cli('myapp')
-			.packageJson()
+			.manifest()
 			.config('myapp')
 			.command(
 				command('deploy')
@@ -645,7 +600,7 @@ describe('CLIBuilder.run() — package.json combined with config', () => {
 	});
 
 	it('--version shows discovered version when combined with .config()', async () => {
-		const app = cli('myapp').packageJson().config('myapp').command(infoCommand());
+		const app = cli('myapp').manifest().config('myapp').command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
 			'/test/package.json': '{"version":"4.5.6"}',
@@ -655,11 +610,11 @@ describe('CLIBuilder.run() — package.json combined with config', () => {
 	});
 });
 
-// === CLIBuilder.packageJson({ from }) — anchored discovery in run()
+// === CLIBuilder.manifest({ from }) — anchored discovery in run()
 
-describe('CLIBuilder.packageJson({ from }) — anchored discovery', () => {
+describe('CLIBuilder.manifest({ from }) — anchored discovery', () => {
 	it('anchors discovery to the from directory, overriding cwd', async () => {
-		const app = cli('myapp').packageJson({ from: '/anchor' }).command(infoCommand());
+		const app = cli('myapp').manifest({ from: '/anchor' }).command(infoCommand());
 
 		// cwd is the default '/test'; the from anchor must win.
 		const { stdout } = await runWithAdapter(app, ['--version'], {
@@ -671,7 +626,7 @@ describe('CLIBuilder.packageJson({ from }) — anchored discovery', () => {
 	});
 
 	it('anchors discovery from a file: URL string (e.g. import.meta.url)', async () => {
-		const app = cli('myapp').packageJson({ from: 'file:///anchor/cli.js' }).command(infoCommand());
+		const app = cli('myapp').manifest({ from: 'file:///anchor/cli.js' }).command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
 			'/anchor/package.json': '{"version":"2.2.2"}',
@@ -682,7 +637,7 @@ describe('CLIBuilder.packageJson({ from }) — anchored discovery', () => {
 
 	it('anchors discovery from a URL instance', async () => {
 		const app = cli('myapp')
-			.packageJson({ from: new URL('file:///anchor/cli.js') })
+			.manifest({ from: new URL('file:///anchor/cli.js') })
 			.command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
@@ -694,7 +649,7 @@ describe('CLIBuilder.packageJson({ from }) — anchored discovery', () => {
 
 	it('anchors discovery from an import.meta object', async () => {
 		const meta: ImportMeta = { ...import.meta, url: 'file:///anchor/cli.js' };
-		const app = cli('myapp').packageJson({ from: meta }).command(infoCommand());
+		const app = cli('myapp').manifest({ from: meta }).command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--version'], {
 			'/anchor/package.json': '{"version":"3.3.3"}',
@@ -715,91 +670,11 @@ describe('isMainModule', () => {
 	});
 });
 
-// === CLIBuilder.packageJson(data) — pre-loaded data
+// === CLIBuilder.manifest() — settings vs data discrimination (end-to-end)
 
-describe('CLIBuilder.packageJson(data) — pre-loaded data', () => {
-	it('reports version from data via run() without touching the filesystem', async () => {
-		let readCalled = false;
-		const stdoutLines: string[] = [];
-		const adapter = createTestAdapter({
-			argv: ['node', 'test', '--version'],
-			stdout: (s) => stdoutLines.push(s),
-			readFile: async () => {
-				readCalled = true;
-				return null;
-			},
-		});
-
-		const app = cli('myapp').packageJson({ version: '6.0.0' }).command(infoCommand());
-
-		try {
-			await app.run({ adapter });
-		} catch (e: unknown) {
-			if (!(e instanceof ExitError)) throw e;
-		}
-
-		expect(readCalled).toBe(false);
-		expect(stdoutLines.join('')).toBe('6.0.0\n');
-	});
-
-	it('reports version from data via execute() — filesystem-free path', async () => {
-		const app = cli('myapp').packageJson({ version: '6.0.0' }).command(infoCommand());
-
-		const result = await app.execute(['--version']);
-
-		expect(result.exitCode).toBe(0);
-		expect(result.stdout.join('')).toBe('6.0.0\n');
-	});
-
-	it('fills description from data into help via execute()', async () => {
-		const app = cli('myapp').packageJson({ description: 'Data desc' }).command(infoCommand());
-
-		const result = await app.execute(['--help']);
-
-		expect(result.stdout.join('')).toContain('Data desc');
-	});
-
-	it('explicit .version() before .packageJson(data) wins', async () => {
-		const app = cli('myapp')
-			.version('9.9.9')
-			.packageJson({ version: '1.1.1' })
-			.command(infoCommand());
-
-		const result = await app.execute(['--version']);
-
-		expect(result.stdout.join('')).toBe('9.9.9\n');
-	});
-
-	it('explicit .description() wins over data description', async () => {
-		const app = cli('myapp')
-			.description('Explicit desc')
-			.packageJson({ description: 'Data desc' })
-			.command(infoCommand());
-
-		const result = await app.execute(['--help']);
-
-		expect(result.stdout.join('')).toContain('Explicit desc');
-		expect(result.stdout.join('')).not.toContain('Data desc');
-	});
-
-	it('does NOT infer name from data even when name/bin present', async () => {
-		const app = cli('placeholder')
-			.packageJson({ name: '@scope/my-tool', bin: { 'my-tool': './dist/cli.js' } })
-			.command(infoCommand());
-
-		expect(app.schema.packageJsonSettings?.inferName).toBe(false);
-
-		const result = await app.execute(['--help']);
-		expect(result.stdout.join('')).toContain('placeholder');
-		expect(result.stdout.join('')).not.toContain('my-tool');
-	});
-});
-
-// === CLIBuilder.packageJson() — settings vs data discrimination (end-to-end)
-
-describe('CLIBuilder.packageJson() — settings vs data discrimination', () => {
+describe('CLIBuilder.manifest() — settings vs data discrimination', () => {
 	it('empty {} routes to settings: --version falls through as unknown flag', async () => {
-		const app = cli('myapp').packageJson({}).command(infoCommand());
+		const app = cli('myapp').manifest({}).command(infoCommand());
 
 		const { exitCode, stderr } = await runWithAdapter(app, ['--version']);
 
@@ -808,7 +683,7 @@ describe('CLIBuilder.packageJson() — settings vs data discrimination', () => {
 	});
 
 	it('{ inferName: true } routes to settings and still infers the name', async () => {
-		const app = cli('placeholder').packageJson({ inferName: true }).command(infoCommand());
+		const app = cli('placeholder').manifest({ inferName: true }).command(infoCommand());
 
 		const { stdout } = await runWithAdapter(app, ['--help'], {
 			'/test/package.json': '{"name":"@scope/inferred-tool"}',
@@ -816,28 +691,6 @@ describe('CLIBuilder.packageJson() — settings vs data discrimination', () => {
 
 		expect(stdout.join('')).toContain('inferred-tool');
 		expect(stdout.join('')).not.toContain('placeholder');
-	});
-
-	it('presets pin their file list even when a settings variable leaks `files`', () => {
-		// A ManifestSettings variable binds structurally to the data overload,
-		// slips past the Omit<…,'files'> compile guard, and would otherwise leak
-		// `files` into the settings branch at runtime. Presets must pin regardless.
-		const leakyDeno: ManifestSettings = { files: ['deno.json', 'jsr.json'] };
-		const leakyPkg: ManifestSettings = { files: ['package.json'] };
-
-		expect(cli('x').packageJson(leakyDeno).schema.packageJsonSettings?.files).toEqual([
-			'package.json',
-		]);
-		expect(cli('y').denoJson(leakyPkg).schema.packageJsonSettings?.files).toEqual([
-			'deno.json',
-			'deno.jsonc',
-			'jsr.json',
-		]);
-		// manifest() is NOT a preset — it honours an explicit files list.
-		expect(cli('z').manifest(leakyDeno).schema.packageJsonSettings?.files).toEqual([
-			'deno.json',
-			'jsr.json',
-		]);
 	});
 });
 
@@ -883,5 +736,37 @@ describe('CLIBuilder.manifest(data) — end-to-end', () => {
 		const result = await app.execute(['--help']);
 
 		expect(result.stdout.join('')).toContain('Manifest data desc');
+	});
+
+	it('explicit .version() before .manifest(data) wins', async () => {
+		const app = cli('myapp').version('9.9.9').manifest({ version: '1.1.1' }).command(infoCommand());
+
+		const result = await app.execute(['--version']);
+
+		expect(result.stdout.join('')).toBe('9.9.9\n');
+	});
+
+	it('explicit .description() wins over data description', async () => {
+		const app = cli('myapp')
+			.description('Explicit desc')
+			.manifest({ description: 'Data desc' })
+			.command(infoCommand());
+
+		const result = await app.execute(['--help']);
+
+		expect(result.stdout.join('')).toContain('Explicit desc');
+		expect(result.stdout.join('')).not.toContain('Data desc');
+	});
+
+	it('does NOT infer name from data even when name/bin present', async () => {
+		const app = cli('placeholder')
+			.manifest({ name: '@scope/my-tool', bin: { 'my-tool': './dist/cli.js' } })
+			.command(infoCommand());
+
+		expect(app.schema.packageJsonSettings?.inferName).toBe(false);
+
+		const result = await app.execute(['--help']);
+		expect(result.stdout.join('')).toContain('placeholder');
+		expect(result.stdout.join('')).not.toContain('my-tool');
 	});
 });

--- a/src/core/cli/compiled.test.ts
+++ b/src/core/cli/compiled.test.ts
@@ -157,8 +157,6 @@ describe('CLISchema and the compiled graph', () => {
 			.config('mytool')
 			.configLoader(configFormat(['yaml'], () => ({})))
 			.manifest({ version: '1.0.0' })
-			.packageJson()
-			.denoJson()
 			.completions()
 			.plugin(plugin({}))
 			.default(leaf('serve'));

--- a/src/core/cli/help-links.ts
+++ b/src/core/cli/help-links.ts
@@ -1,10 +1,10 @@
 /**
  * Root-help header hyperlink resolution.
  *
- * Stores explicit `.links()` URLs and derives missing ones from package.json
+ * Stores explicit `.links()` URLs and derives missing ones from manifest
  * metadata (`repository` / `homepage`) once that data is available — during
  * runtime preflight for `.run()`, or directly from pre-loaded
- * `.packageJson(data)` for `.execute()`.
+ * `.manifest(data)` for `.execute()`.
  *
  * @module dreamcli/core/cli/help-links
  * @internal
@@ -17,7 +17,7 @@ import { packageRepositoryUrl } from '#internals/core/config/package-json.ts';
  * OSC 8 hyperlink targets for the root-help header.
  *
  * Set via `CLIBuilder.links()`; fields left `undefined` are derived from
- * package.json metadata when `.packageJson()` is active.
+ * manifest metadata when `.manifest()` is active.
  */
 interface HelpLinks {
 	/** URL the program name links to (e.g. the repository or homepage). */

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -191,9 +191,7 @@ interface CLISchema {
 	 * nearest manifest (`package.json`, `deno.json`, `jsr.json`, …) and merges
 	 * metadata before dispatch.
 	 *
-	 * Set via the {@linkcode CLIBuilder.manifest | .manifest()} builder method
-	 * (or the {@linkcode CLIBuilder.packageJson | .packageJson()} /
-	 * {@linkcode CLIBuilder.denoJson | .denoJson()} presets).
+	 * Set via the {@linkcode CLIBuilder.manifest | .manifest()} builder method.
 	 */
 	readonly packageJsonSettings: ResolvedManifestSettings | undefined;
 	/**
@@ -382,10 +380,9 @@ interface ConfigSettings {
  *
  * Note: the schema FIELD name (`packageJsonSettings`) keeps its `packageJson`
  * prefix for backward compatibility — renaming it would break consumers reading
- * `app.schema.packageJsonSettings`. The type itself is now generically named
- * (it holds discovery config for any manifest — `package.json`, `deno.json`,
- * `jsr.json`); the legacy {@link PackageJsonSettings} alias remains exported for
- * backward compatibility.
+ * `app.schema.packageJsonSettings`. The type itself is generically named (it
+ * holds discovery config for any manifest — `package.json`, `deno.json`,
+ * `jsr.json`).
  */
 interface ResolvedManifestSettings {
 	/**
@@ -419,7 +416,7 @@ interface ResolvedManifestSettings {
 	readonly from: string | undefined;
 	/**
 	 * Candidate manifest filenames, in per-directory priority order
-	 * (e.g. `['deno.json', 'deno.jsonc', 'jsr.json']` for `.denoJson()`).
+	 * (e.g. `['deno.json', 'deno.jsonc', 'jsr.json']` for a Deno CLI).
 	 */
 	readonly files: readonly string[];
 	/**
@@ -434,16 +431,6 @@ interface ResolvedManifestSettings {
 	 */
 	readonly data: PackageJsonData | undefined;
 }
-
-/**
- * Resolved manifest discovery settings stored in {@link CLISchema}.
- *
- * @deprecated Renamed to {@link ResolvedManifestSettings}. The stored shape
- *   holds generic manifest discovery config (`package.json`, `deno.json`,
- *   `jsr.json`), not just `package.json`; the misleading name is kept only for
- *   backward compatibility.
- */
-type PackageJsonSettings = ResolvedManifestSettings;
 
 // --- CLI definition — input shape accepted by createCLISchema
 
@@ -1226,60 +1213,7 @@ class CLIBuilder {
 	 */
 	manifest(settings?: ManifestSettings): CLIBuilder;
 	manifest(input?: PackageJsonData | ManifestSettings): CLIBuilder {
-		return rebuild(this, buildManifestSchema(this.schema, input, DEFAULT_MANIFEST_FILES, false));
-	}
-
-	/**
-	 * Discover metadata from `package.json` (preset for {@link CLIBuilder.manifest}).
-	 *
-	 * @deprecated Use {@link CLIBuilder.manifest} — `.manifest()` defaults to
-	 *   `package.json` and also supports `deno.json` / `jsr.json` via `files`.
-	 *
-	 * @param data - Pre-loaded `package.json` metadata.
-	 */
-	packageJson(data: PackageJsonData): CLIBuilder;
-	/**
-	 * Discover metadata from `package.json` (preset for {@link CLIBuilder.manifest}).
-	 *
-	 * @deprecated Use {@link CLIBuilder.manifest}.
-	 *
-	 * @param settings - `inferName` / `from` (see {@link CLIBuilder.manifest}).
-	 */
-	packageJson(settings?: ManifestPresetSettings): CLIBuilder;
-	packageJson(input?: PackageJsonData | ManifestPresetSettings): CLIBuilder {
-		return rebuild(this, buildManifestSchema(this.schema, input, DEFAULT_MANIFEST_FILES, true));
-	}
-
-	/**
-	 * Discover metadata from `deno.json`, `deno.jsonc`, then `jsr.json` (preset for
-	 * {@link CLIBuilder.manifest}).
-	 *
-	 * @deprecated Use `.manifest({ files: ['deno.json', 'deno.jsonc', 'jsr.json'] })`.
-	 *
-	 * @param data - Pre-loaded `deno.json` / `jsr.json` metadata.
-	 */
-	denoJson(data: PackageJsonData): CLIBuilder;
-	/**
-	 * Discover metadata from `deno.json`, `deno.jsonc`, then `jsr.json` (preset for
-	 * {@link CLIBuilder.manifest}).
-	 *
-	 * @deprecated Use `.manifest({ files: ['deno.json', 'deno.jsonc', 'jsr.json'] })`.
-	 *
-	 * @param settings - `inferName` / `from` (see {@link CLIBuilder.manifest}).
-	 *   `deno.json` / `jsr.json` have no `bin` field, so `inferName` resolves
-	 *   from `name`; pass `{ scope: 'keep' }` to retain a leading `@scope/`.
-	 *
-	 * @example
-	 * ```ts
-	 * cli('mycli')
-	 *   .denoJson({ from: import.meta.url })
-	 *   .command(deploy)
-	 *   .run();
-	 * ```
-	 */
-	denoJson(settings?: ManifestPresetSettings): CLIBuilder;
-	denoJson(input?: PackageJsonData | ManifestPresetSettings): CLIBuilder {
-		return rebuild(this, buildManifestSchema(this.schema, input, DENO_MANIFEST_FILES, true));
+		return rebuild(this, buildManifestSchema(this.schema, input, DEFAULT_MANIFEST_FILES));
 	}
 
 	// -- Command registration ------------------------------------------------
@@ -1876,12 +1810,12 @@ function toUrlString(value: string | URL | undefined): string | undefined {
 }
 
 /**
- * Resolve derived help links against pre-loaded package.json data.
+ * Resolve derived help links against pre-loaded manifest data.
  *
- * `.run()` resolves links during runtime preflight (where discovered
- * package.json metadata lives); this covers the filesystem-free
- * `.execute()` path, where only the `.packageJson(data)` overload can
- * contribute. Idempotent — already-resolved fields pass through unchanged.
+ * `.run()` resolves links during runtime preflight (where discovered manifest
+ * metadata lives); this covers the filesystem-free `.execute()` path, where
+ * only the `.manifest(data)` overload can contribute. Idempotent —
+ * already-resolved fields pass through unchanged.
  *
  * @internal
  */
@@ -1895,11 +1829,8 @@ function resolveHelpLinksSchema(schema: CLISchema): CLISchema {
 
 // --- manifest discovery settings
 
-/** Default manifest filenames for `.manifest()` / `.packageJson()`. @internal */
+/** Default manifest filenames for `.manifest()`. @internal */
 const DEFAULT_MANIFEST_FILES: readonly string[] = ['package.json'];
-
-/** Manifest filenames for the `.denoJson()` preset, in priority order. @internal */
-const DENO_MANIFEST_FILES: readonly string[] = ['deno.json', 'deno.jsonc', 'jsr.json'];
 
 /**
  * CLI-name inference control for {@link ManifestSettings.inferName}.
@@ -1936,14 +1867,6 @@ interface ManifestSettings {
 }
 
 /**
- * Discovery settings for the `.packageJson()` / `.denoJson()` presets (no `files`).
- *
- * @deprecated Both presets are deprecated; use {@link ManifestSettings} with
- *   {@link CLIBuilder.manifest}.
- */
-type ManifestPresetSettings = Omit<ManifestSettings, 'files'>;
-
-/**
  * Normalise an {@link InferNameOption} into the flat `{ inferName, stripScope }`
  * pair stored in {@link ResolvedManifestSettings}.
  *
@@ -1959,12 +1882,11 @@ function normalizeInferName(option: InferNameOption | undefined): {
 }
 
 /**
- * Build the next {@link CLISchema} for a manifest builder method.
+ * Build the next {@link CLISchema} for {@link CLIBuilder.manifest}.
  *
- * Shared by {@link CLIBuilder.manifest}, {@link CLIBuilder.packageJson}, and
- * {@link CLIBuilder.denoJson}. The data overload (detected via field shape)
- * merges `version`/`description` immediately so `.execute()` sees them; the
- * settings overload stores discovery config for runtime preflight.
+ * The data overload (detected via field shape) merges `version`/`description`
+ * immediately so `.execute()` sees them; the settings overload stores discovery
+ * config for runtime preflight.
  *
  * @internal
  */
@@ -1972,7 +1894,6 @@ function buildManifestSchema(
 	schema: CLISchema,
 	input: PackageJsonData | ManifestSettings | undefined,
 	defaultFiles: readonly string[],
-	pinFiles: boolean,
 ): CLISchema {
 	if (isPackageJsonData(input)) {
 		// Merge data into schema immediately so `.execute()` (which skips runtime
@@ -1996,10 +1917,7 @@ function buildManifestSchema(
 		};
 	}
 	const { inferName, stripScope } = normalizeInferName(input?.inferName);
-	// Presets (`pinFiles`) always use their fixed list: the `Omit<…,'files'>` guard
-	// only stops fresh literals at compile time, so a `ManifestSettings`-typed
-	// variable could otherwise leak `files` through the data-overload dispatch gap.
-	const files = pinFiles ? defaultFiles : (input?.files ?? defaultFiles);
+	const files = input?.files ?? defaultFiles;
 	return {
 		...schema,
 		packageJsonSettings: {
@@ -2012,7 +1930,7 @@ function buildManifestSchema(
 	};
 }
 
-// --- packageJson.from normalisation
+// --- manifest.from normalisation
 
 /**
  * Coerce a {@link ResolvedManifestSettings.from | `manifest.from`} input
@@ -2051,7 +1969,7 @@ function normalizeFromSetting(from: string | URL | ImportMeta | undefined): stri
 
 /**
  * Predicate distinguishing the {@link PackageJsonData | data} overload of
- * `.packageJson()` from the settings overload at runtime.
+ * `.manifest()` from the settings overload at runtime.
  *
  * A value is treated as `PackageJsonData` when it's a plain object that
  * carries at least one recognised field (`name`, `version`, `description`,
@@ -2205,9 +2123,7 @@ export type {
 	DefaultCommandOptions,
 	HelpConfig,
 	InferNameOption,
-	ManifestPresetSettings,
 	ManifestSettings,
-	PackageJsonSettings,
 	RenderContext,
 	RenderContextOptions,
 	ResolvedManifestSettings,

--- a/src/core/cli/runtime-preflight.test.ts
+++ b/src/core/cli/runtime-preflight.test.ts
@@ -47,7 +47,7 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 	it('loads config and package metadata before execution', async () => {
 		const app = cli('fallback')
 			.config('myapp')
-			.packageJson({ inferName: true })
+			.manifest({ inferName: true })
 			.command(
 				command('deploy')
 					.flag('region', flag.string().config('deploy.region').default('us'))
@@ -90,10 +90,10 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 		expect(preflight.filteredArgv).toEqual(['deploy']);
 	});
 
-	it('uses pre-loaded packageJson data and skips package.json discovery', async () => {
+	it('uses pre-loaded manifest data and skips package.json discovery', async () => {
 		const readFile = vi.fn(async () => null);
 		const app = cli('myapp')
-			.packageJson({ version: '4.4.4', description: 'pre-loaded' })
+			.manifest({ version: '4.4.4', description: 'pre-loaded' })
 			.command(command('info').action(() => {}));
 
 		const adapter = createTestAdapter({ argv: ['node', 'test', 'info'], readFile });
@@ -113,9 +113,9 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 		expect(readFile).not.toHaveBeenCalled();
 	});
 
-	it('honors packageJson from anchor when discovering metadata', async () => {
+	it('honors the manifest anchor when discovering metadata', async () => {
 		const app = cli('myapp')
-			.packageJson({ from: '/anchor' })
+			.manifest({ from: '/anchor' })
 			.command(command('info').action(() => {}));
 
 		const adapter = createTestAdapter({

--- a/src/core/config/AGENTS.md
+++ b/src/core/config/AGENTS.md
@@ -3,7 +3,7 @@
 ## OVERVIEW
 
 Config loading is adapter-driven and side-effect free from the module's perspective. It covers both
-user config discovery and `packageJson()` metadata inference.
+user config discovery and `manifest()` metadata inference.
 
 ## FILES
 
@@ -16,12 +16,12 @@ user config discovery and `packageJson()` metadata inference.
 
 ## WHERE TO LOOK
 
-| Task                            | Location                                  | Notes                                                 |
-| ------------------------------- | ----------------------------------------- | ----------------------------------------------------- |
-| Change default config locations | `buildConfigSearchPaths()`                | cwd dotfile, cwd explicit config, platform config dir |
-| Change custom format loading    | `FormatLoader`, `buildLoaderMap()`        | JSON built in; later loaders override earlier ones    |
-| Change main discovery flow      | `discoverConfig()`                        | first found path wins, parses through adapter         |
-| Change CLI metadata inference   | `discoverPackageJson()`, `inferCliName()` | backs `CLIBuilder.packageJson()`                      |
+| Task                            | Location                               | Notes                                                 |
+| ------------------------------- | -------------------------------------- | ----------------------------------------------------- |
+| Change default config locations | `buildConfigSearchPaths()`             | cwd dotfile, cwd explicit config, platform config dir |
+| Change custom format loading    | `FormatLoader`, `buildLoaderMap()`     | JSON built in; later loaders override earlier ones    |
+| Change main discovery flow      | `discoverConfig()`                     | first found path wins, parses through adapter         |
+| Change CLI metadata inference   | `discoverManifest()`, `inferCliName()` | backs `CLIBuilder.manifest()`                         |
 
 ## CONVENTIONS
 

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -478,12 +478,7 @@ export type {
 	PackageRepository,
 	PackageRepositoryUrlOptions,
 } from './package-json.ts';
-export {
-	discoverManifest,
-	discoverPackageJson,
-	inferCliName,
-	packageRepositoryUrl,
-} from './package-json.ts';
+export { discoverManifest, inferCliName, packageRepositoryUrl } from './package-json.ts';
 export type {
 	ConfigAdapter,
 	ConfigDiscoveryOptions,

--- a/src/core/config/package-json.test.ts
+++ b/src/core/config/package-json.test.ts
@@ -1,19 +1,14 @@
 /**
- * Unit tests for package.json auto-discovery and CLI name inference.
+ * Unit tests for manifest auto-discovery and CLI name inference.
  *
- * Tests the discoverPackageJson() walk-up, field extraction, edge cases
+ * Tests the discoverManifest() walk-up, field extraction, edge cases
  * (malformed JSON, missing fields, non-object roots), and inferCliName()
  * resolution order (bin → name → undefined).
  */
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { isCLIError } from '#internals/core/errors/index.ts';
 import type { PackageJsonAdapter } from './package-json.ts';
-import {
-	discoverManifest,
-	discoverPackageJson,
-	inferCliName,
-	packageRepositoryUrl,
-} from './package-json.ts';
+import { discoverManifest, inferCliName, packageRepositoryUrl } from './package-json.ts';
 
 // === Test helpers
 
@@ -28,24 +23,12 @@ function createAdapter(
 	};
 }
 
-// === discoverPackageJson
+// === discoverManifest — default package.json discovery
 
-describe('discoverPackageJson', () => {
+describe('discoverManifest — package.json defaults', () => {
 	// --- walk-up resolution
 
 	describe('walk-up resolution', () => {
-		it('finds package.json in cwd', async () => {
-			const adapter = createAdapter({
-				'/projects/myapp/package.json': '{"name":"myapp","version":"1.0.0"}',
-			});
-
-			const result = await discoverPackageJson(adapter);
-			expect(result).toEqual({
-				name: 'myapp',
-				version: '1.0.0',
-			});
-		});
-
 		it('walks up to parent directory', async () => {
 			const adapter = createAdapter(
 				{
@@ -54,7 +37,7 @@ describe('discoverPackageJson', () => {
 				'/projects/myapp/src',
 			);
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toEqual({
 				name: 'root',
 				version: '2.0.0',
@@ -70,14 +53,14 @@ describe('discoverPackageJson', () => {
 				'/projects/myapp/src',
 			);
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.name).toBe('inner');
 		});
 
 		it('returns null when no package.json found', async () => {
 			const adapter = createAdapter({});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toBeNull();
 		});
 
@@ -89,7 +72,7 @@ describe('discoverPackageJson', () => {
 				'/a/b/c/d',
 			);
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.name).toBe('root-pkg');
 		});
 	});
@@ -106,20 +89,8 @@ describe('discoverPackageJson', () => {
 				'/projects/myapp',
 			);
 
-			const result = await discoverPackageJson(adapter, '/anchor');
+			const result = await discoverManifest(adapter, { startDir: '/anchor' });
 			expect(result).toEqual({ name: 'anchored', version: '7.0.0' });
-		});
-
-		it('walks up from a startDir deeper than the package.json', async () => {
-			const adapter = createAdapter(
-				{
-					'/anchor/package.json': '{"version":"3.0.0"}',
-				},
-				'/somewhere/else',
-			);
-
-			const result = await discoverPackageJson(adapter, '/anchor/dist/sub');
-			expect(result?.version).toBe('3.0.0');
 		});
 
 		it('treats a file-like startDir as a directory first, then walks up', async () => {
@@ -135,7 +106,7 @@ describe('discoverPackageJson', () => {
 
 			// A file path (e.g. fileURLToPath(import.meta.url)) is probed as a
 			// directory first (no hit), then the walk-up reaches the real parent.
-			const result = await discoverPackageJson(adapter, '/pkg/dist/cli.js');
+			const result = await discoverManifest(adapter, { startDir: '/pkg/dist/cli.js' });
 			expect(result?.version).toBe('9.9.9');
 			expect(probed).toEqual([
 				'/pkg/dist/cli.js/package.json',
@@ -144,12 +115,12 @@ describe('discoverPackageJson', () => {
 			]);
 		});
 
-		it('falls back to adapter.cwd when startDir is undefined', async () => {
+		it('falls back to adapter.cwd when startDir is omitted', async () => {
 			const adapter = createAdapter({
 				'/projects/myapp/package.json': '{"version":"1.2.3"}',
 			});
 
-			const result = await discoverPackageJson(adapter, undefined);
+			const result = await discoverManifest(adapter, {});
 			expect(result?.version).toBe('1.2.3');
 		});
 
@@ -158,7 +129,7 @@ describe('discoverPackageJson', () => {
 				'/projects/myapp/package.json': '{"version":"1.2.3"}',
 			});
 
-			const result = await discoverPackageJson(adapter, '/no/such/dir');
+			const result = await discoverManifest(adapter, { startDir: '/no/such/dir' });
 			expect(result).toBeNull();
 		});
 	});
@@ -176,7 +147,7 @@ describe('discoverPackageJson', () => {
 				}),
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toEqual({
 				name: '@scope/myapp',
 				version: '3.2.1',
@@ -193,7 +164,7 @@ describe('discoverPackageJson', () => {
 				}),
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.bin).toBe('./dist/cli.js');
 		});
 
@@ -204,7 +175,7 @@ describe('discoverPackageJson', () => {
 				'/projects/myapp/package.json': '{}',
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toBeNull();
 		});
 
@@ -217,7 +188,7 @@ describe('discoverPackageJson', () => {
 				}),
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.name).toBeUndefined();
 			expect(result?.version).toBeUndefined();
 			expect(result?.description).toBeUndefined();
@@ -231,7 +202,7 @@ describe('discoverPackageJson', () => {
 				}),
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.bin).toBeUndefined();
 		});
 
@@ -243,7 +214,7 @@ describe('discoverPackageJson', () => {
 				}),
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.bin).toBeUndefined();
 		});
 
@@ -255,7 +226,7 @@ describe('discoverPackageJson', () => {
 				}),
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.homepage).toBe('https://myapp.dev');
 			expect(result?.repository).toBe('github:me/myapp');
 		});
@@ -271,7 +242,7 @@ describe('discoverPackageJson', () => {
 				}),
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.repository).toEqual({
 				type: 'git',
 				url: 'git+https://github.com/me/myapp.git',
@@ -287,7 +258,7 @@ describe('discoverPackageJson', () => {
 				}),
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.homepage).toBeUndefined();
 			expect(result?.repository).toBeUndefined();
 		});
@@ -296,21 +267,12 @@ describe('discoverPackageJson', () => {
 	// --- error resilience
 
 	describe('error resilience', () => {
-		it('returns null for malformed JSON', async () => {
-			const adapter = createAdapter({
-				'/projects/myapp/package.json': '{bad json',
-			});
-
-			const result = await discoverPackageJson(adapter);
-			expect(result).toBeNull();
-		});
-
 		it('returns null for array root', async () => {
 			const adapter = createAdapter({
 				'/projects/myapp/package.json': '[1,2,3]',
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toBeNull();
 		});
 
@@ -319,7 +281,7 @@ describe('discoverPackageJson', () => {
 				'/projects/myapp/package.json': '"just a string"',
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toBeNull();
 		});
 
@@ -328,7 +290,7 @@ describe('discoverPackageJson', () => {
 				'/projects/myapp/package.json': 'null',
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toBeNull();
 		});
 
@@ -337,7 +299,7 @@ describe('discoverPackageJson', () => {
 				'/projects/myapp/package.json': '42',
 			});
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toBeNull();
 		});
 
@@ -347,7 +309,7 @@ describe('discoverPackageJson', () => {
 				readFile: () => Promise.reject(new Error('EACCES: permission denied')),
 			};
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toBeNull();
 		});
 
@@ -367,7 +329,7 @@ describe('discoverPackageJson', () => {
 				},
 			};
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).not.toBeNull();
 			expect(result?.name).toBe('myapp');
 			expect(calls).toBeGreaterThanOrEqual(2);
@@ -385,14 +347,14 @@ describe('discoverPackageJson', () => {
 				'C:\\Users\\dev\\projects\\myapp',
 			);
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result?.name).toBe('win-app');
 		});
 
 		it('terminates at Windows drive root', async () => {
 			const adapter = createAdapter({}, 'C:\\Users\\dev');
 
-			const result = await discoverPackageJson(adapter);
+			const result = await discoverManifest(adapter);
 			expect(result).toBeNull();
 		});
 	});
@@ -552,7 +514,7 @@ describe('packageRepositoryUrl — repository field normalization', () => {
 // === discoverManifest — generalized multi-file discovery
 
 describe('discoverManifest', () => {
-	it('defaults to package.json (parity with discoverPackageJson)', async () => {
+	it('defaults to package.json when no files are given', async () => {
 		const adapter = createAdapter({
 			'/projects/myapp/package.json': '{"name":"myapp","version":"1.0.0"}',
 		});

--- a/src/core/config/package-json.ts
+++ b/src/core/config/package-json.ts
@@ -222,45 +222,6 @@ async function discoverManifest(
 	return null;
 }
 
-// --- discoverPackageJson
-
-/**
- * Discover the nearest `package.json` by walking up from `startDir` (or
- * `adapter.cwd` when omitted).
- *
- * @deprecated Use {@link discoverManifest} with `{ files: ['package.json'] }`
- *   (the default), which also supports `deno.json` / `jsr.json`.
- *
- * Behavior note (changed by the manifest generalization): a parseable but
- * metadata-less `package.json` — `{}`, or one carrying only non-metadata fields
- * such as `dependencies` / `scripts` / `type` — is no longer treated as a
- * discovery hit. Previously such a file halted the walk-up and resolved to `{}`;
- * now it is skipped and the walk-up CONTINUES to parent directories. In a
- * monorepo this means a metadata-less leaf `package.json` no longer shadows an
- * ancestor manifest, so an ancestor's `version` can surface where the old
- * behavior returned `{}`. Pass pre-loaded `data` (or use {@link discoverManifest}
- * with an explicit `startDir`) when you need to pin discovery to one directory.
- *
- * @param adapter - Adapter providing `readFile` + `cwd`.
- * @param startDir - Optional explicit directory or file path to walk up from.
- *
- * @example
- * ```ts
- * import { discoverPackageJson } from '@kjanat/dreamcli';
- *
- * const pkg = await discoverPackageJson(adapter);
- * if (pkg !== null) {
- *   console.log(pkg.version); // '1.2.3'
- * }
- * ```
- */
-async function discoverPackageJson(
-	adapter: PackageJsonAdapter,
-	startDir?: string,
-): Promise<PackageJsonData | null> {
-	return discoverManifest(adapter, startDir !== undefined ? { startDir } : {});
-}
-
 // --- stripJsonc
 
 /** Whitespace characters JSON treats as insignificant. @internal */
@@ -616,4 +577,4 @@ export type {
 	PackageRepository,
 	PackageRepositoryUrlOptions,
 };
-export { discoverManifest, discoverPackageJson, inferCliName, packageRepositoryUrl };
+export { discoverManifest, inferCliName, packageRepositoryUrl };

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,9 +37,7 @@ export type {
 	HelpConfig,
 	HelpLinks,
 	InferNameOption,
-	ManifestPresetSettings,
 	ManifestSettings,
-	PackageJsonSettings,
 	PluginCommandContext,
 	RenderContext,
 	RenderContextOptions,
@@ -81,7 +79,6 @@ export {
 	configFormat,
 	discoverConfig,
 	discoverManifest,
-	discoverPackageJson,
 	inferCliName,
 	packageRepositoryUrl,
 } from './core/config/index.ts';


### PR DESCRIPTION
Breaking, targets v4. Stacked on #103. Implements L6 of the approved v4 plan — spending the major-version deletion budget.

Removed (all deprecated since 2.5.0, zero non-test src usage): `CLIBuilder.packageJson()`, `CLIBuilder.denoJson()`, `discoverPackageJson()`, `PackageJsonSettings`, `ManifestPresetSettings`, plus `buildManifestSchema`'s preset-only file-pinning branch. Replacements: `.manifest()` / `.manifest(data)` / `.manifest({ files })`, `discoverManifest()`, `ResolvedManifestSettings`, `ManifestSettings`. The `CLISchema.packageJsonSettings` field is deliberately retained.

Test migration: `cli-package-json.test.ts` → `cli-manifest.test.ts` (66→57 tests: preset-unique coverage migrated, duplicates folded — two survivors upgraded from `toMatchObject` to full `toEqual` in the fold); `cli-links.test.ts` 35→33; `package-json.test.ts` folds `discoverPackageJson` describes into `discoverManifest` keeping walk-up/probe-order/field-extraction/error/Windows coverage. Review mapped every deleted `it` to a named surviving equivalent (and corrected one migration agent's wrong justification for a correct deletion).

Suite drops 2982→2968 — all 14 removed tests are verified duplicates or tests of the deleted preset pinning itself.

Gates: typecheck exit 0, lint clean, fmt clean, 2968/2968 tests, build (attw+publint) clean, docs build clean, docs-contract literals intact.