### PR TITLE
feat(json-schema)!: version the definition format, self-host the canonical schema URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `CommandArgEntryDefinition`; and `CLIDefinition` with
   `ConfigSettingsDefinition`. All of them are exported from the package root.
 
+- **Definition format v1 — versioned, typed documents** — `generateSchema()`
+  and `generateCommandSchema()` now emit `schemaVersion: 1`, so a consumer can
+  tell which format it is reading before parsing the rest. Both return typed
+  documents instead of `Record<string, unknown>`: `DefinitionDocumentV1` for a
+  whole CLI, `CommandDefinitionDocumentV1` for a single command, with
+  `DefinitionDocument` and `CommandDefinitionDocument` aliasing the current
+  version. Documents are distinct from the fragments nested inside them.
+  `CommandDefinitionFragmentV1`, `FlagDefinitionFragmentV1`,
+  `ArgDefinitionFragmentV1`, `ExampleDefinitionFragmentV1`,
+  `PromptDefinitionFragmentV1`, `PromptChoiceFragmentV1`,
+  `FlagNegationFragmentV1`, `FlagStringConstraintsFragmentV1`, and
+  `FlagPathChecksFragmentV1` carry no `schemaVersion` and take the version of
+  the document they sit in. `generateInputSchema()` is standard JSON Schema and
+  stays outside the family, typed as `InputSchemaDocument` with
+  `InputSchemaBranch` and `InputSchemaProperty`. Every one of these is exported
+  from the package root, and the returned documents remain assignable to
+  `Record<string, unknown>`. `--help` in `--json` mode serializes through
+  `generateCommandSchema()`, so that output gains `schemaVersion: 1` as its
+  first key.
+
 ### Changed
 
 - **Breaking: `CLISchema.commands` and `CLISchema.defaultCommand` hold
@@ -124,6 +144,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   signature referenced it. `AnyCommandBuilder` is `@internal` erasure machinery
   that appears only on `CommandBuilder`'s underscore members, so the package
   root no longer exports the name.
+
+- **Breaking: the canonical `$schema`/`$id` for definition documents is
+  self-hosted and format-versioned** —
+  `https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json` replaces the
+  jsDelivr URL in `generateSchema()` output and in `definitionMetaSchema.$id`.
+  The `v1` segment tracks the definition format, so it stays valid for every
+  package release that emits `schemaVersion: 1`, and it is permanent once
+  published. The `@kjanat/dreamcli/schema` subpath and the jsDelivr URL keep
+  serving the same bytes as mirrors. Documents pinned to the old URL still
+  validate against a local copy but no longer match the meta-schema's `$schema`
+  constant.
 
 ### Removed
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,9 +19,9 @@ import { fixTsProcessedLinkcode, transformerJSDocTags } from './vite-plugins/shi
 
 const projectRoot = normalize(`${import.meta.dirname}/../..`);
 
-// `src/schema.ts` statically imports `../dreamcli.schema.json`, a gitignored
-// build artifact. TypeDoc (run by `*.paths.ts` dynamic-route loaders and
-// `*.data.ts` data loaders) typechecks that import, so the schema must exist
+// `src/schema.ts` statically imports `../dreamcli.schema.json`, a tracked file
+// regenerated from source. TypeDoc (run by `*.paths.ts` dynamic-route loaders
+// and `*.data.ts` data loaders) typechecks that import, so the schema must exist
 // before route/data resolution. VitePress bundles those loaders in a transient
 // esbuild step that bypasses this Vite config's plugins, so the source-artifacts
 // plugin's `buildStart` hook fires too late. Emitting here at config

