### PR TITLE
docs!: complete the v4 stability policy and ship the upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **Stability policy** — a new [reference page](https://dreamcli.kjanat.dev/reference/stability)
-  classifies every exported type: sealed framework values, consumer input
-  options, implementer interfaces, closed unions, and internal surface, with
-  the minor-version rules each category carries.
+- **Stability policy and a 4.0 upgrade guide** — the
+  [stability page](https://dreamcli.kjanat.dev/reference/stability) now places
+  every export of the root, `/testkit`, `/runtime`, and `/version` entrypoints
+  in one of thirteen categories, each with the rules it carries into a minor
+  release: sealed framework values, consumer input options, transparent input
+  definitions, implementer ports, externally governed protocols, structural
+  consumer configuration, closed unions and discriminated results, open unions,
+  framework-produced callback payloads, closed constructible DTOs, serialized
+  formats, classes and functions, and internal surface.
+  [Upgrading From 3.x To 4.0](https://dreamcli.kjanat.dev/guide/upgrading-v4)
+  walks the breaking changes below with before and after code.
 
 - **Definition types and normalization factories for flags, args, commands, and
   the CLI** — `createFlagSchema()`, `createCommandSchema()`, and

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -194,6 +194,7 @@ export default defineConfig({
 						},
 						{ text: 'Migration And Adoption', link: '/guide/migration' },
 						{ text: 'Upgrading From 2.x', link: '/guide/upgrading-v3' },
+						{ text: 'Upgrading From 3.x', link: '/guide/upgrading-v4' },
 						{ text: 'Troubleshooting', link: '/guide/troubleshooting' },
 						{ text: 'Middleware', link: '/guide/middleware' },
 						{ text: 'Config Files', link: '/guide/config' },

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,7 +1,9 @@
 # Migration And Adoption
 
 This page is for serious evaluators and adopters deciding whether to move an existing CLI onto
-dreamcli. Already on dreamcli 2.x? See [Upgrading From 2.x To 3.0](/guide/upgrading-v3) instead.
+dreamcli. Already on dreamcli 2.x? See [Upgrading From 2.x To 3.0](/guide/upgrading-v3) instead, then
+[Upgrading From 3.x To 4.0](/guide/upgrading-v4). Already on 3.x? Go straight to the
+[4.0 guide](/guide/upgrading-v4).
 
 Use it after [Getting Started](/guide/getting-started) and [Why dreamcli](/guide/why): those pages
 explain the shape of the framework; this page explains when switching is worth it and how to do it

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -1,6 +1,6 @@
 # Upgrading From 3.x To 4.0
 
-This page covers moving an existing dreamcli 3.0 CLI to 4.0.0. Coming from 2.x,
+This page covers moving an existing dreamcli 3.x CLI to 4.0.0. Coming from 2.x,
 read [Upgrading From 2.x To 3.0](/guide/upgrading-v3) first. For adopting
 dreamcli from another framework, see
 [Migration And Adoption](/guide/migration).

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -1,0 +1,308 @@
+# Upgrading From 3.x To 4.0
+
+This page covers moving an existing dreamcli 3.0 CLI to 4.0.0. Coming from 2.x,
+read [Upgrading From 2.x To 3.0](/guide/upgrading-v3) first. For adopting
+dreamcli from another framework, see
+[Migration And Adoption](/guide/migration).
+
+A CLI built entirely from the fluent builders (`cli()`, `command()`, `flag`,
+`arg`) mostly runs on 4.0 unchanged. The breaking changes land on code that
+assembles schema objects by hand, hand-rolls an `Out`, reaches into
+`CLISchema.commands`, or passes framework-populated fields into execution
+options. Every category and its compatibility rules are listed on the
+[Stability Policy](/reference/stability) page.
+
+## Breaking Changes
+
+### `Out` gained a required `verbosity` member
+
+An object literal typed as `Out` stops compiling until it declares `verbosity`.
+Handlers read `out.verbosity` for the active level, and
+`resolveRenderContext()` exposes the same decision for content built before
+`.run()`, including `--`-aware `--quiet` / `-q` detection.
+
+Hand-rolled test doubles are the common casualty. Take a real channel from the
+testkit and spy on it:
+
+```ts
+import { createCaptureOutput } from '@kjanat/dreamcli/testkit';
+
+const [out] = createCaptureOutput();
+vi.spyOn(out, 'info');
+```
+
+Do not spread a channel. Its methods are installed as non-enumerable bound own
+properties, so `{ ...out, info: vi.fn() }` carries none of them.
+
+### `Out` and `RenderContext` are sealed
+
+Both interfaces carry a private brand, so implementing or structurally
+constructing them outside the framework no longer type-checks. Obtain instances
+from action parameters, `createOutput()`, `createCaptureOutput()`, or
+`resolveRenderContext()`.
+
+Helpers that only need part of the channel take a capability type:
+
+```ts twoslash
+import type { Out } from '@kjanat/dreamcli';
+// ---cut---
+function renderRows(out: Pick<Out, 'info' | 'status'>, rows: readonly string[]) {
+  for (const row of rows) out.info(row);
+}
+```
+
+Both are non-exhaustive values, so minor releases may add readonly members.
+Exhaustive mappings over their keys (`Record<keyof Out, unknown>`) will break on
+a minor.
+
+### Schemas are sealed and built by factories
+
+`FlagSchema`, `ArgSchema`, `CommandSchema`, `CLISchema`, and `ConfigSettings`
+carry the same type-only brand. An object literal assembled by hand is no longer
+assignable where a schema is expected. Four factories build them:
+`createFlagSchema()`, `createArgSchema()`, `createCommandSchema()`, and
+`createCLISchema()`. Each takes a plain definition object listing only the
+fields you care about, and fills in the rest:
+
+```ts
+// 3.x
+const schema: CommandSchema = {
+  name: 'deploy',
+  description: undefined,
+  flags: { force: createSchema('boolean') },
+  args: [],
+  commands: [],
+  hidden: false,
+  // ...every remaining field
+};
+
+// 4.0
+const schema = createCommandSchema({
+  name: 'deploy',
+  flags: { force: { kind: 'boolean' } },
+});
+```
+
+The brand has no runtime value, so nothing about the objects themselves changed.
+Spreading a built schema keeps the brand (`{ ...schema, hidden: true }` stays
+assignable), `structuredClone()` and JSON round-trips are unaffected, and
+feeding a built schema back through its factory returns a deep-equal schema.
+
+Nested fields accept either rung, so a code generator can hand
+`createCommandSchema()` or `createCLISchema()` one complete tree of plain
+objects:
+
+```ts twoslash
+import { createCLISchema } from '@kjanat/dreamcli';
+// ---cut---
+const schema = createCLISchema({
+  name: 'mycli',
+  version: '1.0.0',
+  commands: [
+    {
+      name: 'deploy',
+      flags: { region: { kind: 'enum', enumValues: ['us', 'eu', 'ap'] } },
+      args: [{ name: 'target', schema: { kind: 'string' } }],
+    },
+  ],
+});
+```
+
+The definition types are exported from the package root: `FlagDefinition`,
+`ArgDefinition`, `CommandDefinition`, `CLIDefinition`,
+`ConfigSettingsDefinition`, the per-kind members (`EnumFlagDefinition`,
+`ArrayFlagDefinition`, and the rest), and the `*DefinitionOverrides` helpers.
+
+### `createSchema()` is now `createFlagSchema()`
+
+The positional form is a rename. Both factories additionally accept a single
+definition object, and both validate fields against the kind:
+
+```ts twoslash
+import { createFlagSchema } from '@kjanat/dreamcli';
+// ---cut---
+const region = createFlagSchema('enum', { enumValues: ['us', 'eu', 'ap'] });
+
+const tags = createFlagSchema({
+  kind: 'array',
+  elementSchema: { kind: 'string' },
+  separator: ',',
+});
+```
+
+A field belonging to another kind, such as `enumValues` on a `boolean` flag,
+fails to compile and throws `INVALID_SCHEMA` at runtime.
+
+`createArgSchema()` picked up the same rule: its second parameter changed from
+`Partial<ArgSchema>` to `ArgDefinitionOverrides<K>`, and `enumValues` is
+required on an `enum` arg.
+
+### `CommandSchema.middleware` is removed
+
+The executor builds the handler chain from the builder's ordered execution
+steps, so registration order, handler identity, and runtime behavior are
+unchanged. `.middleware()` on `CommandBuilder` works exactly as before.
+
+Code that read `schema.middleware` has no replacement field. Assert on behavior
+instead, by running the command and checking what the middleware did.
+`CommandDefinition` has no `middleware` key and `createCommandSchema()` emits
+none.
+
+### `CLISchema` describes the program without the execution graph
+
+`CLISchema.commands` and `CLISchema.defaultCommand` used to hold `ErasedCommand`
+wrappers carrying the action handler and an `_execute` function. Both now hold
+`CommandSchema`, and the compiled execution graph lives beside the schema:
+
+```ts
+// 3.x
+app.schema.commands[0].schema.name;
+// 4.0
+app.schema.commands[0].name;
+```
+
+`ErasedCommand` is gone. `CLISchema.plugins` is gone as well, since plugins are
+execution state; `.plugin()` registration, order, and hook behavior are
+unchanged.
+
+### `CLIBuilder` is factory-only
+
+`CLIBuilder`'s constructor is private, so `new CLIBuilder(schema)` no longer
+compiles. Call `cli(name)` or `cli({ ... })` for an executable program, and
+`createCLISchema()` when you want a description with no handlers attached. Every
+builder method still returns a new builder.
+
+`createCLISchema()` throws `INVALID_SCHEMA` on an empty name, and `cli('')`
+does the same instead of building a nameless program.
+
+### `.execute()` and `.run()` take different option types
+
+`.execute()` takes the new `CLIExecuteOptions`, which carries the process-free
+option surface and has no `adapter` member. `CLIRunOptions` extends it with
+`adapter`, and `.run()` is the only method that accepts one.
+
+```ts
+// 3.x
+await app.execute(argv, { adapter, env });
+// 4.0
+await app.execute(argv, { env });
+await app.run({ adapter });
+```
+
+### Internal execution fields left `RunOptions`
+
+`out`, `captured`, `mergedSchema`, `meta`, and `plugins` were framework-populated
+fields marked `@internal` that shipped on the public option types. They now live
+on unexported internal execution options, so passing them to `runCommand()`,
+`.execute()`, or `.run()` stops compiling.
+
+`runCommand()` captures stdout, stderr, and activity events itself and returns
+them on `RunResult`, so tests assert on the result rather than on an injected
+channel:
+
+```ts
+const result = await runCommand(deploy, ['production']);
+
+expect(result.stdout).toEqual(['Deploying production\n']);
+expect(result.activity).toEqual([{ type: 'spinner:start', text: 'Deploying' }]);
+```
+
+Code that genuinely needs its own writers builds a channel with
+`createOutput({ stdout, stderr })` and drives it directly. `OutputOptions.stdout`
+and `OutputOptions.stderr` are the supported injection seam.
+
+### The 2.5-era manifest API is removed
+
+Deprecated since 2.5, removed here. Every removal has a direct replacement:
+
+| Removed                                  | Replacement                                                                |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| `.packageJson(settings)`                 | `.manifest(settings)`, which defaults to `files: ['package.json']`          |
+| `.packageJson(data)`                     | `.manifest(data)`, taking the same pre-loaded data object                   |
+| `.denoJson(settings)`                    | `.manifest({ files: ['deno.json', 'deno.jsonc', 'jsr.json'], ...settings })` |
+| `ManifestPresetSettings`                 | `ManifestSettings`, which adds `files`                                     |
+| `PackageJsonSettings`                    | `ResolvedManifestSettings`                                                 |
+| `discoverPackageJson(adapter, startDir)` | `discoverManifest(adapter, { startDir, files: ['package.json'] })`         |
+
+```ts
+// 3.x
+cli('mycli').denoJson({ inferName: true });
+// 4.0
+cli('mycli').manifest({
+  files: ['deno.json', 'deno.jsonc', 'jsr.json'],
+  inferName: true,
+});
+```
+
+`files` already defaults to `['package.json']` on both `.manifest()` and
+`discoverManifest()`, so the `package.json` migrations are a rename. The
+`CLISchema.packageJsonSettings` field keeps its name and shape. See
+[`.manifest()`](/reference/main) for the full settings surface.
+
+### `CommandConfig` and the root `AnyCommandBuilder` export are removed
+
+`CommandConfig` described the builder's type-level accumulator shape and no
+signature referenced it. `AnyCommandBuilder` is erasure machinery that appears
+only on `CommandBuilder`'s underscore members, so the package root no longer
+exports the name. Neither has a replacement; code naming them was reaching into
+internals.
+
+### Definition documents are versioned
+
+`generateSchema()` and `generateCommandSchema()` emit `schemaVersion: 1`, so a
+consumer can tell which format it is reading before parsing the rest. Both
+return typed documents (`DefinitionDocumentV1` and
+`CommandDefinitionDocumentV1`, aliased as `DefinitionDocument` and
+`CommandDefinitionDocument`) in place of `Record<string, unknown>`. The returned
+documents stay assignable to `Record<string, unknown>`, so existing consumer
+signatures keep compiling.
+
+Fragments nested inside a document (`CommandDefinitionFragmentV1`,
+`FlagDefinitionFragmentV1`, `ArgDefinitionFragmentV1`, and the rest) carry no
+`schemaVersion` of their own and take the version of the document they sit in.
+`generateInputSchema()` is standard JSON Schema and stays outside the family,
+typed as `InputSchemaDocument`.
+
+The canonical `$schema` and `$id` moved to
+`https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json`, replacing
+`https://cdn.jsdelivr.net/npm/@kjanat/dreamcli/dreamcli.schema.json`. The `v1`
+segment tracks the definition format, so it stays valid for every package
+release that emits `schemaVersion: 1`. The `@kjanat/dreamcli/schema` subpath and
+the jsDelivr URL keep serving the same bytes as mirrors. Documents pinned to the
+old URL still validate against a local copy, but they no longer match the
+meta-schema's `$schema` constant. For offline validation, map the canonical URL
+to the local copy in your tooling; [Schema Export](/guide/schema-export) shows
+the VS Code form.
+
+`--help --json` output changed accordingly. Command-level help serializes
+through `generateCommandSchema()`, so `schemaVersion` is now its first key. Root
+help serializes through `generateSchema()`, so `$schema` still leads, carries
+the new URL, and `schemaVersion` follows it. Snapshot tests over that output
+need re-recording.
+
+## Behavioral Changes To Review
+
+- **Quiet mode suppresses rendered spinner and progress output.** Activity
+  handles resolve to no-ops under quiet verbosity, including on interactive
+  TTYs and for explicit static fallbacks. Capture still records lifecycle
+  events, so `RunResult.activity` assertions are unaffected. Informational rows
+  routed through `out.info()` are suppressed as before.
+
+## New In 4.0
+
+Adopt at your own pace; none of these are required:
+
+- **Stability policy**: [a reference page](/reference/stability) classifying
+  every exported type and the rules each category carries into minor releases.
+- **Descriptions without an execution graph**: `createCLISchema()` and
+  `createCommandSchema()` build a normalized schema tree from plain objects, for
+  code generators, docs tooling, and fixtures that never execute.
+- **Kind-checked definitions**: the `*Definition` types make illegal field
+  combinations unrepresentable, with the same check enforced at runtime for
+  JavaScript callers.
+- **Verbosity in handler code**: `out.verbosity` and
+  `resolveRenderContext().verbosity` expose the active level for custom
+  rendering built inside or before a run.
+
+See the [CHANGELOG](https://github.com/kjanat/dreamcli/blob/master/CHANGELOG.md)
+for the complete record.

--- a/docs/reference/stability.md
+++ b/docs/reference/stability.md
@@ -1,32 +1,120 @@
 # Stability Policy
 
-This page classifies every exported type by the compatibility contract it carries.
-Version numbers follow [SemVer](https://semver.org); the table below defines what
-counts as breaking for each category.
+This page classifies every exported type and value by the compatibility contract
+it carries. Version numbers follow [SemVer](https://semver.org).
+
+"Breaking" is not one rule. It depends on who constructs a value, who reads it,
+and whether the value crosses a serialization boundary. Adding a readonly member
+to [`Out`](#sealed-framework-values) is a minor release because only the
+framework constructs one. Adding the same member to
+[`RuntimeAdapter`](#implementer-ports) is a major release because consumers
+implement it. Adding a variant to [`Shell`](#closed-unions-and-discriminated-results)
+is a major release because consumers switch exhaustively over it, while adding
+one to [`ErrorCode`](#open-unions) is a patch because the union is open by
+construction.
+
+Three questions place a symbol in a category.
+
+1. Who constructs values of this type, the framework or the consumer?
+2. Who reads them, and are they expected to enumerate the members?
+3. Does the value survive `JSON.stringify` and get read by something outside
+   this package?
+
+A symbol not named on this page falls into the category whose shape it matches.
+When the match is ambiguous, the stricter contract applies.
 
 ## Categories
 
-| Category                 | Examples                                                | Minor releases may                                |
-| ------------------------ | ------------------------------------------------------- | ------------------------------------------------- |
-| Sealed framework values  | `Out`, `RenderContext`, `FlagSchema`, `ArgSchema`, `CommandSchema` | add readonly members                   |
-| Consumer input options   | `RunOptions`, `CLIExecuteOptions`, `CLIRunOptions`, `OutputOptions`, `RenderContextOptions`, `HelpOptions` | add optional fields |
-| Implementer interfaces   | `RuntimeAdapter`, `PromptEngine`, `CLIPlugin`           | add optional hooks only                           |
-| Closed unions            | `Verbosity`, `ActivityEvent`, `OutputStream`            | change nothing                                    |
-| Internal surface         | underscore members (`_from`, `_ctx`), `Internal*` option types | change anything, any release            |
+| Category                             | Examples                                                  | Minor releases may                              |
+| ------------------------------------ | --------------------------------------------------------- | ----------------------------------------------- |
+| Sealed framework values              | `Out`, `RenderContext`, `CommandSchema`, `ConfigSettings`  | add readonly members                            |
+| Consumer input options               | `RunOptions`, `CLIExecuteOptions`, `OutputOptions`         | add optional fields                             |
+| Transparent input definitions        | `FlagDefinition`, `CLIDefinition`, `PackageJsonData`       | add optional fields                             |
+| Implementer ports                    | `RuntimeAdapter`, `PromptEngine`, `FormatLoader`           | add optional members only                       |
+| Externally governed protocols        | `StandardSchemaV1` family                                  | track the upstream specification                |
+| Structural consumer configuration    | `CLIPlugin`, `CLIPluginHooks`                              | add optional hooks                              |
+| Closed unions, discriminated results | `Verbosity`, `Shell`, `FlagKind`, `ConfigDiscoveryResult`  | change nothing                                  |
+| Open unions                          | `ErrorCode`                                                | add members in any release                      |
+| Framework-produced callback payloads | `BeforeParseParams`, `DeprecationWarning`                  | add readonly members, required ones included    |
+| Closed constructible DTOs            | `RunResult`, `CommandMeta`                                 | change nothing                                  |
+| Serialized formats                   | `DefinitionDocumentV1` family, `CLIErrorJSON`              | add optional fields at the same `schemaVersion` |
+| Classes and functions                | `CLIBuilder`, `cli()`, `parse()`                           | add optional trailing parameters                |
+| Internal surface                     | underscore members, `Internal*` types, brand symbols       | change anything, any release                    |
 
 ## Sealed framework values
 
-`Out` and `RenderContext` are framework-created, non-exhaustive values. Both
-carry a private brand, so implementing or structurally constructing them
-outside the framework does not type-check.
+`Out`, `RenderContext`, `FlagSchema`, `ArgSchema`, `CommandSchema`, `CLISchema`,
+and `ConfigSettings`.
 
-- Obtain instances from action parameters, `createOutput()`,
-  `createCaptureOutput()`, or `resolveRenderContext()`.
-- New readonly members may appear in minor releases. Code that only reads
-  documented members keeps compiling.
-- Do not enumerate their keys exhaustively (`Record<keyof Out, ...>`); a
-  minor release may add a key.
-- Helpers that need a subset should accept a capability type:
+Each carries a brand a consumer cannot spell. `Out` and `RenderContext` carry a
+`unique symbol` that no entrypoint exports. The schema family carries a
+type-only brand established by its factory. Implementing or structurally
+constructing any of them outside the framework fails to type-check.
+
+Obtain instances from the framework:
+
+- `Out` from action parameters, `createOutput()`, or `createCaptureOutput()`.
+- `RenderContext` from `resolveRenderContext()`.
+- `FlagSchema`, `ArgSchema`, `CommandSchema` from `createFlagSchema()`,
+  `createArgSchema()`, `createCommandSchema()`, or the corresponding builders.
+- `CLISchema` and its `ConfigSettings` from `createCLISchema()`, or from
+  `cli(...).schema`.
+
+The guarantee is one-directional. New readonly members may appear in a minor
+release, and code that reads documented members keeps compiling. Code that
+enumerates keys (`Record<keyof Out, string>`) breaks when a member arrives, so
+enumeration is outside the contract.
+
+Factories take a plain definition and return the sealed value:
+
+```ts twoslash
+import { createCommandSchema } from '@kjanat/dreamcli';
+// ---cut---
+const deploy = createCommandSchema({
+	name: 'deploy',
+	flags: { force: { kind: 'boolean' } },
+	args: [{ name: 'target', schema: { kind: 'string' } }],
+});
+```
+
+The brand rides along on a spread, which is the escape hatch for building a
+variant of an existing schema:
+
+```ts twoslash
+import { createCommandSchema, type CommandSchema } from '@kjanat/dreamcli';
+
+const deploy = createCommandSchema({ name: 'deploy' });
+// ---cut---
+const internalDeploy: CommandSchema = { ...deploy, hidden: true };
+```
+
+A hand-written object literal has no brand to carry, so it is rejected:
+
+```ts twoslash
+// @errors: 2741
+import type { CommandSchema } from '@kjanat/dreamcli';
+// ---cut---
+const fake: CommandSchema = {
+	name: 'deploy',
+	description: undefined,
+	aliases: [],
+	hidden: false,
+	examples: [],
+	flags: {},
+	args: [],
+	hasAction: true,
+	interactive: undefined,
+	commands: [],
+};
+```
+
+Two further properties hold for the schema family. Feeding a built schema back
+through its factory produces a deep-equal schema, so normalization is
+idempotent. A field belonging to another kind (`enumValues` on a `boolean` flag)
+fails to compile and throws `INVALID_SCHEMA` at runtime for JavaScript callers.
+
+Helpers that need part of a sealed value should accept a capability type built
+with `Pick`, which stays correct as members are added:
 
 ```ts twoslash
 import type { Out } from '@kjanat/dreamcli';
@@ -45,51 +133,437 @@ const [out] = createCaptureOutput();
 vi.spyOn(out, 'info');
 ```
 
-`FlagSchema`, `ArgSchema`, and `CommandSchema` carry the same brand. Build them
-with `createFlagSchema()`, `createArgSchema()`, and `createCommandSchema()`,
-which take a definition object and return the normalized schema:
-
-```ts twoslash
-import { createCommandSchema } from '@kjanat/dreamcli';
-// ---cut---
-const deploy = createCommandSchema({
-	name: 'deploy',
-	flags: { force: { kind: 'boolean' } },
-	args: [{ name: 'target', schema: { kind: 'string' } }],
-});
-```
-
-- Spreading a built schema keeps the brand, so `{ ...deploy, hidden: true }`
-  stays assignable to `CommandSchema`.
-- Feeding a built schema back through its factory produces a deep-equal schema.
-- A field belonging to another kind (`enumValues` on a `boolean` flag) fails to
-  compile and throws `INVALID_SCHEMA` at runtime.
+The compiled execution graph behind a program is not in this category because it
+is not exported at all. See [Internal surface](#internal-surface).
 
 ## Consumer input options
 
-Option objects the caller constructs and passes in. All fields are optional;
-minor releases may add optional fields but never required ones, and never
-change the meaning of an existing field.
+Option objects the caller constructs and passes in.
 
-## Implementer interfaces
+Program and execution options: `CLIOptions`, `CLIExecuteOptions`, `CLIRunOptions`,
+`RunOptions` (from `@kjanat/dreamcli/testkit`), `DefaultCommandOptions`,
+`ManifestSettings` with its name-inference value type `InferNameOption`,
+`ManifestDiscoveryOptions`, `ConfigDiscoveryOptions`, and
+`PackageRepositoryUrlOptions`.
 
-Interfaces designed to be implemented outside the framework. Their required
-surface is frozen within a major version; new capabilities arrive as optional
-members. A redesign ships as a new interface, with the old one supported until
-the next major.
+Pipeline and rendering options: `ParseOptions`, `ResolveOptions`, `OutputOptions`,
+`RenderContextOptions`, `HelpOptions`, `HelpTheme`, `CompletionOptions`, and
+`JsonSchemaOptions`.
 
-The low-level output seam is the injected `stdout`/`stderr` writer pair on
-`OutputOptions` (`WriteFn`), not a reimplementation of `Out`.
+Per-call output options: `SpinnerOptions`, `ProgressOptions`, `TableOptions`, and
+`TableColumn`.
 
-## Closed unions
+Value options accepted by the flag factories: `StringConstraints`,
+`NumberConstraints`, `PathFlagOptions`, `UrlFlagOptions`, and `DateFlagOptions`.
 
-String and discriminated unions are closed: consumers may switch exhaustively
-over them (`satisfies never` in the `default` branch), and adding a variant is
-a breaking change released in a major.
+Prompt configuration: `PromptConfig`, `PromptConfigBase`, `InputPromptConfig`,
+`ConfirmPromptConfig`, `SelectPromptConfig`, `MultiselectPromptConfig`, and the
+choice entry `SelectChoice`.
+
+Error constructor options: `CLIErrorOptions`, `ParseErrorOptions`, and
+`ValidationErrorOptions`.
+
+Testkit inputs: `TestAdapterOptions`, `TestPrompterOptions`, the queued answer
+type `TestAnswer`, and the cancellation sentinel value `PROMPT_CANCEL`.
+
+Every field is optional apart from the discriminants and identifiers each type
+needs: `code` on `CLIErrorOptions`, `ParseErrorOptions`, and
+`ValidationErrorOptions`; `message` on `PromptConfigBase` and `kind` on each
+concrete prompt config; `format` on the `'json'` and `'text'` arms of
+`TableOptions`; `type` on the directory arm of `PathFlagOptions`; `value` on
+`SelectChoice`; and `key` on `TableColumn`. Minor releases may add optional
+fields. They never add a required field, remove a field, or change what an
+existing field means. Defaults are part of the contract and change only in a
+major release.
+
+`CLIExecuteOptions` and `CLIRunOptions` sit on top of `RunOptions`.
+`CLIExecuteOptions` is the process-free surface with every input injected
+explicitly. `CLIRunOptions` adds the runtime adapter that `.run()` uses to reach
+the process.
+
+`HelpTheme` is the one entry whose every member is required. A theme reaches the
+framework as the `Partial<HelpTheme>` returned by a `HelpThemeFactory`, so a new
+semantic role added to `HelpTheme` in a minor release leaves existing factories
+compiling. The factory form is the supported way to supply one.
+
+## Transparent input definitions
+
+Plain object types a consumer writes by hand or a code generator emits.
+
+`FlagDefinition`, `ArgDefinition`, `CommandDefinition`, `CLIDefinition`, and
+`ConfigSettingsDefinition`; the shared bases `FlagDefinitionBase` and
+`ArgDefinitionBase`; the per-kind variants `StringFlagDefinition`,
+`NumberFlagDefinition`, `BooleanFlagDefinition`, `EnumFlagDefinition`,
+`ArrayFlagDefinition`, `CustomFlagDefinition`, `CountFlagDefinition`,
+`KeyValueFlagDefinition`, `StringArgDefinition`, `NumberArgDefinition`,
+`EnumArgDefinition`, `CustomArgDefinition`; the kind-indexed maps
+`FlagDefinitionByKind` and `ArgDefinitionByKind`; the override forms
+`FlagDefinitionOverrides` and `ArgDefinitionOverrides`; the entry type
+`CommandArgEntryDefinition`; the values a definition embeds, `PathChecks`,
+`FlagNegation`, `CommandExample`, and its `ExampleCommand` field type; and the
+consumer input data types `PackageJsonData` and `PackageRepository`.
+
+These have no brand, and structural construction is the point. They take the
+same additive contract as consumer input options. Optional fields may arrive in
+a minor release, required fields only in a major.
+
+`PathChecks`, `FlagNegation`, and `CommandExample` are stored verbatim on the
+built schema, so the same type serves as consumer input and as a member of a
+sealed value. The input contract is the one that governs them.
+
+Two properties are load-bearing for code generators. Definitions are recursive
+and accept either rung, so `CommandDefinition.flags` takes a `FlagDefinition` or
+an already-built `FlagSchema`, and `CLIDefinition.commands` takes a
+`CommandDefinition` or a `CommandSchema`. A generator can therefore emit one
+complete structural tree and hand it to `createCLISchema()`. Second, each
+definition is a discriminated union indexed by `kind`, so a field belonging to
+another kind is unrepresentable rather than silently ignored.
+
+Adding a member to `FlagKind` or `ArgKind` widens these unions and is a major
+release. See [Closed unions](#closed-unions-and-discriminated-results).
+
+## Implementer ports
+
+Interfaces designed to be implemented outside the framework.
+
+`RuntimeAdapter` (from `@kjanat/dreamcli/runtime`) with its `TerminalSize` return
+type, `PromptEngine`, `ConfigAdapter`, `PackageJsonAdapter`, `FormatLoader`,
+`ReadFn`, and `WriteFn`.
+
+The required surface is frozen within a major version. New capability arrives as
+an optional member, so an existing implementation keeps compiling. A redesign
+ships as a new interface with the old one supported until the next major.
+
+`ConfigAdapter` and `PackageJsonAdapter` are subsets of `RuntimeAdapter` built
+with `Pick`. `PackageJsonAdapter` requires `readFile` and `cwd`.
+`ConfigAdapter` requires those plus `configDir`, and takes `userConfigDirs` and
+`systemConfigDirs` as optional members. Adding a required key to either subset
+breaks every implementer that passes a hand-built object, so the required key
+sets are frozen alongside the port's own required surface. An optional member
+added to `RuntimeAdapter` reaches these subsets only if the subset picks it.
+
+`TerminalSize` is built by the adapter implementation and read by the framework.
+Its two members are required and frozen with the port.
+
+The function-typed ports are the handler and parser signatures a consumer writes
+and the framework calls: `ActionHandler`, `DeriveHandler`, `MiddlewareHandler`,
+`InteractiveResolver` with its `InteractiveResult` return type, `ArgParseFn`,
+`FlagParseFn`, and `HelpThemeFactory`. Their parameter and return types are
+frozen within a major version. The payload object a handler receives grows
+instead, under
+[Framework-produced callback payloads](#framework-produced-callback-payloads).
+A handler that destructures the members it needs keeps compiling when a new one
+arrives.
+
+The supported low-level output seam is the injected `stdout` and `stderr` writer
+pair on `OutputOptions`, both of type `WriteFn`. Reimplementing `Out` is sealed
+off and is not a supported extension point.
+
+## Externally governed protocols
+
+`StandardSchemaV1` and its namespace members `StandardSchemaV1Props`,
+`StandardSchemaV1Result`, `StandardSchemaV1SuccessResult`,
+`StandardSchemaV1FailureResult`, `StandardSchemaV1Issue`,
+`StandardSchemaV1PathSegment`, `StandardSchemaV1Options`, and
+`StandardSchemaV1Types`.
+
+DreamCLI vendors these as types only, mirroring the specification at
+[standardschema.dev](https://standardschema.dev), so validators from zod,
+valibot, arktype, and any other conforming library can be passed to
+`flag.custom()` and `arg.custom()` without a runtime dependency.
+
+The contract belongs to that specification. DreamCLI tracks it and does not
+extend it. When the upstream spec revises, the vendored types follow, and the
+release carrying that change is labelled by the impact the upstream revision has
+on DreamCLI consumers.
+
+`Colors` takes the same treatment. It is the palette type behind `out.color` and
+`HelpThemeFactory`, re-exported from
+[ansispeck](https://www.npmjs.com/package/ansispeck) so a handler can type a
+color-aware helper without adding that dependency. Its shape is governed by the
+ansispeck version this package depends on, and a DreamCLI release that changes
+which palette members exist is labelled by the impact on consumers.
+
+## Structural consumer configuration
+
+`CLIPlugin` and `CLIPluginHooks`.
+
+The consumer constructs these, the framework consumes them. Every hook on
+`CLIPluginHooks` is optional, so a new lifecycle hook can arrive in a minor
+release without breaking an existing plugin. Adding a required field to
+`CLIPlugin` is a major release.
+
+`plugin()` is the recommended constructor. It freezes the hooks object and fills
+`name`, and it keeps a plugin compiling when `CLIPlugin` gains a field that the
+factory can default. A hand-built object literal has to spell every required
+field itself.
+
+The payload types the hooks receive are covered under
+[Framework-produced callback payloads](#framework-produced-callback-payloads).
+
+## Closed unions and discriminated results
+
+The kind and mode unions `Verbosity`, `Shell`, `ArgKind`, `FlagKind`,
+`PromptKind`, `ArgPresence`, `FlagPresence`, `DuplicatePolicy`, `Fallback`,
+`TableFormat`, `TableStream`, `ParseErrorCode`, `ValidationErrorCode`, and
+`Runtime` (from `@kjanat/dreamcli/runtime`).
+
+The discriminated results `ActivityEvent`, `Token`, `PromptResult`,
+`NumberConstraintViolation`, `StringConstraintViolation`, and
+`ConfigDiscoveryResult` with its members `ConfigFound` and `ConfigNotFound`.
+
+The runtime value forms `SHELLS` and `RUNTIMES` (the latter from
+`@kjanat/dreamcli/runtime`), which are the frozen tuples behind `Shell` and
+`Runtime`.
+
+These are closed. A consumer may switch exhaustively over them and rely on the
+compiler to flag an unhandled case. Adding a variant is a breaking change and
+ships in a major release. The same rule covers the value forms, which tooling
+iterates to emit one artifact per member.
+
+```ts twoslash
+import type { Shell } from '@kjanat/dreamcli';
+// ---cut---
+function scriptFileName(shell: Shell): string {
+	switch (shell) {
+		case 'bash':
+			return 'mycli.bash';
+		case 'zsh':
+			return '_mycli';
+		case 'fish':
+			return 'mycli.fish';
+		case 'powershell':
+			return 'mycli.ps1';
+		default:
+			return shell satisfies never;
+	}
+}
+```
+
+`ConfigDiscoveryResult` narrows on its `found` discriminant. The `false` branch
+carries no other members, so reading `result.path` before narrowing is a type
+error rather than a runtime `undefined`.
+
+## Open unions
+
+`ErrorCode`.
+
+`ErrorCode` is `ParseErrorCode | ValidationErrorCode | (string & {})`. The
+literal members drive autocomplete, and the `string` arm keeps the union open.
+The framework emits codes outside the two closed unions (`CONFIG_NOT_FOUND`,
+`CONFIG_PARSE_ERROR`, `CONFIG_UNKNOWN_FORMAT`, `DUPLICATE_COMMAND`,
+`DUPLICATE_DEFAULT`, `RESERVED_FLAG`, `NO_ACTION`, and others), and may add
+codes in any release including a patch.
+
+Handle it with a fallback branch rather than an exhaustive switch:
+
+```ts twoslash
+import type { ErrorCode } from '@kjanat/dreamcli';
+// ---cut---
+function exitCodeFor(code: ErrorCode): number {
+	if (code === 'UNKNOWN_FLAG' || code === 'MISSING_VALUE') return 2;
+	if (code === 'REQUIRED_FLAG' || code === 'REQUIRED_ARG') return 2;
+	return 1;
+}
+```
+
+A consumer may also emit its own codes through `CLIError`, which is why the
+union stays open rather than growing a variant per framework release.
+
+## Framework-produced callback payloads
+
+The bags handed to a consumer callback: `ActionParams`, `DeriveParams`,
+`MiddlewareParams`, `InteractiveParams`, `BeforeParseParams`,
+`PluginCommandContext`, `ResolvedCommandParams`, `ExampleMeta`, and
+`ResolvedPromptConfig` with its members `ResolvedSelectPromptConfig` and
+`ResolvedMultiselectPromptConfig`.
+
+The values a framework call returns: `SpinnerHandle`, `ProgressHandle`,
+`ResolveResult`, `DeprecationWarning`, `Middleware`, and `CapturedOutput` (from
+`@kjanat/dreamcli/testkit`).
+
+The normalized state a sealed schema carries: `ResolvedManifestSettings`,
+`HelpLinks`, and `CommandArgEntry`.
+
+The framework builds all of these. They carry no brand, so a test can assemble
+one, but constructibility is not part of the contract. A minor release may add a
+required readonly member. Every reader keeps compiling; an object literal that
+spells the type exhaustively does not.
+
+Destructure the members a callback needs and let the rest pass through. Code
+that builds one of these types by hand should treat that as a
+version-pinned convenience rather than a supported surface.
+
+`ResolvedManifestSettings` is the normalized manifest-discovery state stored on
+`CLISchema.packageJsonSettings`. The consumer-facing input form is
+`ManifestSettings`, which is a
+[consumer input option](#consumer-input-options).
+
+`Middleware` comes from `middleware()` and is passed straight to
+`CommandBuilder.middleware()`. Its `_handler` and `_output` members belong to the
+[internal surface](#internal-surface), so the value is opaque in practice.
+
+`SpinnerHandle` and `ProgressHandle` gain lifecycle methods the same way these
+types gain members. Calling code keeps working; a hand-written test double that
+implements the interface exhaustively does not.
+
+## Closed constructible DTOs
+
+`RunResult`, `CommandMeta`, and `ParseResult`.
+
+The framework produces these, and consumers construct them on purpose. None
+carries a brand and every member is required, so a hand-built object is
+assignable. `RunResult` comes out of `runCommand()` and `.execute()`, and a
+test fixture standing in for a run builds one. `CommandMeta` reaches a handler
+as `meta`, and the [planner contract](/reference/planner-contract) carries it
+on the execution plan, so tooling reproducing that seam builds one.
+`ParseResult` comes out of `parse()` and goes into `resolve()`, so tooling
+driving the low-level pipeline builds one directly.
+
+Every member is required, and the set is closed. Adding a member is a breaking
+change and ships in a major release. That is the price of guaranteeing
+constructibility in both directions.
+
+Consumers that only read a `RunResult` should still narrow with `Pick` where a
+helper needs part of it, which keeps the helper honest about what it depends on.
+
+## Serialized formats
+
+`DefinitionDocumentV1` and its alias `DefinitionDocument`;
+`CommandDefinitionDocumentV1` and its alias `CommandDefinitionDocument`; the
+fragment types `CommandDefinitionFragmentV1`, `FlagDefinitionFragmentV1`,
+`ArgDefinitionFragmentV1`, `ExampleDefinitionFragmentV1`,
+`FlagNegationFragmentV1`, `FlagPathChecksFragmentV1`,
+`FlagStringConstraintsFragmentV1`, `PromptChoiceFragmentV1`, and
+`PromptDefinitionFragmentV1`; and the error envelope `CLIErrorJSON`.
+
+These values leave the process. The package version does not govern their shape.
+`schemaVersion` does.
+
+Every standalone document carries `schemaVersion: 1`. Fragments carry no
+`schemaVersion` and inherit the version of the document they sit in. A change
+that breaks a reader of version 1 increments the format to `schemaVersion: 2`
+and ships as `DefinitionDocumentV2` alongside `DefinitionDocumentV1`, whatever
+the package major happens to be at that time. Additive changes that a version 1
+reader can ignore stay at version 1.
+
+```ts twoslash
+import { createCLISchema, generateSchema } from '@kjanat/dreamcli';
+// ---cut---
+const document = generateSchema(createCLISchema({ name: 'mycli', version: '1.0.0' }));
+
+console.log(document.schemaVersion);
+// 1
+console.log(document.$schema);
+// https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json
+```
+
+The canonical meta-schema URL is
+`https://dreamcli.kjanat.dev/schemas/definition/v1.schema.json`. It is permanent.
+Once published it keeps serving the version 1 meta-schema for as long as the
+domain resolves, and it is never repointed at a later format. A version 2 format
+would be served at `/schemas/definition/v2.schema.json`.
+
+Two mirrors carry identical bytes for offline and local-first workflows:
+
+- `./node_modules/@kjanat/dreamcli/dreamcli.schema.json`
+- `https://cdn.jsdelivr.net/npm/@kjanat/dreamcli/dreamcli.schema.json`
+
+The `definitionMetaSchema` export is the same document as a value, for tooling
+that validates definition documents without a network round-trip.
+
+`CLIErrorJSON` is the `--json` error envelope. `name`, `code`, `message`, and
+`exitCode` are always present; `suggest` and `details` appear when set. Its
+`code` field is the open [`ErrorCode`](#open-unions) union, so a consumer
+reading the envelope needs a fallback branch.
+
+`generateInputSchema()` produces standard JSON Schema draft 2020-12, typed as
+`InputSchemaDocument`, `InputSchemaBranch`, and `InputSchemaProperty`. That
+output is governed by the JSON Schema draft it declares rather than by
+`schemaVersion`, and it sits outside the definition-format family.
+
+## Classes and functions
+
+The callable surface, plus the exported type-level operators and constants in the
+two subsections below.
+
+Exported classes: `CLIBuilder`, `CommandBuilder`, `FlagBuilder`, `ArgBuilder`,
+`CLIError`, `ParseError`, `ValidationError`, and `ExitError` (from
+`@kjanat/dreamcli/runtime`).
+
+Exported functions, by area:
+
+- Program construction: `cli`, `command`, `group`, `flag`, `arg`, `middleware`,
+  `plugin`.
+- Schema normalization: `createFlagSchema`, `createArgSchema`,
+  `createCommandSchema`, `createCLISchema`.
+- Low-level pipeline: `tokenize`, `parse`, `resolve`, `formatHelp`,
+  `resolveRenderContext`, `resolvePromptConfig`, `includesBeforeSeparator`,
+  `stripBeforeSeparator`, `getFlagNegatedName`, `resolveExampleCommand`.
+- Serialization: `generateSchema`, `generateCommandSchema`, `generateInputSchema`.
+- Discovery: `discoverConfig`, `discoverManifest`, `inferCliName`,
+  `buildConfigSearchPaths`, `configFormat`, `packageRepositoryUrl`.
+- Output and terminal: `createOutput`, `createTerminalPrompter`, `osc8`,
+  `visibleWidth`.
+- Completion generation: `generateCompletion`, `generateBashCompletion`,
+  `generateZshCompletion`, `generateFishCompletion`,
+  `generatePowerShellCompletion`.
+- Error narrowing: `isCLIError`, `isParseError`, `isValidationError`.
+- Host integration: `isMainModule`, and from `@kjanat/dreamcli/runtime`
+  `createAdapter`, `createNodeAdapter`, `createDenoAdapter`, `detectRuntime`.
+- Testkit, from `@kjanat/dreamcli/testkit`: `runCommand`, `createCaptureOutput`,
+  `createTestPrompter`, `createTestAdapter`.
+
+The [API reference](/reference/api) lists their signatures.
+
+`flag` and `arg` are callable namespaces typed by `FlagFactory` and `ArgFactory`.
+A new factory method on either is a new function and ships in a minor release.
+
+A function may gain optional trailing parameters in a minor release, and its
+return type may gain members subject to the category that return type belongs
+to. Removing an overload, adding a required parameter, reordering parameters, or
+narrowing a return type is a major release. Throwing a new error code from an
+existing call path is a minor release, since `ErrorCode` is open.
+
+Class constructors follow the same rule as functions, with one exception.
+`CLIBuilder` has no public constructor. `cli()` builds an executable program and
+`createCLISchema()` builds a description; there is no third way to obtain one.
+
+### Type-level operators
+
+`InferFlag`, `InferFlags`, `InferArg`, `InferArgs`, `InferStandardInput`,
+`InferStandardOutput`, `ResolvedValue`, `ResolvedArgValue`, `WithPresence`,
+`WithArgPresence`, `WithVariadic`, and the builder state types `FlagConfig` and
+`ArgConfig`.
+
+These compute a type from another type. Most code reaches them through inference
+and never names one. `InferFlags<typeof flags>` in an extracted handler signature
+is the common exception.
+
+The mapping each performs is frozen within a major version. The type it produces
+carries the contract of whatever category that type belongs to. `FlagConfig` and
+`ArgConfig` are the compile-time state threaded through a builder chain, and a
+tracked property may be added to either in a minor release, since builders are
+obtained from `flag` and `arg` rather than written by hand.
+
+### Constants
+
+`DREAMCLI_VERSION` and `DREAMCLI_REVISION`, both from
+`@kjanat/dreamcli/version`, identify the framework build for diagnostics and bug
+reports. They are typed `string` and their values change every release. They are
+unrelated to the app version configured through `cli().version(...)`.
 
 ## Internal surface
 
-Members prefixed with an underscore and types named `Internal*` exist for the
-framework's own layering and for in-repo tests. They may change or disappear
-in any release. The `@internal` TSDoc tag marks the same boundary on
-individual members.
+Members prefixed with an underscore (`_from`, `_subcommands`, `_executionSteps`,
+`_flags`, `_args`, `_ctx`, `_config`, `_output`), types named `Internal*`
+(`InternalRunOptions`, `InternalCLIExecuteOptions`), and the brand symbols
+behind sealed values exist for the framework's own layering and for in-repo
+tests. They may change or disappear in any release, including a patch. The
+`@internal` TSDoc tag marks the same boundary on individual members.
+
+The compiled execution graph is internal in the strongest available sense.
+`CompiledCLI` and `CompiledCommand` are not exported from any entrypoint and do
+not appear in the generated declarations. A `CLIBuilder` holds its compiled
+graph in module-private state, which is why `cli(...).schema` describes the
+program while only the builder can execute it.

--- a/docs/reference/stability.md
+++ b/docs/reference/stability.md
@@ -6,9 +6,10 @@ it carries. Version numbers follow [SemVer](https://semver.org).
 "Breaking" is not one rule. It depends on who constructs a value, who reads it,
 and whether the value crosses a serialization boundary. Adding a readonly member
 to [`Out`](#sealed-framework-values) is a minor release because only the
-framework constructs one. Adding the same member to
+framework constructs one. Adding a required member to
 [`RuntimeAdapter`](#implementer-ports) is a major release because consumers
-implement it. Adding a variant to [`Shell`](#closed-unions-and-discriminated-results)
+implement it; adding an optional member is a minor release. Adding a variant to
+[`Shell`](#closed-unions-and-discriminated-results)
 is a major release because consumers switch exhaustively over it, while adding
 one to [`ErrorCode`](#open-unions) is a patch because the union is open by
 construction.
@@ -440,7 +441,7 @@ fragment types `CommandDefinitionFragmentV1`, `FlagDefinitionFragmentV1`,
 These values leave the process. The package version does not govern their shape.
 `schemaVersion` does.
 
-Every standalone document carries `schemaVersion: 1`. Fragments carry no
+Every standalone definition document carries `schemaVersion: 1`. Fragments carry no
 `schemaVersion` and inherit the version of the document they sit in. A change
 that breaks a reader of version 1 increments the format to `schemaVersion: 2`
 and ships as `DefinitionDocumentV2` alongside `DefinitionDocumentV1`, whatever

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,8 +7,11 @@ export default defineConfig({
 		// and CI runners (GitHub Actions) advertise color even without a TTY.
 		// Pin it off so auto-gated color is deterministic everywhere; tests
 		// that exercise themed output opt in explicitly via `createColors(true)`
-		// or `color: true`, which bypass detection.
+		// or `color: true`, which bypass detection. FORCE_COLOR outranks
+		// NO_COLOR and any non-empty value counts as on, so the setup file
+		// deletes inherited FORCE_* variables instead of overwriting them.
 		env: { NO_COLOR: '1' },
+		setupFiles: ['./vitest.setup.ts'],
 		include: ['src/**/*.test.ts', 'docs/.vitepress/data/*.test.ts'],
 		coverage: {
 			include: ['src/**/*.ts', 'docs/.vitepress/data/*.ts'],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,8 @@
+/**
+ * Runs before each test file's imports. ansispeck treats any non-empty
+ * FORCE_COLOR/FORCE_HYPERLINKS value, including '0', as force-on and checks
+ * them before NO_COLOR, so inherited values must be deleted, not overwritten.
+ */
+
+delete process.env.FORCE_COLOR;
+delete process.env.FORCE_HYPERLINKS;


### PR DESCRIPTION
Targets v4. Stacked on #105. Implements L8 of the approved v4 plan.

- `docs/reference/stability.md` rewritten: thirteen categories, each with its construction/reading/serialization contract and minor-release rules. Membership audited against the complete export lists of all four entrypoints — 248 names, 0 uncited, 0 stale, 0 double-categorized. Review truth-checked every claim against the tree and fixed six (incl. `INVALID_SCHEMA` cited as an open-union example while being a closed `ParseErrorCode` member, and an unverifiable DTO justification replaced with checkable facts).
- `docs/guide/upgrading-v4.md` new, shaped like the v3 guide: every break with verified before/after snippets (before-snippets confirmed to fail against v4, after-snippets compile under twoslash). Nav + migration chain registered.
- Second commit: the reviewer-diagnosed `FORCE_COLOR` flake fired live during my gate run (ansispeck checks it for truthiness before `NO_COLOR`, so an inherited `'0'` still forces color on) — a vitest setup file now deletes inherited `FORCE_*` variables before test imports; 20 previously environment-dependent assertions are deterministic.

Gates: typecheck exit 0, lint clean, fmt clean, 2974/2974 tests (green in a FORCE_COLOR-polluted shell), docs build clean with 45 sources.