--- a/docs/.vitepress/data/meta-schema-descriptions.ts
+++ b/docs/.vitepress/data/meta-schema-descriptions.ts
@@ -36,6 +36,7 @@ const ROOT_PROPERTY_TARGETS: Readonly<Record<string, NodeTarget>> = {
 
 const DEF_TARGETS: Readonly<Record<string, NodeTarget>> = {
 	command: { exportId: 'dreamcli:CommandSchema' },
+	commandDocument: { exportId: 'dreamcli:CommandDefinitionDocumentV1' },
 	flag: { exportId: 'dreamcli:FlagSchema' },
 	negation: { exportId: 'dreamcli:FlagNegation' },
 	arg: { exportId: 'dreamcli:ArgSchema' },
@@ -57,6 +58,20 @@ const DEF_PROPERTY_TARGETS: Readonly<Record<string, Readonly<Record<string, Node
 		flags: { exportId: 'dreamcli:CommandSchema', property: 'flags' },
 		args: { exportId: 'dreamcli:CommandSchema', property: 'args' },
 		commands: { exportId: 'dreamcli:CommandSchema', property: 'commands' },
+	},
+	commandDocument: {
+		schemaVersion: { exportId: 'dreamcli:DEFINITION_SCHEMA_VERSION' },
+		name: { exportId: 'dreamcli:CommandDefinitionFragmentV1', property: 'name' },
+		description: {
+			exportId: 'dreamcli:CommandDefinitionFragmentV1',
+			property: 'description',
+		},
+		aliases: { exportId: 'dreamcli:CommandDefinitionFragmentV1', property: 'aliases' },
+		hidden: { exportId: 'dreamcli:CommandDefinitionFragmentV1', property: 'hidden' },
+		examples: { exportId: 'dreamcli:CommandDefinitionFragmentV1', property: 'examples' },
+		flags: { exportId: 'dreamcli:CommandDefinitionFragmentV1', property: 'flags' },
+		args: { exportId: 'dreamcli:CommandDefinitionFragmentV1', property: 'args' },
+		commands: { exportId: 'dreamcli:CommandDefinitionFragmentV1', property: 'commands' },
 	},
 	flag: {
 		kind: { exportId: 'dreamcli:FlagSchema', property: 'kind' },

--- a/docs/.vitepress/vite-plugins/source-artifacts.ts
+++ b/docs/.vitepress/vite-plugins/source-artifacts.ts
@@ -4,7 +4,7 @@
  * Twoslash examples import `@kjanat/dreamcli/schema`, which resolves
  * through tsconfig paths to the root `dreamcli.schema.json` file. This
  * plugin ensures that file exists during docs dev/build and emits it into
- * docs dist for hosting.
+ * docs dist at the canonical `$schema` path and at the root mirror.
  *
  * @module
  */
@@ -18,6 +18,9 @@ const rootDir = normalize(`${import.meta.dirname}/../../..`);
 const definitionSchemaPath = `${rootDir}/dreamcli.schema.json`;
 const emitDefinitionSchemaPath = `${rootDir}/scripts/emit-definition-schema.ts`;
 const emitDefinitionSchemaUrl = pathToFileURL(emitDefinitionSchemaPath).href;
+
+const CANONICAL_SCHEMA_PATH = 'schemas/definition/v1.schema.json';
+const MIRROR_SCHEMA_PATH = 'dreamcli.schema.json';
 
 export function sourceArtifactsPlugin(): Plugin {
 	let buildingPromise: Promise<void> | null = null;
@@ -58,11 +61,13 @@ export function sourceArtifactsPlugin(): Plugin {
 		async generateBundle() {
 			const { readFile } = await import('node:fs/promises');
 			const schema = await readExistingSchema(readFile, definitionSchemaPath);
-			this.emitFile({
-				type: 'asset',
-				fileName: 'dreamcli.schema.json',
-				source: schema,
-			});
+			for (const fileName of [CANONICAL_SCHEMA_PATH, MIRROR_SCHEMA_PATH]) {
+				this.emitFile({
+					type: 'asset',
+					fileName,
+					source: schema,
+				});
+			}
 		},
 
 		configureServer(server) {

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -46,5 +46,6 @@ public/        # static assets
 
 ## NOTES
 
-- Root `dreamcli.schema.json` is required for docs and gets copied into site output during build
+- Root `dreamcli.schema.json` is required for docs; the build emits it into site output twice, at
+  `schemas/definition/v1.schema.json` (the canonical `$schema` URL) and at `dreamcli.schema.json`
 - See `docs/.vitepress/AGENTS.md` for plugin, theme, and data-pipeline gotchas

--- a/docs/guide/schema-export.md
+++ b/docs/guide/schema-export.md
@@ -27,12 +27,26 @@ writeFileSync(
 );
 ```
 
-Output includes a `$schema` URL pointing at the CDN-hosted definition
-schema. For offline or CI-friendly setups, use the local copy instead:
+Output includes a `$schema` URL pointing at
+`https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json`. The `v1` in
+that path is the definition format version, the same one the document reports
+as `schemaVersion`. Every release that emits `schemaVersion: 1` resolves to it.
+
+Two mirrors carry the same bytes: the copy inside the installed package, and
+`https://cdn.jsdelivr.net/npm/@kjanat/dreamcli/dreamcli.schema.json` on the npm
+CDN. Emitted documents always carry the canonical URL in `$schema`, and the
+meta-schema pins that exact value. For offline or CI-friendly validation, map
+the canonical URL to the local copy in your tooling instead of rewriting the
+document — in VS Code:
 
 ```json
 {
-  "$schema": "./node_modules/@kjanat/dreamcli/dreamcli.schema.json"
+  "json.schemas": [
+    {
+      "url": "./node_modules/@kjanat/dreamcli/dreamcli.schema.json",
+      "fileMatch": ["*.definition.json"]
+    }
+  ]
 }
 ```
 
@@ -42,7 +56,8 @@ Full example output:
 
 ```json
 {
-  "$schema": "https://cdn.jsdelivr.net/npm/@kjanat/dreamcli/dreamcli.schema.json",
+  "$schema": "https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json",
+  "schemaVersion": 1,
   "name": "mycli",
   "version": "1.0.0",
   "commands": [

--- a/docs/guide/schema-export.md
+++ b/docs/guide/schema-export.md
@@ -44,13 +44,17 @@ document — in VS Code:
   "json.schemas": [
     {
       "url": "./node_modules/@kjanat/dreamcli/dreamcli.schema.json",
-      "fileMatch": ["*.definition.json"]
+      "fileMatch": ["cli-schema.json", "*.definition.json"]
     }
   ]
 }
 ```
 
 The schema is also importable as `@kjanat/dreamcli/schema`.
+
+Standalone documents from `generateCommandSchema()` validate against the dedicated
+`https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json#/$defs/commandDocument`
+entry point.
 
 Full example output:
 

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,6 +1,6 @@
 /*
   Link: </reference/main>; rel="service-doc"; type="text/html"; title="API reference"
-  Link: </dreamcli.schema.json>; rel="describedby"; type="application/json"; title="CLI definition schema"
+  Link: </schemas/definition/v1.schema.json>; rel="describedby"; type="application/json"; title="CLI definition schema"
   Link: </sitemap.xml>; rel="sitemap"; type="application/xml"
   Link: </AGENTS>; rel="author"; type="text/html"; title="Agent guide"
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -6,7 +6,8 @@ It resolves to the same schema referenced by `generateSchema()` output, with a p
 - npm/package export (`package.json`): `./schema` -> `dreamcli.schema.json`
 - Deno/JSR export (`deno.json`): `./schema` -> `src/schema.ts` (which re-exports the same schema)
 
-Use it when you want local or offline validation of dreamcli definition metadata without depending on the CDN `$schema` URL.
+Its bytes are identical to the canonical hosted copy at
+`https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json`, so use it when you want local or offline validation of dreamcli definition metadata without a network lookup.
 
 ## Importing The Schema
 
@@ -44,7 +45,7 @@ definition.$schema;
 schema.$id;
 ```
 
-`definition.$schema` points at the public schema URL, while the package export gives you the same definition locally from the installed package.
+`definition.$schema` points at the canonical hosted URL. Its `v1` segment is the definition format version, matching the document's `schemaVersion`. The package export gives you the same schema locally from the installed package.
 
 ## Related Pages
 

--- a/dreamcli.schema.json
+++ b/dreamcli.schema.json
@@ -108,46 +108,55 @@
       "additionalProperties": false,
       "properties": {
         "schemaVersion": {
-          "const": 1
+          "const": 1,
+          "description": "Version of the definition document format emitted by generateSchema\nand generateCommandSchema."
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The command name used for dispatch."
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Human-readable description for help text."
         },
         "aliases": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "Alternative names accepted for this command."
         },
         "hidden": {
-          "const": true
+          "const": true,
+          "description": "Whether the command is omitted from help listings."
         },
         "examples": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/example"
-          }
+          },
+          "description": "Usage examples attached to the command."
         },
         "flags": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/flag"
-          }
+          },
+          "description": "Named flag definitions keyed by flag name."
         },
         "args": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/arg"
-          }
+          },
+          "description": "Positional argument definitions in CLI order."
         },
         "commands": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/command"
-          }
+          },
+          "description": "Nested subcommand definitions."
         }
       },
       "required": [
@@ -156,7 +165,8 @@
         "flags",
         "args",
         "commands"
-      ]
+      ],
+      "description": "A single-command definition document, version 1.\n\nProduced by generateCommandSchema. Same shape as a\nCommandDefinitionFragmentV1 plus the `schemaVersion` every standalone\ndocument carries."
     },
     "flag": {
       "type": "object",

--- a/dreamcli.schema.json
+++ b/dreamcli.schema.json
@@ -1,13 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdn.jsdelivr.net/npm/@kjanat/dreamcli/dreamcli.schema.json",
+  "$id": "https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json",
   "title": "@kjanat/dreamcli definition schema",
   "description": "Runtime descriptor for the CLI program.\n\nStores the program name, version, description, and registered command schemas.\\\nSealed by createCLISchema and rebuilt by each CLIBuilder step.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "const": "https://cdn.jsdelivr.net/npm/@kjanat/dreamcli/dreamcli.schema.json"
+      "const": "https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json"
+    },
+    "schemaVersion": {
+      "const": 1
     },
     "name": {
       "type": "string",
@@ -35,6 +38,7 @@
   },
   "required": [
     "$schema",
+    "schemaVersion",
     "name",
     "commands"
   ],
@@ -98,6 +102,61 @@
         "commands"
       ],
       "description": "Runtime descriptor produced by CommandBuilder.\n\nConsumers (parser, help generator, CLI dispatcher) read this to\nunderstand the command's shape — flags, args, aliases, subcommands,\nand interactive resolver."
+    },
+    "commandDocument": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schemaVersion": {
+          "const": 1
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hidden": {
+          "const": true
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/example"
+          }
+        },
+        "flags": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/flag"
+          }
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/arg"
+          }
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/command"
+          }
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "name",
+        "flags",
+        "args",
+        "commands"
+      ]
     },
     "flag": {
       "type": "object",

--- a/scripts/emit-definition-schema.ts
+++ b/scripts/emit-definition-schema.ts
@@ -2,10 +2,6 @@
 /**
  * Emit the definition meta-schema as `dreamcli.schema.json` at the package root.
  *
- * Uses `REGISTRY` to set the registry-specific `$id`:
- * - `jsr`            → esm.sh JSR URL
- * - `npm` or unset   → npm CDN URL
- *
  * @module
  */
 
@@ -13,37 +9,11 @@ import { writeFile } from 'node:fs/promises';
 import { normalize } from 'node:path';
 import { exit } from 'node:process';
 import { definitionMetaSchema } from '@kjanat/dreamcli';
-import packageJson from '../package.json' with { type: 'json' };
 
 const outFile = normalize(`${import.meta.dirname}/../dreamcli.schema.json`);
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function resolveSchemaId(): string {
-	return `https://cdn.jsdelivr.net/npm/${packageJson.name}/dreamcli.schema.json`;
-}
-
 export async function emitDefinitionSchema(): Promise<void> {
-	const schemaId = resolveSchemaId();
-	const schema = {
-		...definitionMetaSchema,
-		$id: schemaId,
-		properties: isRecord(definitionMetaSchema.properties)
-			? {
-					...definitionMetaSchema.properties,
-					$schema: isRecord(definitionMetaSchema.properties.$schema)
-						? {
-								...definitionMetaSchema.properties.$schema,
-								const: schemaId,
-							}
-						: definitionMetaSchema.properties.$schema,
-				}
-			: definitionMetaSchema.properties,
-	};
-
-	const schemaStr = `${JSON.stringify(schema, null, '  ')}\n`;
+	const schemaStr = `${JSON.stringify(definitionMetaSchema, null, '  ')}\n`;
 	await writeFile(outFile, schemaStr, 'utf-8');
 	console.error(`Definition schema emitted to ${outFile}`);
 }

--- a/src/core/json-schema/AGENTS.md
+++ b/src/core/json-schema/AGENTS.md
@@ -41,5 +41,7 @@ output.
 
 ## NOTES
 
-- Definition schema URL points at `@kjanat/dreamcli/dreamcli.schema.json` on the CDN
+- Definition schema URL is the self-hosted, format-versioned
+  `https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json`; the npm package copy and the
+  jsDelivr URL are mirrors of the same bytes
 - This module sits on the boundary between public API docs, config validation, and build artifacts

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -230,13 +230,21 @@ type ArgDefinitionFragmentV1 = {
  * they sit in. The standalone form is {@link CommandDefinitionDocumentV1}.
  */
 type CommandDefinitionFragmentV1 = {
+	/** The command name used for dispatch. */
 	readonly name: string;
+	/** Human-readable description for help text. */
 	readonly description?: string;
+	/** Alternative names accepted for this command. */
 	readonly aliases?: readonly string[];
+	/** Whether the command is omitted from help listings. */
 	readonly hidden?: true;
+	/** Usage examples attached to the command. */
 	readonly examples?: readonly ExampleDefinitionFragmentV1[];
+	/** Named flag definitions keyed by flag name. */
 	readonly flags: Readonly<Record<string, FlagDefinitionFragmentV1>>;
+	/** Positional argument definitions in CLI order. */
 	readonly args: readonly ArgDefinitionFragmentV1[];
+	/** Nested subcommand definitions. */
 	readonly commands: readonly CommandDefinitionFragmentV1[];
 };
 
@@ -264,6 +272,7 @@ type DefinitionDocumentV1 = {
  * document carries.
  */
 type CommandDefinitionDocumentV1 = CommandDefinitionFragmentV1 & {
+	/** Definition document format version. */
 	readonly schemaVersion: 1;
 };
 
@@ -366,6 +375,8 @@ function generateSchema(
  * @param meta - Program name/version for function-form examples; defaults to
  *   the command's own name with no version.
  * @returns A plain object suitable for `JSON.stringify()`.
+ * @remarks Validate standalone output against
+ *   `https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json#/$defs/commandDocument`.
  */
 function generateCommandSchema(
 	schema: CommandSchema,
@@ -1254,4 +1265,11 @@ export type {
 	PromptChoiceFragmentV1,
 	PromptDefinitionFragmentV1,
 };
-export { definitionMetaSchema, generateCommandSchema, generateInputSchema, generateSchema };
+export {
+	DEFINITION_SCHEMA_URL,
+	DEFINITION_SCHEMA_VERSION,
+	definitionMetaSchema,
+	generateCommandSchema,
+	generateInputSchema,
+	generateSchema,
+};

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -18,14 +18,22 @@ import type { schemaBrand } from '#internals/core/schema/brand.ts';
 import { resolveExampleCommand } from '#internals/core/schema/command.ts';
 import { getFlagAliasNames } from '#internals/core/schema/flag.ts';
 import type {
+	ArgKind,
+	ArgPresence,
 	ArgSchema,
 	CommandArgEntry,
 	CommandExample,
 	CommandSchema,
+	DuplicatePolicy,
 	ExampleMeta,
+	FlagKind,
+	FlagPresence,
 	FlagSchema,
+	NumberConstraints,
 	PromptConfig,
+	PromptKind,
 	SelectChoice,
+	StringConstraints,
 } from '#internals/core/schema/index.ts';
 import { definitionMetaSchemaDescriptions } from './meta-descriptions.generated.ts';
 
@@ -91,18 +99,204 @@ function resolveOptions(options: JsonSchemaOptions | undefined): ResolvedOptions
 /**
  * `$schema` URL for definition documents.
  *
- * Resolves via the actual file path on the CDN (`dreamcli.schema.json`).
- * For offline or local-first workflows, use
- * `./node_modules/@kjanat/dreamcli/dreamcli.schema.json`.
+ * Self-hosted. The `v1` segment is the definition format version, the value
+ * every document reports as `schemaVersion`, so it resolves for every package
+ * release that emits `schemaVersion: 1`. Two mirrors carry identical bytes:
+ * `./node_modules/@kjanat/dreamcli/dreamcli.schema.json` for offline or
+ * local-first workflows, and
+ * `https://cdn.jsdelivr.net/npm/@kjanat/dreamcli/dreamcli.schema.json` on the
+ * npm CDN.
  */
-const DEFINITION_SCHEMA_URL = 'https://cdn.jsdelivr.net/npm/@kjanat/dreamcli/dreamcli.schema.json';
+const DEFINITION_SCHEMA_URL = 'https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json';
 
 /** Meta-schema URL for JSON Schema draft 2020-12 (input validation). */
 const JSON_SCHEMA_DRAFT = 'https://json-schema.org/draft/2020-12/schema';
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+/**
+ * Version of the definition document format emitted by {@link generateSchema}
+ * and {@link generateCommandSchema}.
+ */
+const DEFINITION_SCHEMA_VERSION = 1;
+
+// --- Definition document types
+
+/**
+ * A usage example inside a definition document.
+ *
+ * Function-form examples are resolved to strings during serialization.
+ */
+type ExampleDefinitionFragmentV1 = {
+	readonly command: string;
+	readonly description?: string;
+};
+
+/** A selectable choice of a `select` or `multiselect` prompt fragment. */
+type PromptChoiceFragmentV1 = {
+	readonly value: string;
+	readonly label?: string;
+	readonly description?: string;
+};
+
+/**
+ * Prompt configuration attached to a flag fragment.
+ *
+ * Validation callbacks are dropped. Only the serializable description of the
+ * prompt survives.
+ */
+type PromptDefinitionFragmentV1 = {
+	readonly kind: PromptKind;
+	readonly message: string;
+	readonly placeholder?: string;
+	readonly choices?: readonly PromptChoiceFragmentV1[];
+	readonly min?: number;
+	readonly max?: number;
+};
+
+/** Negated-spelling settings of a boolean flag fragment. */
+type FlagNegationFragmentV1 = {
+	readonly alias?: string;
+	readonly hidden?: true;
+};
+
+/** String constraints of a flag fragment, with the pattern split into source and flags. */
+type FlagStringConstraintsFragmentV1 = {
+	readonly nonEmpty?: boolean;
+	readonly minLength?: number;
+	readonly maxLength?: number;
+	readonly pattern?: {
+		readonly source: string;
+		readonly flags: string;
+	};
+};
+
+/** Filesystem expectations of a flag fragment. */
+type FlagPathChecksFragmentV1 = {
+	readonly mustExist: boolean;
+	readonly type?: 'file' | 'directory';
+	readonly create?: true;
+};
+
+/**
+ * A flag entry inside a definition document.
+ *
+ * Optional fields appear only when the flag sets them; `defaultValue` appears
+ * only when the value survives a JSON round-trip.
+ */
+type FlagDefinitionFragmentV1 = {
+	readonly kind: FlagKind;
+	readonly presence: FlagPresence;
+	readonly defaultValue?: unknown;
+	readonly aliases?: readonly string[];
+	readonly envVar?: string;
+	readonly configPath?: string;
+	readonly description?: string;
+	readonly enumValues?: readonly string[];
+	readonly numberConstraints?: NumberConstraints;
+	readonly stringConstraints?: FlagStringConstraintsFragmentV1;
+	readonly elementSchema?: FlagDefinitionFragmentV1;
+	readonly separator?: string;
+	readonly unique?: true;
+	readonly pathChecks?: FlagPathChecksFragmentV1;
+	readonly valueHint?: string;
+	readonly prompt?: PromptDefinitionFragmentV1;
+	readonly deprecated?: string | true;
+	readonly propagate?: true;
+	readonly negation?: FlagNegationFragmentV1;
+	readonly duplicates?: DuplicatePolicy;
+};
+
+/**
+ * A positional arg entry inside a definition document.
+ *
+ * Array order carries the CLI position.
+ */
+type ArgDefinitionFragmentV1 = {
+	readonly name: string;
+	readonly kind: ArgKind;
+	readonly presence: ArgPresence;
+	readonly variadic?: true;
+	readonly stdinMode?: true;
+	readonly defaultValue?: unknown;
+	readonly description?: string;
+	readonly envVar?: string;
+	readonly enumValues?: readonly string[];
+	readonly deprecated?: string | true;
+};
+
+/**
+ * A command nested inside a definition document.
+ *
+ * Fragments carry no `schemaVersion`. They inherit the version of the document
+ * they sit in. The standalone form is {@link CommandDefinitionDocumentV1}.
+ */
+type CommandDefinitionFragmentV1 = {
+	readonly name: string;
+	readonly description?: string;
+	readonly aliases?: readonly string[];
+	readonly hidden?: true;
+	readonly examples?: readonly ExampleDefinitionFragmentV1[];
+	readonly flags: Readonly<Record<string, FlagDefinitionFragmentV1>>;
+	readonly args: readonly ArgDefinitionFragmentV1[];
+	readonly commands: readonly CommandDefinitionFragmentV1[];
+};
+
+/**
+ * A whole-CLI definition document, version 1.
+ *
+ * Produced by {@link generateSchema}. Validated by {@link definitionMetaSchema}
+ * and served at {@link DEFINITION_SCHEMA_URL}.
+ */
+type DefinitionDocumentV1 = {
+	readonly $schema: string;
+	readonly schemaVersion: 1;
+	readonly name: string;
+	readonly version?: string;
+	readonly description?: string;
+	readonly defaultCommand?: CommandDefinitionFragmentV1;
+	readonly commands: readonly CommandDefinitionFragmentV1[];
+};
+
+/**
+ * A single-command definition document, version 1.
+ *
+ * Produced by {@link generateCommandSchema}. Same shape as a
+ * {@link CommandDefinitionFragmentV1} plus the `schemaVersion` every standalone
+ * document carries.
+ */
+type CommandDefinitionDocumentV1 = CommandDefinitionFragmentV1 & {
+	readonly schemaVersion: 1;
+};
+
+/** The current whole-CLI definition document. */
+type DefinitionDocument = DefinitionDocumentV1;
+
+/** The current single-command definition document. */
+type CommandDefinitionDocument = CommandDefinitionDocumentV1;
+
+// --- Input schema types
+
+/** A JSON Schema fragment describing one flag or arg as an input property. */
+type InputSchemaProperty = Readonly<Record<string, unknown>>;
+
+/** The JSON Schema object describing one command's flags and args. */
+type InputSchemaBranch = {
+	readonly type: 'object';
+	readonly properties: Readonly<Record<string, InputSchemaProperty>>;
+	readonly additionalProperties: false;
+	readonly required?: readonly string[];
+};
+
+/**
+ * A JSON Schema (draft 2020-12) document produced by {@link generateInputSchema}.
+ *
+ * This document sits outside the definition-document family. It holds one
+ * branch for a single invocable command, a `oneOf` union for several, and a
+ * bare object schema when a CLI has none.
+ */
+type InputSchemaDocument =
+	| ({ readonly $schema: string } & InputSchemaBranch)
+	| { readonly $schema: string; readonly oneOf: readonly InputSchemaBranch[] }
+	| { readonly $schema: string; readonly type: 'object' };
 
 // === Definition schema — generateSchema()
 
@@ -131,36 +325,29 @@ function generateSchema(
 	schema: CLISchema,
 	options?: JsonSchemaOptions,
 	meta?: ExampleMeta,
-): Record<string, unknown> {
+): DefinitionDocumentV1 {
 	const opts = resolveOptions(options);
 	const resolvedMeta: ExampleMeta = meta ?? { name: schema.name, version: schema.version };
 
-	const result: Record<string, unknown> = {
+	// Full definition, not just the name — the default command lives only in
+	// `defaultCommand` (never in `commands`), so a name-only reference would
+	// drop its flags/args from the document entirely.
+	const defaultCommand =
+		schema.defaultCommand !== undefined && (opts.includeHidden || !schema.defaultCommand.hidden)
+			? serializeCommand(schema.defaultCommand, opts, resolvedMeta)
+			: undefined;
+
+	return {
 		$schema: DEFINITION_SCHEMA_URL,
+		schemaVersion: DEFINITION_SCHEMA_VERSION,
 		name: schema.name,
+		...(schema.version !== undefined ? { version: schema.version } : {}),
+		...(schema.description !== undefined ? { description: schema.description } : {}),
+		...(defaultCommand !== undefined ? { defaultCommand } : {}),
+		commands: schema.commands
+			.filter((cmd) => opts.includeHidden || !cmd.hidden)
+			.map((cmd) => serializeCommand(cmd, opts, resolvedMeta)),
 	};
-
-	if (schema.version !== undefined) {
-		result.version = schema.version;
-	}
-	if (schema.description !== undefined) {
-		result.description = schema.description;
-	}
-	if (
-		schema.defaultCommand !== undefined &&
-		(opts.includeHidden || !schema.defaultCommand.hidden)
-	) {
-		// Full definition, not just the name — the default command lives only in
-		// `defaultCommand` (never in `commands`), so a name-only reference would
-		// drop its flags/args from the document entirely.
-		result.defaultCommand = serializeCommand(schema.defaultCommand, opts, resolvedMeta);
-	}
-
-	result.commands = schema.commands
-		.filter((cmd) => opts.includeHidden || !cmd.hidden)
-		.map((cmd) => serializeCommand(cmd, opts, resolvedMeta));
-
-	return result;
 }
 
 // --- Command serialization
@@ -168,10 +355,11 @@ function generateSchema(
 /**
  * Generate the definition metadata document for a single command.
  *
- * The per-command counterpart of {@link generateSchema}: the same
- * JSON-serializable shape as one entry of its `commands` array (flags, args,
- * subcommands, examples). Powers `--help` in `--json` mode and is useful for
- * embedding one command's definition into custom tooling.
+ * The per-command counterpart of {@link generateSchema}: one entry of its
+ * `commands` array (flags, args, subcommands, examples), plus the
+ * `schemaVersion` every standalone document carries. Powers `--help` in
+ * `--json` mode and is useful for embedding one command's definition into
+ * custom tooling.
  *
  * @param schema - The command schema to serialize.
  * @param options - Generation options.
@@ -183,9 +371,12 @@ function generateCommandSchema(
 	schema: CommandSchema,
 	options?: JsonSchemaOptions,
 	meta?: ExampleMeta,
-): Record<string, unknown> {
+): CommandDefinitionDocumentV1 {
 	const resolvedMeta: ExampleMeta = meta ?? { name: schema.name, version: undefined };
-	return serializeCommand(schema, resolveOptions(options), resolvedMeta);
+	return {
+		schemaVersion: DEFINITION_SCHEMA_VERSION,
+		...serializeCommand(schema, resolveOptions(options), resolvedMeta),
+	};
 }
 
 /**
@@ -199,38 +390,29 @@ function serializeCommand(
 	schema: CommandSchema,
 	opts: ResolvedOptions,
 	meta: ExampleMeta,
-): Record<string, unknown> {
-	const result: Record<string, unknown> = { name: schema.name };
-
-	if (schema.description !== undefined) {
-		result.description = schema.description;
-	}
-	if (schema.aliases.length > 0) {
-		result.aliases = [...schema.aliases];
-	}
-	if (schema.hidden) {
-		result.hidden = true;
-	}
-	if (schema.examples.length > 0) {
-		result.examples = schema.examples.map((example) => serializeExample(example, meta));
-	}
-
+): CommandDefinitionFragmentV1 {
 	// Flags — always present (consumers iterate without existence check)
-	const flags: Record<string, Record<string, unknown>> = {};
+	const flags: Record<string, FlagDefinitionFragmentV1> = {};
 	for (const [name, flagDef] of Object.entries(schema.flags)) {
 		flags[name] = serializeFlag(flagDef, opts);
 	}
-	result.flags = flags;
 
-	// Args — always present (positional order matters)
-	result.args = schema.args.map(serializeArgEntry);
-
-	// Subcommands — always present
-	result.commands = schema.commands
-		.filter((cmd) => opts.includeHidden || !cmd.hidden)
-		.map((cmd) => serializeCommand(cmd, opts, meta));
-
-	return result;
+	return {
+		name: schema.name,
+		...(schema.description !== undefined ? { description: schema.description } : {}),
+		...(schema.aliases.length > 0 ? { aliases: [...schema.aliases] } : {}),
+		...(schema.hidden ? { hidden: true } : {}),
+		...(schema.examples.length > 0
+			? { examples: schema.examples.map((example) => serializeExample(example, meta)) }
+			: {}),
+		flags,
+		// Args — always present (positional order matters)
+		args: schema.args.map(serializeArgEntry),
+		// Subcommands — always present
+		commands: schema.commands
+			.filter((cmd) => opts.includeHidden || !cmd.hidden)
+			.map((cmd) => serializeCommand(cmd, opts, meta)),
+	};
 }
 
 // --- Flag serialization
@@ -242,90 +424,77 @@ function serializeCommand(
  * @param opts - Resolved generation options (prompt inclusion).
  * @returns JSON-serializable object representing the flag.
  */
-function serializeFlag(schema: FlagSchema, opts: ResolvedOptions): Record<string, unknown> {
-	const result: Record<string, unknown> = {
+function serializeFlag(schema: FlagSchema, opts: ResolvedOptions): FlagDefinitionFragmentV1 {
+	const visibleAliases = getFlagAliasNames(schema);
+	const stringConstraints = schema.stringConstraints;
+	const pathChecks = schema.pathChecks;
+	const negation = schema.negation;
+
+	return {
 		kind: schema.kind,
 		presence: schema.presence,
+		...(schema.presence === 'defaulted' && isJsonSerializable(schema.defaultValue)
+			? { defaultValue: schema.defaultValue }
+			: {}),
+		...(visibleAliases.length > 0 ? { aliases: [...visibleAliases] } : {}),
+		...(schema.envVar !== undefined ? { envVar: schema.envVar } : {}),
+		...(schema.configPath !== undefined ? { configPath: schema.configPath } : {}),
+		...(schema.description !== undefined ? { description: schema.description } : {}),
+		...(schema.enumValues !== undefined ? { enumValues: [...schema.enumValues] } : {}),
+		...(schema.numberConstraints !== undefined
+			? { numberConstraints: { ...schema.numberConstraints } }
+			: {}),
+		...(stringConstraints !== undefined
+			? { stringConstraints: serializeStringConstraints(stringConstraints) }
+			: {}),
+		...(schema.elementSchema !== undefined
+			? { elementSchema: serializeFlag(schema.elementSchema, opts) }
+			: {}),
+		...(schema.separator !== undefined ? { separator: schema.separator } : {}),
+		...(schema.unique ? { unique: true } : {}),
+		...(pathChecks !== undefined
+			? {
+					pathChecks: {
+						mustExist: pathChecks.mustExist,
+						...(pathChecks.type !== undefined ? { type: pathChecks.type } : {}),
+						...(pathChecks.create ? { create: true } : {}),
+					},
+				}
+			: {}),
+		...(schema.valueHint !== undefined ? { valueHint: schema.valueHint } : {}),
+		...(opts.includePrompts && schema.prompt !== undefined
+			? { prompt: serializePrompt(schema.prompt) }
+			: {}),
+		...(schema.deprecated !== undefined ? { deprecated: schema.deprecated } : {}),
+		...(schema.propagate ? { propagate: true } : {}),
+		...(negation !== undefined
+			? {
+					negation: {
+						...(negation.alias !== undefined ? { alias: negation.alias } : {}),
+						...(negation.hidden ? { hidden: true } : {}),
+					},
+				}
+			: {}),
+		...(schema.duplicates !== 'last' ? { duplicates: schema.duplicates } : {}),
 	};
+}
 
-	if (schema.presence === 'defaulted' && isJsonSerializable(schema.defaultValue)) {
-		result.defaultValue = schema.defaultValue;
-	}
-	const visibleAliases = getFlagAliasNames(schema);
-	if (visibleAliases.length > 0) {
-		result.aliases = [...visibleAliases];
-	}
-	if (schema.envVar !== undefined) {
-		result.envVar = schema.envVar;
-	}
-	if (schema.configPath !== undefined) {
-		result.configPath = schema.configPath;
-	}
-	if (schema.description !== undefined) {
-		result.description = schema.description;
-	}
-	if (schema.enumValues !== undefined) {
-		result.enumValues = [...schema.enumValues];
-	}
-	if (schema.numberConstraints !== undefined) {
-		result.numberConstraints = { ...schema.numberConstraints };
-	}
-	if (schema.stringConstraints !== undefined) {
-		result.stringConstraints = {
-			...schema.stringConstraints,
-			...(schema.stringConstraints.pattern !== undefined
-				? {
-						pattern: {
-							source: schema.stringConstraints.pattern.source,
-							flags: schema.stringConstraints.pattern.flags,
-						},
-					}
-				: {}),
-		};
-	}
-	if (schema.elementSchema !== undefined) {
-		result.elementSchema = serializeFlag(schema.elementSchema, opts);
-	}
-	if (schema.separator !== undefined) {
-		result.separator = schema.separator;
-	}
-	if (schema.unique) {
-		result.unique = true;
-	}
-	if (schema.pathChecks !== undefined) {
-		result.pathChecks = {
-			mustExist: schema.pathChecks.mustExist,
-			...(schema.pathChecks.type !== undefined ? { type: schema.pathChecks.type } : {}),
-			...(schema.pathChecks.create ? { create: true } : {}),
-		};
-	}
-	if (schema.valueHint !== undefined) {
-		result.valueHint = schema.valueHint;
-	}
-	if (opts.includePrompts && schema.prompt !== undefined) {
-		result.prompt = serializePrompt(schema.prompt);
-	}
-	if (schema.deprecated !== undefined) {
-		result.deprecated = schema.deprecated;
-	}
-	if (schema.propagate) {
-		result.propagate = true;
-	}
-	if (schema.negation !== undefined) {
-		const negation: Record<string, unknown> = {};
-		if (schema.negation.alias !== undefined) {
-			negation.alias = schema.negation.alias;
-		}
-		if (schema.negation.hidden) {
-			negation.hidden = true;
-		}
-		result.negation = negation;
-	}
-	if (schema.duplicates !== 'last') {
-		result.duplicates = schema.duplicates;
-	}
-
-	return result;
+/**
+ * Serialize {@link StringConstraints} into a plain object.
+ *
+ * @param constraints - The string constraints to serialize.
+ * @returns JSON-serializable object with the pattern split into source and flags.
+ */
+function serializeStringConstraints(
+	constraints: StringConstraints,
+): FlagStringConstraintsFragmentV1 {
+	const pattern = constraints.pattern;
+	return {
+		...(constraints.nonEmpty !== undefined ? { nonEmpty: constraints.nonEmpty } : {}),
+		...(constraints.minLength !== undefined ? { minLength: constraints.minLength } : {}),
+		...(constraints.maxLength !== undefined ? { maxLength: constraints.maxLength } : {}),
+		...(pattern !== undefined ? { pattern: { source: pattern.source, flags: pattern.flags } } : {}),
+	};
 }
 
 // --- Arg serialization
@@ -336,37 +505,23 @@ function serializeFlag(schema: FlagSchema, opts: ResolvedOptions): Record<string
  * @param entry - The positional arg entry (name + {@link ArgSchema}).
  * @returns JSON-serializable object representing the arg.
  */
-function serializeArgEntry(entry: CommandArgEntry): Record<string, unknown> {
+function serializeArgEntry(entry: CommandArgEntry): ArgDefinitionFragmentV1 {
 	const { name, schema } = entry;
-	const result: Record<string, unknown> = {
+
+	return {
 		name,
 		kind: schema.kind,
 		presence: schema.presence,
+		...(schema.variadic ? { variadic: true } : {}),
+		...(schema.stdinMode ? { stdinMode: true } : {}),
+		...(schema.presence === 'defaulted' && isJsonSerializable(schema.defaultValue)
+			? { defaultValue: schema.defaultValue }
+			: {}),
+		...(schema.description !== undefined ? { description: schema.description } : {}),
+		...(schema.envVar !== undefined ? { envVar: schema.envVar } : {}),
+		...(schema.enumValues !== undefined ? { enumValues: [...schema.enumValues] } : {}),
+		...(schema.deprecated !== undefined ? { deprecated: schema.deprecated } : {}),
 	};
-
-	if (schema.variadic) {
-		result.variadic = true;
-	}
-	if (schema.stdinMode) {
-		result.stdinMode = true;
-	}
-	if (schema.presence === 'defaulted' && isJsonSerializable(schema.defaultValue)) {
-		result.defaultValue = schema.defaultValue;
-	}
-	if (schema.description !== undefined) {
-		result.description = schema.description;
-	}
-	if (schema.envVar !== undefined) {
-		result.envVar = schema.envVar;
-	}
-	if (schema.enumValues !== undefined) {
-		result.enumValues = [...schema.enumValues];
-	}
-	if (schema.deprecated !== undefined) {
-		result.deprecated = schema.deprecated;
-	}
-
-	return result;
 }
 
 // --- Prompt serialization
@@ -377,40 +532,32 @@ function serializeArgEntry(entry: CommandArgEntry): Record<string, unknown> {
  * @param prompt - The prompt configuration to serialize.
  * @returns JSON-serializable object representing the prompt.
  */
-function serializePrompt(prompt: PromptConfig): Record<string, unknown> {
-	const result: Record<string, unknown> = {
-		kind: prompt.kind,
-		message: prompt.message,
-	};
-
+function serializePrompt(prompt: PromptConfig): PromptDefinitionFragmentV1 {
 	switch (prompt.kind) {
 		case 'input':
-			if (prompt.placeholder !== undefined) {
-				result.placeholder = prompt.placeholder;
-			}
 			// validate fn omitted — not serializable
-			break;
+			return {
+				kind: prompt.kind,
+				message: prompt.message,
+				...(prompt.placeholder !== undefined ? { placeholder: prompt.placeholder } : {}),
+			};
 		case 'select':
-			if (prompt.choices !== undefined) {
-				result.choices = prompt.choices.map(serializeChoice);
-			}
-			break;
+			return {
+				kind: prompt.kind,
+				message: prompt.message,
+				...(prompt.choices !== undefined ? { choices: prompt.choices.map(serializeChoice) } : {}),
+			};
 		case 'multiselect':
-			if (prompt.choices !== undefined) {
-				result.choices = prompt.choices.map(serializeChoice);
-			}
-			if (prompt.min !== undefined) {
-				result.min = prompt.min;
-			}
-			if (prompt.max !== undefined) {
-				result.max = prompt.max;
-			}
-			break;
+			return {
+				kind: prompt.kind,
+				message: prompt.message,
+				...(prompt.choices !== undefined ? { choices: prompt.choices.map(serializeChoice) } : {}),
+				...(prompt.min !== undefined ? { min: prompt.min } : {}),
+				...(prompt.max !== undefined ? { max: prompt.max } : {}),
+			};
 		case 'confirm':
-			break;
+			return { kind: prompt.kind, message: prompt.message };
 	}
-
-	return result;
 }
 
 /**
@@ -419,15 +566,12 @@ function serializePrompt(prompt: PromptConfig): Record<string, unknown> {
  * @param choice - The select/multiselect choice to serialize.
  * @returns JSON-serializable object with value, optional label and description.
  */
-function serializeChoice(choice: SelectChoice): Record<string, unknown> {
-	const result: Record<string, unknown> = { value: choice.value };
-	if (choice.label !== undefined) {
-		result.label = choice.label;
-	}
-	if (choice.description !== undefined) {
-		result.description = choice.description;
-	}
-	return result;
+function serializeChoice(choice: SelectChoice): PromptChoiceFragmentV1 {
+	return {
+		value: choice.value,
+		...(choice.label !== undefined ? { label: choice.label } : {}),
+		...(choice.description !== undefined ? { description: choice.description } : {}),
+	};
 }
 
 // --- Example serialization
@@ -442,14 +586,11 @@ function serializeChoice(choice: SelectChoice): Record<string, unknown> {
  * @param meta - Program name/version passed to function-form commands.
  * @returns JSON-serializable object with command and optional description.
  */
-function serializeExample(example: CommandExample, meta: ExampleMeta): Record<string, unknown> {
-	const result: Record<string, unknown> = {
+function serializeExample(example: CommandExample, meta: ExampleMeta): ExampleDefinitionFragmentV1 {
+	return {
 		command: resolveExampleCommand(example.command, meta),
+		...(example.description !== undefined ? { description: example.description } : {}),
 	};
-	if (example.description !== undefined) {
-		result.description = example.description;
-	}
-	return result;
 }
 
 // === Input validation schema — generateInputSchema()
@@ -485,7 +626,7 @@ function serializeExample(example: CommandExample, meta: ExampleMeta): Record<st
 function generateInputSchema(
 	schema: CLISchema | CommandSchema,
 	options?: JsonSchemaOptions,
-): Record<string, unknown> {
+): InputSchemaDocument {
 	const opts = resolveOptions(options);
 
 	// Discriminate between a leaf/group command schema and the CLI root schema.
@@ -497,7 +638,7 @@ function generateInputSchema(
 	}
 
 	// CLISchema — collect all invocable commands into branches
-	const branches: Array<Record<string, unknown>> = [];
+	const branches: InputSchemaBranch[] = [];
 	if (
 		schema.defaultCommand !== undefined &&
 		(opts.includeHidden || !schema.defaultCommand.hidden)
@@ -511,11 +652,11 @@ function generateInputSchema(
 	}
 
 	// Single branch: emit flat (no oneOf wrapper)
-	if (branches.length === 1) {
-		const branch = stripCommandDiscriminator(branches[0] ?? {});
+	const [onlyBranch] = branches;
+	if (branches.length === 1 && onlyBranch !== undefined) {
 		return {
 			$schema: JSON_SCHEMA_DRAFT,
-			...branch,
+			...stripCommandDiscriminator(onlyBranch),
 		};
 	}
 
@@ -564,7 +705,7 @@ function isCommandSchema(schema: CLISchema | CommandSchema): schema is CommandSc
 function collectInputBranches(
 	schema: CommandSchema,
 	prefix: string,
-	branches: Array<Record<string, unknown>>,
+	branches: InputSchemaBranch[],
 	opts: ResolvedOptions,
 ): void {
 	const path = prefix ? `${prefix}.${schema.name}` : schema.name;
@@ -585,11 +726,8 @@ function collectInputBranches(
  * When `commandPath` is provided, a `command` const discriminator property
  * is added and required (used in multi-command oneOf schemas).
  */
-function commandToInputSchema(
-	schema: CommandSchema,
-	commandPath?: string,
-): Record<string, unknown> {
-	const properties: Record<string, Record<string, unknown>> = {};
+function commandToInputSchema(schema: CommandSchema, commandPath?: string): InputSchemaBranch {
+	const properties: Record<string, InputSchemaProperty> = {};
 	const required: string[] = [];
 
 	// Command discriminator (for multi-command schemas)
@@ -614,58 +752,35 @@ function commandToInputSchema(
 		}
 	}
 
-	const result: Record<string, unknown> = {
+	return {
 		type: 'object',
 		properties,
 		additionalProperties: false,
+		...(required.length > 0 ? { required } : {}),
 	};
-
-	if (required.length > 0) {
-		result.required = required;
-	}
-
-	return result;
 }
 
 /** @internal */
-function stripCommandDiscriminator(branch: Record<string, unknown>): Record<string, unknown> {
-	const propertiesValue = branch.properties;
-	const requiredValue = branch.required;
-	const properties = isRecord(propertiesValue) ? { ...propertiesValue } : undefined;
-	const required = Array.isArray(requiredValue)
-		? requiredValue.filter((value): value is string => typeof value === 'string')
-		: undefined;
+function stripCommandDiscriminator(branch: InputSchemaBranch): InputSchemaBranch {
+	const { command: _discriminator, ...properties } = branch.properties;
+	const required = branch.required?.filter((value) => value !== 'command');
 
-	if (properties !== undefined) {
-		delete properties.command;
-	}
-
-	const cleanedRequired = required?.filter((value) => value !== 'command');
-	const result: Record<string, unknown> = { ...branch };
-
-	if (properties !== undefined) {
-		result.properties = properties;
-	}
-
-	if (cleanedRequired !== undefined && cleanedRequired.length > 0) {
-		result.required = cleanedRequired;
-	} else {
-		delete result.required;
-	}
-
-	return result;
+	return {
+		type: branch.type,
+		properties,
+		additionalProperties: branch.additionalProperties,
+		...(required !== undefined && required.length > 0 ? { required } : {}),
+	};
 }
 
-function getBranchCommandDiscriminator(branch: Record<string, unknown>): string | undefined {
-	const propertiesValue = branch.properties;
-	if (!isRecord(propertiesValue)) {
+function getBranchCommandDiscriminator(branch: InputSchemaBranch): string | undefined {
+	const commandValue = branch.properties.command;
+	if (commandValue === undefined) {
 		return undefined;
 	}
 
-	const commandValue = propertiesValue.command;
-	return isRecord(commandValue) && typeof commandValue.const === 'string'
-		? commandValue.const
-		: undefined;
+	const constValue = commandValue.const;
+	return typeof constValue === 'string' ? constValue : undefined;
 }
 
 // --- Type mapping — flags → JSON Schema types
@@ -926,6 +1041,21 @@ function withDefinitionMetaSchemaDescriptions(
 }
 
 /**
+ * Command-fragment property schemas shared by the nested `command` def and
+ * the standalone `commandDocument` def, so the two cannot drift.
+ */
+const commandFragmentProperties = {
+	name: { type: 'string' },
+	description: { type: 'string' },
+	aliases: { type: 'array', items: { type: 'string' } },
+	hidden: { const: true },
+	examples: { type: 'array', items: { $ref: '#/$defs/example' } },
+	flags: { type: 'object', additionalProperties: { $ref: '#/$defs/flag' } },
+	args: { type: 'array', items: { $ref: '#/$defs/arg' } },
+	commands: { type: 'array', items: { $ref: '#/$defs/command' } },
+} as const;
+
+/**
  * JSON Schema (draft 2020-12) that validates the output of {@link generateSchema}.
  *
  * Hosted at {@link DEFINITION_SCHEMA_URL} for `$schema` resolution. Also
@@ -953,28 +1083,29 @@ const definitionMetaSchema: Record<string, unknown> = withDefinitionMetaSchemaDe
 		additionalProperties: false,
 		properties: {
 			$schema: { const: DEFINITION_SCHEMA_URL },
+			schemaVersion: { const: DEFINITION_SCHEMA_VERSION },
 			name: { type: 'string' },
 			version: { type: 'string' },
 			description: { type: 'string' },
 			defaultCommand: { $ref: '#/$defs/command' },
 			commands: { type: 'array', items: { $ref: '#/$defs/command' } },
 		},
-		required: ['$schema', 'name', 'commands'],
+		required: ['$schema', 'schemaVersion', 'name', 'commands'],
 		$defs: {
 			command: {
 				type: 'object',
 				additionalProperties: false,
-				properties: {
-					name: { type: 'string' },
-					description: { type: 'string' },
-					aliases: { type: 'array', items: { type: 'string' } },
-					hidden: { const: true },
-					examples: { type: 'array', items: { $ref: '#/$defs/example' } },
-					flags: { type: 'object', additionalProperties: { $ref: '#/$defs/flag' } },
-					args: { type: 'array', items: { $ref: '#/$defs/arg' } },
-					commands: { type: 'array', items: { $ref: '#/$defs/command' } },
-				},
+				properties: commandFragmentProperties,
 				required: ['name', 'flags', 'args', 'commands'],
+			},
+			commandDocument: {
+				type: 'object',
+				additionalProperties: false,
+				properties: {
+					schemaVersion: { const: DEFINITION_SCHEMA_VERSION },
+					...commandFragmentProperties,
+				},
+				required: ['schemaVersion', 'name', 'flags', 'args', 'commands'],
 			},
 			flag: {
 				type: 'object',
@@ -1104,5 +1235,23 @@ const definitionMetaSchema: Record<string, unknown> = withDefinitionMetaSchemaDe
 
 // === Exports
 
-export type { JsonSchemaOptions };
+export type {
+	ArgDefinitionFragmentV1,
+	CommandDefinitionDocument,
+	CommandDefinitionDocumentV1,
+	CommandDefinitionFragmentV1,
+	DefinitionDocument,
+	DefinitionDocumentV1,
+	ExampleDefinitionFragmentV1,
+	FlagDefinitionFragmentV1,
+	FlagNegationFragmentV1,
+	FlagPathChecksFragmentV1,
+	FlagStringConstraintsFragmentV1,
+	InputSchemaBranch,
+	InputSchemaDocument,
+	InputSchemaProperty,
+	JsonSchemaOptions,
+	PromptChoiceFragmentV1,
+	PromptDefinitionFragmentV1,
+};
 export { definitionMetaSchema, generateCommandSchema, generateInputSchema, generateSchema };

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -15,7 +15,12 @@ import type {
 	FlagKind,
 	FlagSchema,
 } from '#internals/core/schema/index.ts';
-import { definitionMetaSchema, generateInputSchema, generateSchema } from './index.ts';
+import {
+	definitionMetaSchema,
+	generateCommandSchema,
+	generateInputSchema,
+	generateSchema,
+} from './index.ts';
 
 // === Test helpers
 
@@ -88,13 +93,97 @@ describe('generateSchema — definition metadata', () => {
 	// CLI-level fields
 	// -------------------------------------------------------------------
 
-	it('emits $schema, name, and empty commands for minimal CLI', () => {
+	it('emits $schema, schemaVersion, name, and empty commands for minimal CLI', () => {
 		const result = generateSchema(minimalCLI());
 		expect(result).toEqual({
-			$schema: 'https://cdn.jsdelivr.net/npm/@kjanat/dreamcli/dreamcli.schema.json',
+			$schema: 'https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json',
+			schemaVersion: 1,
 			name: 'test-cli',
 			commands: [],
 		});
+	});
+
+	// -------------------------------------------------------------------
+	// Document versioning
+	// -------------------------------------------------------------------
+
+	it('emits schemaVersion directly after $schema', () => {
+		const result = generateSchema(minimalCLI());
+		expect(Object.keys(result).slice(0, 2)).toEqual(['$schema', 'schemaVersion']);
+		expect(result.schemaVersion).toBe(1);
+	});
+
+	it('emits schemaVersion on standalone command documents', () => {
+		const document = generateCommandSchema(commandDef({ name: 'deploy' }));
+		expect(document.schemaVersion).toBe(1);
+		expect(Object.keys(document)[0]).toBe('schemaVersion');
+	});
+
+	it('omits schemaVersion from nested command fragments', () => {
+		const rollback = commandDef({ name: 'rollback' });
+		const deploy = commandDef({ name: 'deploy', commands: [rollback] });
+		const result = generateSchema(minimalCLI({ commands: [deploy], defaultCommand: deploy }));
+		const [topLevel] = result.commands;
+		const nested = topLevel?.commands[0];
+		const standalone = generateCommandSchema(deploy);
+
+		expect(topLevel).toBeDefined();
+		expect(topLevel).not.toHaveProperty('schemaVersion');
+		expect(result.defaultCommand).toBeDefined();
+		expect(result.defaultCommand).not.toHaveProperty('schemaVersion');
+		expect(nested).toBeDefined();
+		expect(nested).not.toHaveProperty('schemaVersion');
+		expect(standalone.commands[0]).toBeDefined();
+		expect(standalone.commands[0]).not.toHaveProperty('schemaVersion');
+	});
+
+	it('stays assignable to the Record<string, unknown> consumer pattern', () => {
+		const definition: Record<string, unknown> = generateSchema(minimalCLI());
+		const command: Record<string, unknown> = generateCommandSchema(commandDef());
+		const input: Record<string, unknown> = generateInputSchema(commandDef());
+
+		expect(definition.schemaVersion).toBe(1);
+		expect(command.schemaVersion).toBe(1);
+		expect(input.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+	});
+
+	it('pins schemaVersion as a required const in the meta-schema', () => {
+		expect(definitionMetaSchema).toHaveProperty(['properties', 'schemaVersion', 'const'], 1);
+		expect(definitionMetaSchema).toHaveProperty('required', [
+			'$schema',
+			'schemaVersion',
+			'name',
+			'commands',
+		]);
+	});
+
+	it('accepts standalone command documents via a dedicated def', () => {
+		const defs = expectRecord(definitionMetaSchema.$defs);
+		const command = expectRecord(defs.command);
+		const commandDocument = expectRecord(defs.commandDocument);
+		expect(Object.keys(expectRecord(commandDocument.properties))).toEqual([
+			'schemaVersion',
+			...Object.keys(expectRecord(command.properties)),
+		]);
+		expect(commandDocument.required).toEqual([
+			'schemaVersion',
+			'name',
+			'flags',
+			'args',
+			'commands',
+		]);
+		expect(commandDocument).toHaveProperty(['properties', 'schemaVersion', 'const'], 1);
+
+		const doc: Record<string, unknown> = generateCommandSchema(
+			createCommandSchema({ name: 'deploy', hasAction: true }),
+		);
+		const allowed = new Set(Object.keys(expectRecord(commandDocument.properties)));
+		for (const key of Object.keys(doc)) {
+			expect(allowed).toContain(key);
+		}
+		for (const required of ['schemaVersion', 'name', 'flags', 'args', 'commands']) {
+			expect(doc).toHaveProperty(required);
+		}
 	});
 
 	it('includes version and description when present', () => {

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -175,7 +175,16 @@ describe('generateSchema — definition metadata', () => {
 		expect(commandDocument).toHaveProperty(['properties', 'schemaVersion', 'const'], 1);
 
 		const doc: Record<string, unknown> = generateCommandSchema(
-			createCommandSchema({ name: 'deploy', hasAction: true }),
+			commandDef({
+				name: 'deploy',
+				description: 'Deploy the application',
+				aliases: ['ship'],
+				hidden: true,
+				examples: [{ command: 'deploy production', description: 'Deploy production' }],
+				flags: { force: flagDef({ kind: 'boolean' }) },
+				args: [argEntry('target')],
+				commands: [commandDef({ name: 'status' })],
+			}),
 		);
 		const allowed = new Set(Object.keys(expectRecord(commandDocument.properties)));
 		for (const key of Object.keys(doc)) {

--- a/src/core/json-schema/meta-descriptions.generated.ts
+++ b/src/core/json-schema/meta-descriptions.generated.ts
@@ -59,6 +59,40 @@ const definitionMetaSchemaDescriptions = {
 				},
 			},
 		},
+		commandDocument: {
+			description:
+				'A single-command definition document, version 1.\n\nProduced by generateCommandSchema. Same shape as a\nCommandDefinitionFragmentV1 plus the `schemaVersion` every standalone\ndocument carries.',
+			properties: {
+				schemaVersion: {
+					description:
+						'Version of the definition document format emitted by generateSchema\nand generateCommandSchema.',
+				},
+				name: {
+					description: 'The command name used for dispatch.',
+				},
+				description: {
+					description: 'Human-readable description for help text.',
+				},
+				aliases: {
+					description: 'Alternative names accepted for this command.',
+				},
+				hidden: {
+					description: 'Whether the command is omitted from help listings.',
+				},
+				examples: {
+					description: 'Usage examples attached to the command.',
+				},
+				flags: {
+					description: 'Named flag definitions keyed by flag name.',
+				},
+				args: {
+					description: 'Positional argument definitions in CLI order.',
+				},
+				commands: {
+					description: 'Nested subcommand definitions.',
+				},
+			},
+		},
 		flag: {
 			description:
 				"The runtime descriptor stored inside every FlagBuilder. Consumers (parser,\nhelp generator, resolution chain) read this to understand the flag's shape\nwithout touching generics.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,8 @@ export type {
 	PromptDefinitionFragmentV1,
 } from './core/json-schema/index.ts';
 export {
+	DEFINITION_SCHEMA_URL,
+	DEFINITION_SCHEMA_VERSION,
 	definitionMetaSchema,
 	generateCommandSchema,
 	generateInputSchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,25 @@ export {
 } from './core/errors/index.ts';
 export type { HelpOptions, HelpTheme, HelpThemeFactory } from './core/help/index.ts';
 export { formatHelp, osc8, visibleWidth } from './core/help/index.ts';
-export type { JsonSchemaOptions } from './core/json-schema/index.ts';
+export type {
+	ArgDefinitionFragmentV1,
+	CommandDefinitionDocument,
+	CommandDefinitionDocumentV1,
+	CommandDefinitionFragmentV1,
+	DefinitionDocument,
+	DefinitionDocumentV1,
+	ExampleDefinitionFragmentV1,
+	FlagDefinitionFragmentV1,
+	FlagNegationFragmentV1,
+	FlagPathChecksFragmentV1,
+	FlagStringConstraintsFragmentV1,
+	InputSchemaBranch,
+	InputSchemaDocument,
+	InputSchemaProperty,
+	JsonSchemaOptions,
+	PromptChoiceFragmentV1,
+	PromptDefinitionFragmentV1,
+} from './core/json-schema/index.ts';
 export {
 	definitionMetaSchema,
 	generateCommandSchema,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -8,7 +8,7 @@
  * ```ts
  * import schema from '@kjanat/dreamcli/schema';
  *
- * console.log(schema.$id); // "dreamcli.schema.json"
+ * console.log(schema.$id); // "https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json"
  * ```
  *
  * @ignore


### PR DESCRIPTION
Breaking, targets v4. Stacked on #104. Implements L7 of the approved v4 plan.

**Versioned documents**
- `DefinitionDocumentV1` / `CommandDefinitionDocumentV1` carry `schemaVersion: 1`; nested command/flag/arg/example/prompt fragments are typed separately and unversioned (`*FragmentV1`). Unversioned aliases (`DefinitionDocument`) point at V1 so v2 can coexist later.
- Assignability experiment (plan-pinned): plain **type aliases** get an implicit index signature and stay assignable to `Record<string, unknown>` — interfaces don't. All document types are aliases; a compile test pins the consumer pattern. No index signature added, full typo safety.
- User-visible consequence surfaced in review: `--help --json` serializes through `generateCommandSchema()`, so every dreamcli CLI's JSON help now leads with `schemaVersion: 1`.

**Canonical URL**
- `$schema`/`$id` = `https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json` — format-versioned, package-major-independent, permanent once published. npm subpath + jsDelivr stay as mirrors; the docs site emits the schema at both the canonical path and the root mirror (byte-identical, verified in dist).
- Emit script simplified (dead unimplemented REGISTRY switch doc deleted; `$id` no longer derived from the package name); stale "gitignored" comment corrected.

**Review escalations, resolved in this PR**
- The meta-schema rejected the documents its own layer emits (standalone command docs had no def accepting `schemaVersion`): added `$defs/commandDocument` sharing the command fragment properties via one extracted object so the two defs cannot drift, pinned by test.
- The guide told users to rewrite `$schema` to a node_modules path the const rejects: reworded to editor-mapping (`json.schemas`) with the canonical URL kept in documents.
- The `describedby` Link header pointed at the mirror: now the canonical path.

Gates: typecheck exit 0, lint clean, fmt clean, 2974/2974 tests, build (attw+publint) clean, docs build clean with both dist schema paths, meta-descriptions up to date. No workflow/deploy config touched.
