### PR TITLE
fix(v4): support root output flag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   validate against a local copy but no longer match the meta-schema's `$schema`
   constant.
 
+- **Breaking: a command flag spelled like a root-owned flag now throws
+  `RESERVED_FLAG` at build time**
+  ([#84](https://github.com/kjanat/dreamcli/issues/84)). The root removes
+  `--json` and `--quiet`/`-q` from argv before dispatch, intercepts
+  `--version`/`-V` once a version is configured, and renders help for
+  `--help`/`-h` before a command's flags are parsed. A command declaring one of
+  those spellings used to build, run, and render help while its flag stayed
+  permanently at its default value. `.command()`, `.default()`, `.version()`,
+  `.manifest(data)`, and `createCLISchema()` now reject it with `CLIError` code
+  `RESERVED_FLAG`, checking each flag's canonical name, its aliases (hidden ones
+  included), and its custom negated spelling (`.negatable({ alias: 'quiet' })`)
+  through the whole nested subcommand tree. The error names the colliding flag
+  and the root flag that shadows it, and suggests renaming, or `out.status()`
+  for output that root `--quiet` suppresses. Near misses such as
+  `jsonOutput` or `quietMode` stay legal, the default `--no-<name>` spelling
+  never collides, and `version`/`V` stay available to a CLI that declares no
+  version.
+
+- **`--completions` collision detection now covers negated spellings and the
+  definition path.** `.negatable({ alias: 'completions' })` and a
+  `createCLISchema()` definition carrying `completionsFlag` both used to build a
+  CLI whose command flag the planner intercepted. Both now throw `CLIError` code
+  `RESERVED_FLAG`, matching what `.completions({ as: 'flag' })` already rejected
+  on the builder.
+
 ### Removed
 
 - **Breaking: `.packageJson()`** — deprecated since 2.5. Use `.manifest()`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `out.info()` and rely on DreamCLI to suppress the complete presentation
   layer without reading private output policy state.
 
+- **`--json=true` and `--quiet=true` failed as unknown flags**
+  ([#85](https://github.com/kjanat/dreamcli/issues/85)). Both root flags now
+  take a value the way `flag.boolean()` does. `true` and `1` enable, `false`
+  and `0` disable, the last occurrence wins, and an invalid literal fails with
+  the parser's `INVALID_VALUE` error and exit code 2 instead of `Unknown flag`.
+  `--help`, `-h`, and `--version` still render ahead of that error, so a
+  mistyped value never hides the text that documents the flag. Short `-q` keeps
+  its presence-only form, matching short boolean flags at the command level.
+  `runCommand()` from `/testkit` reads the same layer, and tokens after `--`
+  still reach the command untouched.
+
 ## [3.0.1] - 2026-07-21
 
 No library code changed; this release ships agent-facing material that was

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -79,6 +79,16 @@ as short boolean flags are everywhere else.
 `--help` and `--version` render ahead of that error, so a mistyped value never
 hides the text that documents the flag.
 
+The root owns those tokens: it strips `--json` and `--quiet`/`-q` from argv,
+intercepts `--version`/`-V` once the CLI declares a version, and renders help
+for `--help`/`-h` before a command's flags are parsed. A command flag spelled
+the same way could never be set, so declaring one throws `RESERVED_FLAG`.
+Naming a flag `quiet`, `json`, or `help`, aliasing one to `q` or `h`, or giving
+one a negated spelling like `.negatable({ alias: 'quiet' })` is rejected by
+`.command()`, `.default()`, and `createCLISchema()`, and `version`/`V` join
+that set once a version is configured. Rename the flag, or reach for
+`out.status()` when you wanted output that root `--quiet` suppresses.
+
 | Method   | Stream                      | Suppressed by quiet |
 | -------- | --------------------------- | ------------------- |
 | `log`    | stdout (stderr in `--json`) | no                  |

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -27,6 +27,11 @@ out.json({ status: 'ok', count: 42 });
 When the CLI is invoked with `--json`, structured payloads stay on stdout while
 plain text (`log`, `info`, `warn`, `error`) routes to stderr.
 
+`--json` also takes an explicit value like any boolean flag: `--json=true`,
+`--json=1`, `--json=false`, and `--json=0`. The last occurrence wins, so a
+wrapper script can append `--json=false` to turn a default off, and an invalid
+value fails with exit code 2.
+
 ## Exit Codes Without Error Output
 
 Use `out.setExitCode(code)` when a command should emit normal output but still
@@ -65,6 +70,14 @@ and `error` still emit.
 Like `--json`, it is a root-level flag: it is stripped before dispatch (so
 command schemas never see it) and only counts before the `--` separator; a
 literal `-q` after `--` reaches the command as a positional.
+
+The long spelling takes an explicit value the same way: `--quiet=true`,
+`--quiet=1`, `--quiet=false`, and `--quiet=0`, with the last occurrence winning
+and an invalid value failing with exit code 2. The short `-q` is presence-only,
+as short boolean flags are everywhere else.
+
+`--help` and `--version` render ahead of that error, so a mistyped value never
+hides the text that documents the flag.
 
 | Method   | Stream                      | Suppressed by quiet |
 | -------- | --------------------------- | ------------------- |

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -86,8 +86,8 @@ the same way could never be set, so declaring one throws `RESERVED_FLAG`.
 Naming a flag `quiet`, `json`, or `help`, aliasing one to `q` or `h`, or giving
 one a negated spelling like `.negatable({ alias: 'quiet' })` is rejected by
 `.command()`, `.default()`, and `createCLISchema()`, and `version`/`V` join
-that set once a version is configured. Rename the flag, or reach for
-`out.status()` when you wanted output that root `--quiet` suppresses.
+that set once a version is configured. Rename the flag, or use `out.status()`
+for status output that root `--quiet` suppresses.
 
 | Method   | Stream                      | Suppressed by quiet |
 | -------- | --------------------------- | ------------------- |

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -6,13 +6,69 @@ dreamcli from another framework, see
 [Migration And Adoption](/guide/migration).
 
 A CLI built entirely from the fluent builders (`cli()`, `command()`, `flag`,
-`arg`) mostly runs on 4.0 unchanged. The breaking changes land on code that
-assembles schema objects by hand, hand-rolls an `Out`, reaches into
-`CLISchema.commands`, or passes framework-populated fields into execution
-options. Every category and its compatibility rules are listed on the
+`arg`) mostly runs on 4.0 unchanged, with one exception: a command flag spelled
+like a root-owned flag is now rejected when you register the command. The rest
+of the breaking changes land on code that assembles schema objects by hand,
+hand-rolls an `Out`, reaches into `CLISchema.commands`, or passes
+framework-populated fields into execution options. Every category and its
+compatibility rules are listed on the
 [Stability Policy](/reference/stability) page.
 
 ## Breaking Changes
+
+### A command flag cannot spell a root-owned flag
+
+The root owns `--json`, `--quiet` / `-q`, and `--help` / `-h`, and
+`--version` / `-V` joins them once the CLI declares a version. It strips the
+two output tokens from argv before dispatch, intercepts `--version` / `-V`, and
+renders help before a command's flags are parsed. In 3.x a command could
+declare one of those spellings anyway. It built, it ran, it showed up in help,
+and its flag sat at the default value on every invocation:
+
+```ts
+// 3.x
+const build = command('build')
+  .flag('quiet', flag.boolean().describe('Suppress build logs'))
+  .action(({ flags, out }) => {
+    out.log(`quiet=${flags.quiet}`);
+  });
+
+await cli('mycli').command(build).run();
+
+// $ mycli build --quiet
+// quiet=false
+```
+
+4.0 rejects the registration with a `CLIError` carrying code `RESERVED_FLAG`:
+
+```
+Command 'build' defines a '--quiet' flag, which is reserved by the root
+'--quiet' flag. The root strips that token before dispatch, so the command
+can never receive it
+```
+
+Rename the flag, or drop it and let root `--quiet` govern the output through
+`out.status()`:
+
+```ts
+// 4.0
+const build = command('build').action(({ out }) => {
+  out.status('Building'); // stderr, suppressed by root --quiet
+  out.log('dist/app.js');
+});
+```
+
+The check reads each flag's canonical name, every alias including hidden ones,
+and a custom negated spelling from `.negatable({ alias: 'quiet' })`, through
+the whole subcommand tree. `.command()`, `.default()`, `.version()`,
+`.manifest(data)`, and `createCLISchema()` all run it, so a `version` flag
+throws whether the command is registered before or after `.version()`.
+`--completions` is reserved on the same terms once
+`.completions({ as: 'flag' })` or `CLIDefinition.completionsFlag` is set.
+
+Near misses stay legal: `quietMode` and `jsonOutput` as names, `-Q` and `-j` as
+aliases, the default `--no-<name>` negated spelling, and a `version` flag on a
+CLI that declares no version.
 
 ### `Out` gained a required `verbosity` member
 
@@ -282,6 +338,12 @@ need re-recording.
 
 ## Behavioral Changes To Review
 
+- **Root `--json` and `--quiet` take an explicit value.** `--json=true`,
+  `--json=1`, `--json=false`, and `--json=0` set the mode where 3.x failed with
+  `Unknown flag`, and `--quiet` accepts the same literals. The last occurrence
+  wins, and an invalid literal exits 2 with the parser's `INVALID_VALUE` error.
+  Short `-q` stays presence-only. See
+  [Output](/guide/output#status-lines-and-quiet-mode).
 - **Quiet mode suppresses rendered spinner and progress output.** Activity
   handles resolve to no-ops under quiet verbosity, including on interactive
   TTYs and for explicit static fallbacks. Capture still records lifecycle

--- a/docs/reference/planner-contract.md
+++ b/docs/reference/planner-contract.md
@@ -10,7 +10,8 @@ It is a stability target for tests and refactors, not a public API guarantee.
 - apply default-command fallback
 - merge propagated flags while honoring child shadowing
 - build the execution handoff for the matched command
-- normalize invocation argv for planner-owned global concerns like root `--json`
+- normalize invocation argv for planner-owned global concerns like root `--json`, and reject an
+  invalid value for one of them once root help and version have had their turn
 
 ## Non-Responsibilities
 

--- a/docs/reference/planner-contract.md
+++ b/docs/reference/planner-contract.md
@@ -11,7 +11,7 @@ It is a stability target for tests and refactors, not a public API guarantee.
 - merge propagated flags while honoring child shadowing
 - build the execution handoff for the matched command
 - normalize invocation argv for planner-owned global concerns like root `--json`, and reject an
-  invalid value for one of them once root help and version have had their turn
+  invalid value for one of them after handling root help and version requests
 
 ## Non-Responsibilities
 

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -1,6 +1,6 @@
 # cli — CLIBuilder, multi-command dispatch, plugins
 
-`index.ts` (~2132 lines) — heavily split: 10 `@internal` extraction files.
+`index.ts` (~2167 lines) — heavily split: 11 `@internal` extraction files.
 
 ## KEY TYPES
 
@@ -24,12 +24,13 @@
 
 | File                   | Lines | Purpose                                                               |
 | ---------------------- | ----: | --------------------------------------------------------------------- |
-| `index.ts`             |  2132 | CLIBuilder class + cli() factory + JSON error handling                |
+| `index.ts`             |  2167 | CLIBuilder class + cli() factory + JSON error handling                |
 | `planner.ts`           |   669 | `@internal` — execution planner, command resolution strategy          |
 | `runtime-preflight.ts` |   490 | `@internal` — runtime adapter setup, env/config preflight             |
 | `dispatch.ts`          |   365 | `@internal` — command dispatch (value-flag-arity aware), levenshtein  |
 | `root-help.ts`         |   364 | `@internal` — root-level help text + text helpers, structural schema  |
-| `root-output-flags.ts` |   187 | `@internal` — `--json`/`--quiet` reader + strip, shared by all layers |
+| `reserved-flags.ts`    |   220 | `@internal` — build-time `RESERVED_FLAG` guard for root-owned flags   |
+| `root-output-flags.ts` |   203 | `@internal` — `--json`/`--quiet` reader + strip, shared by all layers |
 | `compiled.ts`          |   138 | `@internal` — compiled execution graph + `compileCommand()`           |
 | `plugin.ts`            |   117 | `@internal` — plugin system + lifecycle hooks                         |
 | `propagate.ts`         |    97 | `@internal` — flag propagation through command tree                   |
@@ -90,6 +91,21 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
 - `createCLISchema()` normalizes commands through `createCommandSchema()`, which clones them. It
   builds descriptions only; `cli()` uses it just for the empty root schema, so the identity
   invariant above is never crossed.
+- `reserved-flags.ts` rejects a command flag spelled like a token the root already owns:
+  `quiet`/`q`, `json`, `help`/`h` always, plus `version`/`V` once `schema.version` is set (#84). It
+  checks canonical names, aliases (hidden included), and custom negated spellings from
+  `.negatable({ alias })`, since all three land in `buildFlagLookup` and any of them can spell a
+  reserved token. The output half of the reserved set is derived from `ROOT_OUTPUT_TOKENS` in
+  `root-output-flags.ts` rather than restated, so a token added to the strip list is reserved in the
+  same change. `help`/`h` and `version`/`V` come from `planner.ts` interception and are declared
+  here; adding one there needs a matching entry.
+- The version half of the guard is bidirectional like the `--completions` guard:
+  `.command()`/`.default()` check against the current `schema.version`, and
+  `.version()`/`.manifest(data)` re-check every registered command because either can set the
+  version after registration. `createCLISchema()` runs the same check, plus
+  `assertNoCompletionsFlagCollision()` when the definition carries `completionsFlag`, so both
+  construction paths agree; `createCommandSchema()` stays permissive, since a bare command is not
+  bound to a root.
 - `root-help.ts` uses structural `CLISchemaLike` instead of importing `CLISchema` — avoids circular
   dep through barrel
 - `levenshtein()` in `dispatch.ts` uses `Uint16Array` rolling buffer — different impl from `parse/`
@@ -109,7 +125,7 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
 - `planner.ts` orchestrates the execution pipeline — shared with testkit via `execution/`
 - `runtime-preflight.ts` handles adapter creation, env loading, config discovery before dispatch
 
-## TEST FILES (25)
+## TEST FILES (26)
 
 | File                              | Tests                                   |
 | --------------------------------- | --------------------------------------- |
@@ -138,3 +154,4 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
 | `runtime-preflight.test.ts`       | Runtime preflight adapter setup         |
 | `root-help-theme.test.ts`         | Root help theming                       |
 | `render-context.test.ts`          | Render context construction             |
+| `reserved-flags.test.ts`          | `RESERVED_FLAG` guard for root flags    |

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -1,6 +1,6 @@
 # cli — CLIBuilder, multi-command dispatch, plugins
 
-`index.ts` (~2214 lines) — heavily split: 9 `@internal` extraction files.
+`index.ts` (~2132 lines) — heavily split: 10 `@internal` extraction files.
 
 ## KEY TYPES
 
@@ -22,18 +22,19 @@
 
 ## FILES
 
-| File                   | Lines | Purpose                                                              |
-| ---------------------- | ----: | -------------------------------------------------------------------- |
-| `index.ts`             |  2214 | CLIBuilder class + cli() factory + JSON error handling               |
-| `runtime-preflight.ts` |   488 | `@internal` — runtime adapter setup, env/config preflight            |
-| `planner.ts`           |   674 | `@internal` — execution planner, command resolution strategy         |
-| `dispatch.ts`          |   365 | `@internal` — command dispatch (value-flag-arity aware), levenshtein |
-| `root-help.ts`         |   364 | `@internal` — root-level help text + text helpers, structural schema |
-| `compiled.ts`          |   138 | `@internal` — compiled execution graph + `compileCommand()`          |
-| `plugin.ts`            |   117 | `@internal` — plugin system + lifecycle hooks                        |
-| `propagate.ts`         |    97 | `@internal` — flag propagation through command tree                  |
-| `root-surface.ts`      |    96 | `@internal` — root-level CLI surface (version, help flags)           |
-| `help-links.ts`        |    82 | `@internal` — help link derivation from manifest metadata            |
+| File                   | Lines | Purpose                                                               |
+| ---------------------- | ----: | --------------------------------------------------------------------- |
+| `index.ts`             |  2132 | CLIBuilder class + cli() factory + JSON error handling                |
+| `planner.ts`           |   669 | `@internal` — execution planner, command resolution strategy          |
+| `runtime-preflight.ts` |   490 | `@internal` — runtime adapter setup, env/config preflight             |
+| `dispatch.ts`          |   365 | `@internal` — command dispatch (value-flag-arity aware), levenshtein  |
+| `root-help.ts`         |   364 | `@internal` — root-level help text + text helpers, structural schema  |
+| `root-output-flags.ts` |   187 | `@internal` — `--json`/`--quiet` reader + strip, shared by all layers |
+| `compiled.ts`          |   138 | `@internal` — compiled execution graph + `compileCommand()`           |
+| `plugin.ts`            |   117 | `@internal` — plugin system + lifecycle hooks                         |
+| `propagate.ts`         |    97 | `@internal` — flag propagation through command tree                   |
+| `root-surface.ts`      |    96 | `@internal` — root-level CLI surface (version, help flags)            |
+| `help-links.ts`        |    82 | `@internal` — help link derivation from manifest metadata             |
 
 ## DISPATCH FLOW
 
@@ -57,6 +58,15 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
 
 - Stripped from argv before command dispatch, but only before the `--` separator (a `--json` after
   `--` stays a literal positional)
+- `readRootOutputFlags()` in `root-output-flags.ts` is the single reader for `--json` and
+  `--quiet`/`-q`; `planner.ts`, `executeCLI()`, `resolveRenderContext()`, `runtime-preflight.ts`, and
+  testkit `runCommand()` all go through it. It accepts `--json=true|1|false|0` via the parser's own
+  `coerceFlagValue()` with `flag.boolean()`'s schema, so values, last-wins duplicates, and the
+  `INVALID_VALUE` error match a command-level boolean (#85). Short `-q` stays presence-only, matching
+  short-flag tokenization
+- An invalid value reaches the user as a `dispatch-error`, but only after root `--version` and
+  `--help` have had their turn, so `requestsHelp()` gates it in both `planner.ts` and testkit
+  `runCommand()` the same way `executeCommand()` short-circuits a command's own `--help`
 - CLI-level errors rendered as JSON when active
 - Propagated to `OutputChannel` via `jsonMode` option
 - `out.log`/`out.info` redirect to stderr in JSON mode (stdout reserved for data)

--- a/src/core/cli/cli-completions-flag.test.ts
+++ b/src/core/cli/cli-completions-flag.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest';
 import { arg } from '#internals/core/schema/arg.ts';
 import { command } from '#internals/core/schema/command.ts';
 import { flag } from '#internals/core/schema/flag.ts';
-import { cli } from './index.ts';
+import { cli, createCLISchema } from './index.ts';
 
 // === Helpers
 
@@ -76,6 +76,24 @@ describe(".completions({ as: 'flag' })", () => {
 				.action(() => {});
 
 			expect(() => cli('x').completions({ as: 'flag' }).default(colliding)).toThrow(/reserved/);
+		});
+
+		it('rejects a --completions negated-spelling collision', () => {
+			const colliding = command('serve')
+				.flag('bare', flag.boolean().default(true).negatable({ alias: 'completions' }))
+				.action(() => {});
+
+			expect(() => cli('x').completions({ as: 'flag' }).default(colliding)).toThrow(/reserved/);
+		});
+
+		it('rejects a --completions collision built through createCLISchema', () => {
+			expect(() =>
+				createCLISchema({
+					name: 'x',
+					completionsFlag: { shells: ['bash'], options: undefined },
+					commands: [{ name: 'serve', flags: { completions: { kind: 'boolean' } } }],
+				}),
+			).toThrow(/reserved/);
 		});
 
 		it('allows a --completions flag in subcommand mode', () => {

--- a/src/core/cli/cli-json.test.ts
+++ b/src/core/cli/cli-json.test.ts
@@ -260,6 +260,32 @@ describe('CLIBuilder --json with root flags', () => {
 		expect(doc).toMatchObject({ name: 'data', flags: { limit: { kind: 'number' } } });
 	});
 
+	it('--help honors an explicit --json value (#85)', async () => {
+		const app = cli('test').version('1.0.0').command(dataCommand());
+
+		for (const token of ['--json=true', '--json=1']) {
+			const machine = await app.execute(['--help', token]);
+			expect(machine.exitCode).toBe(0);
+			expect(JSON.parse(machine.stdout.join(''))).toMatchObject({ name: 'test' });
+		}
+
+		for (const token of ['--json=false', '--json=0']) {
+			const human = await app.execute(['--help', token]);
+			expect(human.exitCode).toBe(0);
+			expect(human.stdout.join('')).toContain('Usage: test');
+		}
+	});
+
+	it('<command> --help honors an explicit --json value (#85)', async () => {
+		const app = cli('test').version('1.0.0').command(dataCommand());
+
+		const machine = await app.execute(['data', '--help', '--json=true']);
+		expect(JSON.parse(machine.stdout.join(''))).toMatchObject({ name: 'data' });
+
+		const human = await app.execute(['data', '--help', '--json=false']);
+		expect(human.stdout.join('')).toContain('Usage: test data');
+	});
+
 	it('json help output round-trips through JSON.parse regardless of flag order', async () => {
 		const app = cli('test').version('1.0.0').command(dataCommand());
 		for (const argv of [

--- a/src/core/cli/cli-quiet.test.ts
+++ b/src/core/cli/cli-quiet.test.ts
@@ -114,6 +114,27 @@ describe('global --quiet with an explicit value', () => {
 		expect(lastWinsOn.stderr.join('')).toBe('');
 	});
 
+	it('lets a later valid value replace an earlier invalid value', async () => {
+		const app = cli('mycli').command(statusCommand());
+
+		const quiet = await app.execute(['gen', '--quiet=banana', '--quiet=true']);
+		expect(quiet.exitCode).toBe(0);
+		expect(quiet.stderr.join('')).toBe('');
+
+		const json = await app.execute(['gen', '--json=banana', '--json=false']);
+		expect(json.exitCode).toBe(0);
+		expect(json.error).toBeUndefined();
+	});
+
+	it('preserves an invalid value for a different root output flag', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await app.execute(['gen', '--quiet=banana', '--json=true']);
+
+		expect(result.exitCode).toBe(2);
+		expect(result.error?.code).toBe('INVALID_VALUE');
+		expect(result.error?.details).toMatchObject({ flag: 'quiet', value: 'banana' });
+	});
+
 	it('rejects an invalid value with the parser boolean error', async () => {
 		const app = cli('mycli').command(statusCommand());
 		const result = await app.execute(['gen', '--quiet=banana']);

--- a/src/core/cli/cli-quiet.test.ts
+++ b/src/core/cli/cli-quiet.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest';
 import { arg } from '#internals/core/schema/arg.ts';
 import { command } from '#internals/core/schema/command.ts';
+import { flag } from '#internals/core/schema/flag.ts';
 import { createTestAdapter, ExitError } from '#internals/runtime/adapter.ts';
 import { cli } from './index.ts';
 
@@ -71,6 +72,168 @@ describe('global --quiet flag', () => {
 	});
 });
 
+// === Explicit --quiet=<value> (#85)
+
+describe('global --quiet with an explicit value', () => {
+	it('--quiet=true and --quiet=1 set quiet verbosity', async () => {
+		const app = cli('mycli').command(statusCommand());
+
+		for (const token of ['--quiet=true', '--quiet=1']) {
+			const result = await app.execute(['gen', token]);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toBe('artifact\n');
+			expect(result.stderr.join('')).toBe('');
+		}
+	});
+
+	it('--quiet=false and --quiet=0 keep normal verbosity', async () => {
+		const app = cli('mycli').command(statusCommand());
+
+		for (const token of ['--quiet=false', '--quiet=0']) {
+			const result = await app.execute(['gen', token]);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toBe('artifact\nstarting\n');
+			expect(result.stderr.join('')).toBe('Wrote dist/app.js\n');
+		}
+	});
+
+	it('is stripped before dispatch, so commands never see the valued form', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await app.execute(['--quiet=true', 'gen']);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('artifact\n');
+	});
+
+	it('takes the last occurrence, like a command boolean flag', async () => {
+		const app = cli('mycli').command(statusCommand());
+
+		const lastWinsOff = await app.execute(['gen', '--quiet', '--quiet=false']);
+		expect(lastWinsOff.stderr.join('')).toBe('Wrote dist/app.js\n');
+
+		const lastWinsOn = await app.execute(['gen', '--quiet=false', '--quiet']);
+		expect(lastWinsOn.stderr.join('')).toBe('');
+	});
+
+	it('rejects an invalid value with the parser boolean error', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await app.execute(['gen', '--quiet=banana']);
+
+		expect(result.exitCode).toBe(2);
+		expect(result.error?.code).toBe('INVALID_VALUE');
+		expect(result.stderr.join('')).toBe(
+			"Invalid boolean value 'banana' for flag --quiet. Use true/false or 1/0\n",
+		);
+	});
+
+	it('reports the same error a command boolean flag reports for the same value', async () => {
+		const local = command('gen')
+			.flag('quiet', flag.boolean())
+			.action(() => {});
+		const app = cli('mycli').command(local);
+		const result = await app.execute(['gen', '--quiet=banana']);
+
+		expect(result.exitCode).toBe(2);
+		expect(result.error?.code).toBe('INVALID_VALUE');
+		expect(result.stderr.join('')).toBe(
+			"Invalid boolean value 'banana' for flag --quiet. Use true/false or 1/0\n",
+		);
+	});
+
+	it('renders --version and root --help ahead of an invalid value', async () => {
+		const app = cli('mycli').version('9.9.9').command(statusCommand());
+
+		const version = await app.execute(['--version', '--quiet=banana']);
+		expect(version.exitCode).toBe(0);
+		expect(version.stdout.join('')).toBe('9.9.9\n');
+
+		const rootHelp = await app.execute(['--help', '--json=banana']);
+		expect(rootHelp.exitCode).toBe(0);
+		expect(rootHelp.stdout.join('')).toContain('Usage: mycli');
+	});
+
+	it('renders a command --help ahead of an invalid value, as a command flag does', async () => {
+		const local = command('gen')
+			.flag('force', flag.boolean())
+			.action(() => {});
+		const app = cli('mycli').command(local);
+
+		const rootFlag = await app.execute(['gen', '--help', '--quiet=banana']);
+		const commandFlag = await app.execute(['gen', '--help', '--force=banana']);
+
+		expect(rootFlag.exitCode).toBe(0);
+		expect(rootFlag.exitCode).toBe(commandFlag.exitCode);
+		expect(rootFlag.stdout).toEqual(commandFlag.stdout);
+	});
+
+	it('leaves -q=true to the command, as a command-level boolean short flag does', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const rootResult = await app.execute(['gen', '-q=true']);
+
+		expect(rootResult.exitCode).toBe(2);
+		expect(rootResult.stderr.join('')).toContain('Unknown flag -q');
+
+		const local = command('gen')
+			.flag('quick', flag.boolean().alias('q'))
+			.action(() => {});
+		const commandResult = await cli('mycli').command(local).execute(['gen', '-q=true']);
+
+		expect(commandResult.exitCode).toBe(2);
+		expect(commandResult.stderr.join('')).toContain('Unknown flag -=');
+	});
+
+	it('a post-separator --quiet=true reaches the command as a positional', async () => {
+		const echo = command('echo')
+			.arg('value', arg.string())
+			.action(({ args, out }) => {
+				out.log(String(args.value));
+			});
+		const app = cli('mycli').command(echo);
+		const result = await app.execute(['echo', '--', '--quiet=true']);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('--quiet=true\n');
+	});
+
+	it('combines --json=true with --quiet=false', async () => {
+		const app = cli('mycli').command(
+			command('emit').action(({ out }) => {
+				out.log('human line');
+				out.json({ ok: true });
+			}),
+		);
+		const result = await app.execute(['emit', '--json=true', '--quiet=false']);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('{"ok":true}\n');
+		expect(result.stderr.join('')).toBe('human line\n');
+	});
+
+	it('--json=false keeps human output', async () => {
+		const app = cli('mycli').command(
+			command('emit').action(({ out }) => {
+				out.log(`json:${String(out.jsonMode)}`);
+			}),
+		);
+		const result = await app.execute(['emit', '--json=false']);
+
+		expect(result.stdout.join('')).toBe('json:false\n');
+	});
+
+	it('--json takes the last occurrence', async () => {
+		const app = cli('mycli').command(
+			command('emit').action(({ out }) => {
+				out.log(`json:${String(out.jsonMode)}`);
+			}),
+		);
+
+		const off = await app.execute(['emit', '--json', '--json=false']);
+		expect(off.stdout.join('')).toBe('json:false\n');
+
+		const on = await app.execute(['emit', '--json=false', '--json=true']);
+		expect(on.stderr.join('')).toBe('json:true\n');
+	});
+});
+
 // === .run() adapter path
 
 async function runWithAdapter(
@@ -104,6 +267,46 @@ describe('run() adapter path', () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.stdout.join('')).toBe('artifact\n');
 		expect(result.stderr.join('')).toBe('');
+	});
+
+	it('honors --quiet=true through preflight', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await runWithAdapter(app, ['gen', '--quiet=true']);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('artifact\n');
+		expect(result.stderr.join('')).toBe('');
+	});
+
+	it('keeps normal verbosity for --quiet=false through preflight', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await runWithAdapter(app, ['gen', '--quiet=false']);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('artifact\nstarting\n');
+		expect(result.stderr.join('')).toBe('Wrote dist/app.js\n');
+	});
+
+	it('rejects --quiet=banana through preflight', async () => {
+		const app = cli('mycli').command(statusCommand());
+		const result = await runWithAdapter(app, ['gen', '--quiet=banana']);
+		expect(result.exitCode).toBe(2);
+		expect(result.stderr.join('')).toBe(
+			"Invalid boolean value 'banana' for flag --quiet. Use true/false or 1/0\n",
+		);
+	});
+
+	it('honors an explicit --json value through preflight', async () => {
+		const emit = command('emit').action(({ out }) => {
+			out.log(`json:${String(out.jsonMode)}`);
+		});
+		const app = cli('mycli').command(emit);
+
+		const machine = await runWithAdapter(app, ['emit', '--json=true']);
+		expect(machine.exitCode).toBe(0);
+		expect(machine.stderr.join('')).toBe('json:true\n');
+
+		const human = await runWithAdapter(app, ['emit', '--json=false']);
+		expect(human.exitCode).toBe(0);
+		expect(human.stdout.join('')).toBe('json:false\n');
 	});
 
 	it('a post-separator --json literal does not enter JSON mode', async () => {

--- a/src/core/cli/cli-quiet.test.ts
+++ b/src/core/cli/cli-quiet.test.ts
@@ -127,15 +127,15 @@ describe('global --quiet with an explicit value', () => {
 
 	it('reports the same error a command boolean flag reports for the same value', async () => {
 		const local = command('gen')
-			.flag('quiet', flag.boolean())
+			.flag('hush', flag.boolean())
 			.action(() => {});
 		const app = cli('mycli').command(local);
-		const result = await app.execute(['gen', '--quiet=banana']);
+		const result = await app.execute(['gen', '--hush=banana']);
 
 		expect(result.exitCode).toBe(2);
 		expect(result.error?.code).toBe('INVALID_VALUE');
 		expect(result.stderr.join('')).toBe(
-			"Invalid boolean value 'banana' for flag --quiet. Use true/false or 1/0\n",
+			"Invalid boolean value 'banana' for flag --hush. Use true/false or 1/0\n",
 		);
 	});
 
@@ -173,9 +173,9 @@ describe('global --quiet with an explicit value', () => {
 		expect(rootResult.stderr.join('')).toContain('Unknown flag -q');
 
 		const local = command('gen')
-			.flag('quick', flag.boolean().alias('q'))
+			.flag('quick', flag.boolean().alias('k'))
 			.action(() => {});
-		const commandResult = await cli('mycli').command(local).execute(['gen', '-q=true']);
+		const commandResult = await cli('mycli').command(local).execute(['gen', '-k=true']);
 
 		expect(commandResult.exitCode).toBe(2);
 		expect(commandResult.stderr.join('')).toContain('Unknown flag -=');

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -32,7 +32,6 @@ import {
 	resolveHyperlinkOverride,
 } from '#internals/core/output/index.ts';
 import type { ParseOptions } from '#internals/core/parse/index.ts';
-import { includesBeforeSeparator } from '#internals/core/parse/index.ts';
 import type { ArgBuilder, ArgConfig } from '#internals/core/schema/arg.ts';
 import { arg } from '#internals/core/schema/arg.ts';
 import type { schemaBrand } from '#internals/core/schema/brand.ts';
@@ -59,6 +58,11 @@ import { planInvocation } from './planner.ts';
 import type { CLIPlugin } from './plugin.ts';
 import { plugin } from './plugin.ts';
 import { formatRootHelp } from './root-help.ts';
+import {
+	readRootOutputFlags,
+	resolveRootJsonMode,
+	resolveRootVerbosity,
+} from './root-output-flags.ts';
 import { prepareRuntimePreflight } from './runtime-preflight.ts';
 
 /** Long-flag name reserved by `.completions({ as: 'flag' })`; the planner intercepts it before dispatch. */
@@ -696,13 +700,15 @@ interface RenderContextOptions {
 	 */
 	readonly isTTY?: boolean;
 	/**
-	 * Force JSON mode on regardless of argv.
+	 * JSON mode when argv carries no root `--json`. An explicit `--json=false`
+	 * in argv wins over this.
 	 *
 	 * @defaultValue detected from a pre-separator `--json` in `argv`
 	 */
 	readonly jsonMode?: boolean;
 	/**
-	 * Output verbosity override when argv does not contain root `--quiet`/`-q`.
+	 * Output verbosity when argv carries no root `--quiet`/`-q`. An explicit
+	 * `--quiet=false` in argv wins over this.
 	 *
 	 * @defaultValue detected from a pre-separator `--quiet`/`-q` in `argv`,
 	 *   otherwise `'normal'`
@@ -810,10 +816,9 @@ function resolveRenderContext(
 	argv: readonly string[],
 	options?: RenderContextOptions,
 ): RenderContext {
-	const jsonMode = includesBeforeSeparator(argv, '--json') || options?.jsonMode === true;
-	const hasQuietFlag =
-		includesBeforeSeparator(argv, '--quiet') || includesBeforeSeparator(argv, '-q');
-	const verbosity = hasQuietFlag ? 'quiet' : (options?.verbosity ?? 'normal');
+	const rootOutputFlags = readRootOutputFlags(argv);
+	const jsonMode = resolveRootJsonMode(rootOutputFlags, options?.jsonMode);
+	const verbosity = resolveRootVerbosity(rootOutputFlags, options?.verbosity) ?? 'normal';
 	const out = createOutput({
 		jsonMode,
 		isTTY: options?.isTTY ?? false,
@@ -1570,13 +1575,12 @@ async function executeCLI(
 	options?: InternalCLIExecuteOptions,
 ): Promise<RunResult> {
 	// -- Detect global --json / --quiet before building output ----------------
-	// Only occurrences before the `--` separator count; a literal positional
-	// (after `--`) must reach the command unchanged (#28).
-	const hasJsonFlag = includesBeforeSeparator(argv, '--json');
-	const jsonMode = hasJsonFlag || options?.jsonMode === true;
-	const hasQuietFlag =
-		includesBeforeSeparator(argv, '--quiet') || includesBeforeSeparator(argv, '-q');
-	const verbosity: Verbosity | undefined = hasQuietFlag ? 'quiet' : options?.verbosity;
+	const rootOutputFlags = readRootOutputFlags(argv);
+	const jsonMode = resolveRootJsonMode(rootOutputFlags, options?.jsonMode);
+	const verbosity: Verbosity | undefined = resolveRootVerbosity(
+		rootOutputFlags,
+		options?.verbosity,
+	);
 
 	const captureOptions = {
 		...(verbosity !== undefined ? { verbosity } : {}),

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -44,7 +44,7 @@ import type {
 } from '#internals/core/schema/command.ts';
 import { command, createCommandSchema } from '#internals/core/schema/command.ts';
 import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
-import { getFlagAliasNames } from '#internals/core/schema/flag.ts';
+import { getFlagAliasNames, getFlagNegatedName } from '#internals/core/schema/flag.ts';
 import type { InternalRunOptions, RunOptions, RunResult } from '#internals/core/schema/run.ts';
 import type { RuntimeAdapter } from '#internals/runtime/adapter.ts';
 import { createAdapter } from '#internals/runtime/auto.ts';
@@ -57,6 +57,7 @@ import type { OutputPolicy } from './planner.ts';
 import { planInvocation } from './planner.ts';
 import type { CLIPlugin } from './plugin.ts';
 import { plugin } from './plugin.ts';
+import { assertNoReservedFlagCollisions } from './reserved-flags.ts';
 import { formatRootHelp } from './root-help.ts';
 import {
 	readRootOutputFlags,
@@ -70,13 +71,14 @@ const COMPLETIONS_FLAG_NAME = 'completions';
 
 /**
  * Whether a command — or any of its nested subcommands — declares a flag that
- * collides with the eager `--completions` flag, by canonical name or long alias.
+ * collides with the eager `--completions` flag, by canonical name, long alias,
+ * or negated spelling.
  *
  * @internal
  */
 function commandReservesCompletionsFlag(schema: CommandSchema): boolean {
 	if (Object.hasOwn(schema.flags, COMPLETIONS_FLAG_NAME)) return true;
-	for (const flagSchema of Object.values(schema.flags)) {
+	for (const [flagName, flagSchema] of Object.entries(schema.flags)) {
 		if (
 			getFlagAliasNames(flagSchema, { kind: 'long', includeHidden: true }).includes(
 				COMPLETIONS_FLAG_NAME,
@@ -84,6 +86,7 @@ function commandReservesCompletionsFlag(schema: CommandSchema): boolean {
 		) {
 			return true;
 		}
+		if (getFlagNegatedName(flagName, flagSchema) === COMPLETIONS_FLAG_NAME) return true;
 	}
 	return schema.commands.some(commandReservesCompletionsFlag);
 }
@@ -612,6 +615,10 @@ function buildCLISchema(definition: CLIDefinition): CLISchema {
  * @param definition - Program name plus optional metadata and commands.
  * @returns A fully populated {@link CLISchema}.
  * @throws {CLIError} With code `'INVALID_SCHEMA'` when the name is empty.
+ * @throws {CLIError} With code `'RESERVED_FLAG'` when a command spells a flag
+ *   the same way as a root-owned flag (`--json`, `--quiet`/`-q`, `--help`/`-h`,
+ *   `--version`/`-V` once `version` is set, and `--completions` once
+ *   `completionsFlag` is set), by name, alias, or negated spelling.
  *
  * @example
  * ```ts
@@ -642,6 +649,13 @@ function createCLISchema(definition: CLIDefinition): CLISchema {
 		definition.commands?.includes(definition.defaultCommand) === true;
 	if (schema.defaultCommand !== undefined && !defaultIsRegisteredCommand) {
 		assertNoTopLevelRouteConflict(registered, schema.defaultCommand);
+	}
+	const allCommands = [schema.defaultCommand, ...schema.commands];
+	assertNoReservedFlagCollisions(schema.version, allCommands);
+	if (schema.completionsFlag !== undefined) {
+		for (const cmd of allCommands) {
+			if (cmd !== undefined) assertNoCompletionsFlagCollision(cmd);
+		}
 	}
 	return schema;
 }
@@ -959,10 +973,16 @@ class CLIBuilder {
 	/**
 	 * Set the program version (shown by `--version`).
 	 *
+	 * Declaring a version also reserves `--version`/`-V` on every registered
+	 * command, so this rejects a command that already declares either spelling.
+	 *
 	 * @param v - Semantic version string.
 	 * @returns The builder (for chaining).
+	 * @throws {@link CLIError} `RESERVED_FLAG` when a registered command declares
+	 *   a flag named `version` or aliased `V`.
 	 */
 	version(v: string): CLIBuilder {
+		assertNoReservedFlagCollisions(v, [this.schema.defaultCommand, ...this.schema.commands]);
 		return rebuild(this, { ...this.schema, version: v });
 	}
 
@@ -1218,7 +1238,9 @@ class CLIBuilder {
 	 */
 	manifest(settings?: ManifestSettings): CLIBuilder;
 	manifest(input?: PackageJsonData | ManifestSettings): CLIBuilder {
-		return rebuild(this, buildManifestSchema(this.schema, input, DEFAULT_MANIFEST_FILES));
+		const next = buildManifestSchema(this.schema, input, DEFAULT_MANIFEST_FILES);
+		assertNoReservedFlagCollisions(next.version, [next.defaultCommand, ...next.commands]);
+		return rebuild(this, next);
 	}
 
 	// -- Command registration ------------------------------------------------
@@ -1231,6 +1253,10 @@ class CLIBuilder {
 	 *
 	 * @param cmd - {@link CommandBuilder} to register.
 	 * @returns The builder (for chaining).
+	 * @throws {@link CLIError} `RESERVED_FLAG` when the command, or one of its
+	 *   nested subcommands, declares a flag named or aliased to a root-owned flag
+	 *   (`--json`, `--quiet`/`-q`, `--help`/`-h`, and `--version`/`-V` once
+	 *   {@link CLIBuilder.version | .version()} is set).
 	 */
 	command<
 		F extends Record<string, FlagBuilder<FlagConfig>>,
@@ -1238,6 +1264,7 @@ class CLIBuilder {
 		C extends Record<string, unknown>,
 	>(cmd: CommandBuilder<F, A, C>): CLIBuilder {
 		assertNoTopLevelRouteConflict(this.schema.commands, cmd.schema, this.schema.defaultCommand);
+		assertNoReservedFlagCollisions(this.schema.version, [cmd.schema]);
 		if (this.schema.completionsFlag !== undefined) {
 			assertNoCompletionsFlagCollision(cmd.schema);
 		}
@@ -1303,6 +1330,10 @@ class CLIBuilder {
 	 * @param options - Default-command options. `{ route: true }` also exposes
 	 *   the command under its own name (see {@link DefaultCommandOptions}).
 	 * @returns The builder (for chaining).
+	 * @throws {@link CLIError} `RESERVED_FLAG` when the command, or one of its
+	 *   nested subcommands, declares a flag named or aliased to a root-owned flag
+	 *   (`--json`, `--quiet`/`-q`, `--help`/`-h`, and `--version`/`-V` once
+	 *   {@link CLIBuilder.version | .version()} is set).
 	 */
 	default<
 		F extends Record<string, FlagBuilder<FlagConfig>>,
@@ -1317,6 +1348,7 @@ class CLIBuilder {
 		}
 
 		assertNoTopLevelRouteConflict(this.schema.commands, cmd.schema);
+		assertNoReservedFlagCollisions(this.schema.version, [cmd.schema]);
 		if (this.schema.completionsFlag !== undefined) {
 			assertNoCompletionsFlagCollision(cmd.schema);
 		}

--- a/src/core/cli/planner.test.ts
+++ b/src/core/cli/planner.test.ts
@@ -98,6 +98,104 @@ describe('planInvocation() — root interception', () => {
 	});
 });
 
+// === Root output flags with an explicit value (#85)
+
+describe('planInvocation() — root output flag values (#85)', () => {
+	it('strips the =value form of --json and --quiet', () => {
+		const deploy = leaf('deploy');
+
+		const result = planFor([deploy], ['--json=true', '--quiet=false', 'deploy', '--force']);
+
+		expect(result.kind).toBe('match');
+		if (result.kind === 'match') {
+			expect(result.plan.argv).toEqual(['--force']);
+		}
+	});
+
+	it('leaves -q=true for the command, matching short-flag parsing', () => {
+		const deploy = leaf('deploy');
+
+		const result = planFor([deploy], ['deploy', '-q=true']);
+
+		expect(result.kind).toBe('match');
+		if (result.kind === 'match') {
+			expect(result.plan.argv).toEqual(['-q=true']);
+		}
+	});
+
+	it('leaves the tail after -- untouched', () => {
+		const deploy = leaf('deploy');
+
+		const result = planFor([deploy], ['--json=true', 'deploy', '--', '--quiet=true']);
+
+		expect(result.kind).toBe('match');
+		if (result.kind === 'match') {
+			expect(result.plan.argv).toEqual(['--', '--quiet=true']);
+		}
+	});
+
+	it('reports an invalid boolean value as a dispatch error', () => {
+		const deploy = leaf('deploy');
+
+		const result = planFor([deploy], ['--quiet=banana', 'deploy']);
+
+		expect(result.kind).toBe('dispatch-error');
+		if (result.kind === 'dispatch-error') {
+			expect(result.error.code).toBe('INVALID_VALUE');
+			expect(result.error.exitCode).toBe(2);
+			expect(result.error.message).toBe(
+				"Invalid boolean value 'banana' for flag --quiet. Use true/false or 1/0",
+			);
+			expect(result.error.details).toEqual({
+				flag: 'quiet',
+				input: '--quiet',
+				value: 'banana',
+				expected: 'boolean',
+			});
+		}
+	});
+
+	it('errors on an invalid value even when argv is otherwise empty', () => {
+		const deploy = leaf('deploy');
+
+		expect(planFor([deploy], ['--json=banana']).kind).toBe('dispatch-error');
+	});
+
+	it('renders --version ahead of an invalid value', () => {
+		const deploy = leaf('deploy');
+
+		const result = planFor([deploy], ['--version', '--quiet=banana']);
+
+		expect(result.kind).toBe('root-version');
+	});
+
+	it('renders root --help ahead of an invalid value', () => {
+		const deploy = leaf('deploy');
+
+		expect(planFor([deploy], ['--help', '--json=banana']).kind).toBe('root-help');
+		expect(planFor([deploy], ['-h', '--json=banana']).kind).toBe('root-help');
+	});
+
+	it('leaves a command --help ahead of an invalid value to the command', () => {
+		const deploy = leaf('deploy');
+
+		const result = planFor([deploy], ['deploy', '--help', '--quiet=banana']);
+
+		expect(result.kind).toBe('match');
+		if (result.kind === 'match') {
+			expect(result.plan.argv).toEqual(['--help']);
+		}
+	});
+
+	it('reports the invalid value when the help token is a post-separator literal', () => {
+		const deploy = leaf('deploy');
+
+		const result = planFor([deploy], ['deploy', '--quiet=banana', '--', '--help']);
+
+		expect(result.kind).toBe('dispatch-error');
+	});
+});
+
 // === Consistent --help / --version positional reach (#29)
 
 describe('planInvocation() — consistent help/version reach (#29)', () => {

--- a/src/core/cli/planner.ts
+++ b/src/core/cli/planner.ts
@@ -20,12 +20,14 @@ import {
 	buildFlagLookup,
 	flagExpectsValue,
 	includesBeforeSeparator,
+	requestsHelp,
 } from '#internals/core/parse/index.ts';
 import type { CommandMeta, CommandSchema } from '#internals/core/schema/command.ts';
 import type { CompiledCLI, CompiledCommand } from './compiled.ts';
 import { dispatch, findClosestCommand } from './dispatch.ts';
 import type { CLIPlugin } from './plugin.ts';
 import { collectPropagatedFlags } from './propagate.ts';
+import { readRootOutputFlags } from './root-output-flags.ts';
 
 /**
  * Descriptive subset of CLISchema used by the planner.
@@ -441,9 +443,6 @@ function planCompletionsFlag(
 	return undefined;
 }
 
-/** Root-level output flags stripped before dispatch (never part of a command schema). */
-const ROOT_OUTPUT_FLAGS = new Set(['--json', '--quiet', '-q']);
-
 /**
  * Decide what to do with an argv invocation before any command executes.
  *
@@ -453,18 +452,10 @@ const ROOT_OUTPUT_FLAGS = new Set(['--json', '--quiet', '-q']);
  * @internal
  */
 function planInvocation(options: PlanInvocationOptions): InvocationPlan {
-	// `--json` and `--quiet`/`-q` are root-level flags, not part of any command
-	// schema, so they are stripped before dispatch/parse — but only before the
-	// `--` separator, so a literal positional (after `--`) survives and reaches
-	// the command (#28). The output mode/verbosity themselves are detected
-	// separately in `.execute()`.
-	const separatorIndex = options.argv.indexOf('--');
-	const head = separatorIndex === -1 ? options.argv : options.argv.slice(0, separatorIndex);
-	const tail = separatorIndex === -1 ? [] : options.argv.slice(separatorIndex);
-	const filteredHead = head.some((arg) => ROOT_OUTPUT_FLAGS.has(arg))
-		? head.filter((arg) => !ROOT_OUTPUT_FLAGS.has(arg))
-		: head;
-	const filteredArgv = separatorIndex === -1 ? filteredHead : [...filteredHead, ...tail];
+	const rootOutputFlags = readRootOutputFlags(options.argv);
+	const filteredArgv = rootOutputFlags.argv;
+	const separatorIndex = filteredArgv.indexOf('--');
+	const filteredHead = separatorIndex === -1 ? filteredArgv : filteredArgv.slice(0, separatorIndex);
 
 	const defaultCommand = options.compiled.defaultCommand;
 	// At the root, a default command's flags govern value-flag arity so a
@@ -527,6 +518,10 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 				argv: [...rest, '--help'],
 			});
 		}
+	}
+
+	if (rootOutputFlags.kind === 'failed' && !requestsHelp(filteredArgv)) {
+		return { kind: 'dispatch-error', error: rootOutputFlags.error };
 	}
 
 	// A CLI with no commands and no default is misconfigured: report NO_ACTION

--- a/src/core/cli/render-context.test.ts
+++ b/src/core/cli/render-context.test.ts
@@ -20,6 +20,32 @@ describe('resolveRenderContext — jsonMode', () => {
 	it('honors an explicit jsonMode override', () => {
 		expect(resolveRenderContext([], { jsonMode: true }).jsonMode).toBe(true);
 	});
+
+	it('reads an explicit --json value (#85)', () => {
+		expect(resolveRenderContext(['--json=true']).jsonMode).toBe(true);
+		expect(resolveRenderContext(['--json=1']).jsonMode).toBe(true);
+		expect(resolveRenderContext(['--json=false']).jsonMode).toBe(false);
+		expect(resolveRenderContext(['--json=0']).jsonMode).toBe(false);
+	});
+
+	it('lets an explicit --json=false win over the jsonMode override', () => {
+		expect(resolveRenderContext(['--json=false'], { jsonMode: true }).jsonMode).toBe(false);
+	});
+
+	it('ignores a post-separator --json=true literal', () => {
+		expect(resolveRenderContext(['deploy', '--', '--json=true']).jsonMode).toBe(false);
+	});
+
+	it('takes the last --json occurrence', () => {
+		expect(resolveRenderContext(['--json', '--json=false']).jsonMode).toBe(false);
+		expect(resolveRenderContext(['--json=false', '--json']).jsonMode).toBe(true);
+	});
+
+	it('falls back to the defaults when a value is invalid', () => {
+		const ctx = resolveRenderContext(['--json=banana']);
+		expect(ctx.jsonMode).toBe(false);
+		expect(ctx.verbosity).toBe('normal');
+	});
 });
 
 // === Verbosity detection
@@ -44,6 +70,32 @@ describe('resolveRenderContext — verbosity', () => {
 
 	it('lets a pre-separator quiet flag override explicit normal verbosity', () => {
 		expect(resolveRenderContext(['--quiet'], { verbosity: 'normal' }).verbosity).toBe('quiet');
+	});
+
+	it('reads an explicit --quiet value (#85)', () => {
+		expect(resolveRenderContext(['--quiet=true']).verbosity).toBe('quiet');
+		expect(resolveRenderContext(['--quiet=1']).verbosity).toBe('quiet');
+		expect(resolveRenderContext(['--quiet=false']).verbosity).toBe('normal');
+		expect(resolveRenderContext(['--quiet=0']).verbosity).toBe('normal');
+	});
+
+	it('lets an explicit --quiet=false win over the verbosity override', () => {
+		expect(resolveRenderContext(['--quiet=false'], { verbosity: 'quiet' }).verbosity).toBe(
+			'normal',
+		);
+	});
+
+	it('does not read -q=true, which is not a short-flag value form', () => {
+		expect(resolveRenderContext(['-q=true']).verbosity).toBe('normal');
+	});
+
+	it('ignores a post-separator --quiet=true literal', () => {
+		expect(resolveRenderContext(['deploy', '--', '--quiet=true']).verbosity).toBe('normal');
+	});
+
+	it('takes the last --quiet occurrence', () => {
+		expect(resolveRenderContext(['--quiet', '--quiet=false']).verbosity).toBe('normal');
+		expect(resolveRenderContext(['--quiet=false', '-q']).verbosity).toBe('quiet');
 	});
 });
 

--- a/src/core/cli/reserved-flags.test.ts
+++ b/src/core/cli/reserved-flags.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Tests for the build-time `RESERVED_FLAG` guard covering command flags the CLI
+ * root already owns (#84).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { CLIError } from '#internals/core/errors/index.ts';
+import { command } from '#internals/core/schema/command.ts';
+import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import type { CLIDefinition } from './index.ts';
+import { cli, createCLISchema } from './index.ts';
+import { readRootOutputFlags } from './root-output-flags.ts';
+
+// === Helpers
+
+function commandWithFlag<B extends FlagBuilder<FlagConfig>>(name: string, builder: B) {
+	return command('serve')
+		.flag(name, builder)
+		.action(() => {});
+}
+
+function booleanCommand(name: string) {
+	return commandWithFlag(name, flag.boolean());
+}
+
+function reservedError(register: () => unknown): CLIError {
+	let thrown: unknown;
+	try {
+		register();
+	} catch (error: unknown) {
+		thrown = error;
+	}
+
+	expect(thrown).toBeInstanceOf(CLIError);
+	if (!(thrown instanceof CLIError)) throw new Error('unreachable');
+	return thrown;
+}
+
+// === Unconditionally reserved names and aliases
+
+describe('reserved root flags', () => {
+	describe('unconditional reservations', () => {
+		it.each(['quiet', 'json', 'help'])('rejects a command flag named %s', (name) => {
+			expect(() => cli('mycli').command(booleanCommand(name))).toThrow(CLIError);
+		});
+
+		it.each(['q', 'h'])('rejects a command flag aliased %s', (alias) => {
+			expect(() =>
+				cli('mycli').command(commandWithFlag('quick', flag.boolean().alias(alias))),
+			).toThrow(CLIError);
+		});
+
+		it.each(['q', 'h'])('rejects a single-char command flag named %s', (name) => {
+			expect(() => cli('mycli').command(booleanCommand(name))).toThrow(CLIError);
+		});
+
+		it('rejects a long alias that spells a reserved name', () => {
+			expect(() =>
+				cli('mycli').command(commandWithFlag('silent', flag.boolean().alias('quiet'))),
+			).toThrow(CLIError);
+		});
+
+		it('rejects a hidden reserved alias', () => {
+			expect(() =>
+				cli('mycli').command(commandWithFlag('hush', flag.boolean().alias('q', { hidden: true }))),
+			).toThrow(CLIError);
+		});
+
+		it('rejects a reserved flag on a nested subcommand', () => {
+			const parent = command('db').command(
+				command('migrate')
+					.flag('json', flag.boolean())
+					.action(() => {}),
+			);
+
+			expect(() => cli('mycli').command(parent)).toThrow(CLIError);
+		});
+
+		it('rejects a reserved flag on the default command', () => {
+			expect(() => cli('mycli').default(booleanCommand('quiet'))).toThrow(CLIError);
+		});
+
+		it.each(['quiet', 'json', 'help'])('rejects a negated spelling of %s', (spelling) => {
+			expect(() =>
+				cli('mycli').command(
+					commandWithFlag('loud', flag.boolean().default(true).negatable({ alias: spelling })),
+				),
+			).toThrow(CLIError);
+		});
+
+		it('rejects a hidden negated spelling of a reserved token', () => {
+			expect(() =>
+				cli('mycli').command(
+					commandWithFlag(
+						'loud',
+						flag.boolean().default(true).negatable({ alias: 'q', hidden: true }),
+					),
+				),
+			).toThrow(CLIError);
+		});
+	});
+
+	// --- version, reserved only once a version is configured
+
+	describe('version reservations', () => {
+		it('allows a version flag and a V alias when no version is configured', () => {
+			expect(() => cli('mycli').command(booleanCommand('version'))).not.toThrow();
+			expect(() =>
+				cli('mycli').command(commandWithFlag('verbose', flag.boolean().alias('V'))),
+			).not.toThrow();
+		});
+
+		it('rejects a version flag registered after .version()', () => {
+			expect(() => cli('mycli').version('1.0.0').command(booleanCommand('version'))).toThrow(
+				CLIError,
+			);
+		});
+
+		it('rejects a V alias registered after .version()', () => {
+			expect(() =>
+				cli('mycli')
+					.version('1.0.0')
+					.command(commandWithFlag('verbose', flag.boolean().alias('V'))),
+			).toThrow(CLIError);
+		});
+
+		it('rejects .version() after the colliding command is registered', () => {
+			expect(() => cli('mycli').command(booleanCommand('version')).version('1.0.0')).toThrow(
+				CLIError,
+			);
+			expect(() =>
+				cli('mycli')
+					.command(commandWithFlag('verbose', flag.boolean().alias('V')))
+					.version('1.0.0'),
+			).toThrow(CLIError);
+		});
+
+		it('rejects .version() after the colliding default command is registered', () => {
+			expect(() => cli('mycli').default(booleanCommand('version')).version('1.0.0')).toThrow(
+				CLIError,
+			);
+		});
+
+		it('rejects .manifest(data) whose version reaches a colliding command', () => {
+			expect(() =>
+				cli('mycli').command(booleanCommand('version')).manifest({ version: '1.0.0' }),
+			).toThrow(CLIError);
+		});
+
+		it('rejects a negated spelling of version only once a version is configured', () => {
+			const negatedVersion = flag.boolean().default(true).negatable({ alias: 'version' });
+
+			expect(() => cli('mycli').command(commandWithFlag('loud', negatedVersion))).not.toThrow();
+			expect(() =>
+				cli('mycli').command(commandWithFlag('loud', negatedVersion)).version('1.0.0'),
+			).toThrow(CLIError);
+		});
+	});
+
+	// --- definition path
+
+	describe('createCLISchema', () => {
+		it('rejects a reserved flag on a command definition', () => {
+			const error = reservedError(() =>
+				createCLISchema({
+					name: 'mycli',
+					commands: [{ name: 'serve', flags: { quiet: { kind: 'boolean' } } }],
+				}),
+			);
+
+			expect(error.code).toBe('RESERVED_FLAG');
+		});
+
+		it('rejects a reserved flag on a nested command definition', () => {
+			expect(() =>
+				createCLISchema({
+					name: 'mycli',
+					commands: [
+						{ name: 'db', commands: [{ name: 'migrate', flags: { json: { kind: 'boolean' } } }] },
+					],
+				}),
+			).toThrow(CLIError);
+		});
+
+		it('rejects a reserved flag on a default command definition', () => {
+			expect(() =>
+				createCLISchema({
+					name: 'mycli',
+					defaultCommand: { name: 'serve', flags: { help: { kind: 'boolean' } } },
+				}),
+			).toThrow(CLIError);
+		});
+
+		it('reserves version only when the definition declares one', () => {
+			const definition: CLIDefinition = {
+				name: 'mycli',
+				commands: [{ name: 'serve', flags: { version: { kind: 'boolean' } } }],
+			};
+
+			expect(() => createCLISchema(definition)).not.toThrow();
+			expect(() => createCLISchema({ ...definition, version: '1.0.0' })).toThrow(CLIError);
+		});
+	});
+
+	// --- error shape
+
+	describe('error shape', () => {
+		it('carries the code, both flag names, and the rename-or-status remedy', () => {
+			const error = reservedError(() => cli('mycli').command(booleanCommand('quiet')));
+
+			expect(error.code).toBe('RESERVED_FLAG');
+			expect(error.message).toContain("Command 'serve' defines a '--quiet' flag");
+			expect(error.message).toContain("reserved by the root '--quiet' flag");
+			expect(error.message).toContain('so the command can never receive it');
+			expect(error.suggest).toBe(
+				'Rename the flag, or use out.status() for output that root --quiet suppresses',
+			);
+		});
+
+		it('names the alias and its owning flag when the collision is an alias', () => {
+			const error = reservedError(() =>
+				cli('mycli').command(commandWithFlag('quick', flag.boolean().alias('q'))),
+			);
+
+			expect(error.message).toContain("defines a '-q' alias on flag 'quick'");
+		});
+
+		it('names the negated spelling and its owning flag', () => {
+			const error = reservedError(() =>
+				cli('mycli').command(
+					commandWithFlag('loud', flag.boolean().default(true).negatable({ alias: 'quiet' })),
+				),
+			);
+
+			expect(error.message).toContain("defines a '--quiet' negated spelling on flag 'loud'");
+		});
+
+		it('suggests renaming for the non-quiet reservations', () => {
+			const error = reservedError(() => cli('mycli').command(booleanCommand('json')));
+
+			expect(error.suggest).toBe('Rename the flag');
+		});
+
+		it('explains help interception without claiming the root strips it', () => {
+			const error = reservedError(() => cli('mycli').command(booleanCommand('help')));
+
+			expect(error.message).toContain('A help request renders before flags are parsed');
+			expect(error.message).not.toContain('strips');
+		});
+
+		it('says the root intercepts the version token', () => {
+			const error = reservedError(() =>
+				cli('mycli').version('1.0.0').command(booleanCommand('version')),
+			);
+
+			expect(error.message).toContain('The root intercepts that token before dispatch');
+		});
+	});
+
+	// --- near misses stay legal
+
+	describe('near misses', () => {
+		it.each(['jsonOutput', 'quietMode', 'helpTopic', 'versionTag', 'no-json'])(
+			'allows a flag named %s',
+			(name) => {
+				expect(() => cli('mycli').version('1.0.0').command(booleanCommand(name))).not.toThrow();
+			},
+		);
+
+		it.each(['Q', 'H', 'j'])('allows a flag aliased %s', (alias) => {
+			expect(() =>
+				cli('mycli')
+					.version('1.0.0')
+					.command(commandWithFlag('quick', flag.boolean().alias(alias))),
+			).not.toThrow();
+		});
+
+		it('allows a negatable boolean', () => {
+			expect(() =>
+				cli('mycli').command(commandWithFlag('color', flag.boolean().default(true).negatable())),
+			).not.toThrow();
+		});
+
+		it('allows a custom negated spelling that is not reserved', () => {
+			expect(() =>
+				cli('mycli').command(
+					commandWithFlag('loud', flag.boolean().default(true).negatable({ alias: 'silent' })),
+				),
+			).not.toThrow();
+		});
+	});
+
+	// --- the reserved set matches what the root layer actually takes
+
+	describe('agreement with the root layer', () => {
+		it.each(['--json', '--quiet', '-q'])('strips %s ahead of the command', (token) => {
+			expect(readRootOutputFlags(['serve', token]).argv).toEqual(['serve']);
+		});
+
+		it.each(['-Q', '-j', '--no-json', '--quietMode'])('leaves %s for the command', (token) => {
+			expect(readRootOutputFlags(['serve', token]).argv).toEqual(['serve', token]);
+		});
+
+		it('renders help instead of running the command for --help and -h', async () => {
+			const app = cli('mycli').command(
+				command('serve')
+					.description('Serve it')
+					.action(({ out }) => out.log('ran')),
+			);
+
+			for (const token of ['--help', '-h']) {
+				const result = await app.execute(['serve', token]);
+				expect(result.stdout.join('')).not.toContain('ran');
+				expect(result.stdout.join('')).toContain('Serve it');
+			}
+		});
+
+		it('intercepts --version and -V only once a version is configured', async () => {
+			const serve = command('serve').action(({ out }) => out.log('ran'));
+			const versioned = cli('mycli').version('9.9.9').command(serve);
+
+			for (const token of ['--version', '-V']) {
+				expect((await versioned.execute(['serve', token])).stdout.join('')).toContain('9.9.9');
+			}
+
+			const unversioned = await cli('mycli').command(serve).execute(['serve', '--version']);
+			expect(unversioned.stdout.join('')).not.toContain('9.9.9');
+		});
+	});
+});

--- a/src/core/cli/reserved-flags.ts
+++ b/src/core/cli/reserved-flags.ts
@@ -1,0 +1,221 @@
+/**
+ * Build-time guard for command flags the CLI root already owns.
+ *
+ * `--json`, `--quiet`/`-q` and `--help`/`-h` never reach a command handler, and
+ * `--version`/`-V` joins them once the CLI declares a version. A command flag
+ * spelled the same way can never be set, so registering one throws
+ * {@linkcode CLIError} `RESERVED_FLAG` here rather than building a CLI whose
+ * flag silently stays at its default (#84).
+ *
+ * @module dreamcli/core/cli/reserved-flags
+ * @internal
+ */
+
+import { CLIError } from '#internals/core/errors/index.ts';
+import type { CommandSchema } from '#internals/core/schema/command.ts';
+import type { FlagSchema } from '#internals/core/schema/flag.ts';
+import { getFlagAliasNames, getFlagNegatedName } from '#internals/core/schema/flag.ts';
+import type { RootOutputFlagName } from './root-output-flags.ts';
+import { ROOT_OUTPUT_TOKENS } from './root-output-flags.ts';
+
+/** What the root does with a token, and how a colliding command flag is fixed. @internal */
+interface ReservedFlag {
+	/** Spelling of the root flag that owns the token. */
+	readonly rootSpelling: string;
+	/** Clause explaining why the command cannot receive the token. */
+	readonly effect: string;
+	/** Remedy offered as the error's `suggest`. */
+	readonly remedy: string;
+}
+
+/** Remedy for every reserved token whose only fix is a different spelling. */
+const RENAME = 'Rename the flag';
+
+/** Remedy for the `--quiet`/`-q` tokens, which have a framework equivalent. */
+const RENAME_OR_STATUS =
+	'Rename the flag, or use out.status() for output that root --quiet suppresses';
+
+/** Remedy per root output flag, keyed by the canonical name the root strips under. */
+const ROOT_OUTPUT_REMEDIES: Readonly<Record<RootOutputFlagName, string>> = {
+	json: RENAME,
+	quiet: RENAME_OR_STATUS,
+};
+
+/** Reservations for the tokens {@linkcode ROOT_OUTPUT_TOKENS} strips from argv. */
+const OUTPUT_RESERVED: readonly (readonly [string, ReservedFlag])[] = [...ROOT_OUTPUT_TOKENS].map(
+	([token, name]) => [
+		token,
+		{
+			rootSpelling: `--${name}`,
+			effect: 'The root strips that token before dispatch',
+			remedy: ROOT_OUTPUT_REMEDIES[name],
+		},
+	],
+);
+
+/**
+ * Reservation for `--help`/`-h`.
+ *
+ * The root intercepts the token when it precedes any command token, and the
+ * command executor renders help ahead of `parse()` otherwise, so neither path
+ * assigns the flag a value.
+ */
+const HELP_RESERVED: ReservedFlag = {
+	rootSpelling: '--help',
+	effect: 'A help request renders before flags are parsed',
+	remedy: RENAME,
+};
+
+/** Reservation for `--version`/`-V`, active once the CLI declares a version. */
+const VERSION_RESERVED: ReservedFlag = {
+	rootSpelling: '--version',
+	effect: 'The root intercepts that token before dispatch',
+	remedy: RENAME,
+};
+
+/** Tokens the root owns on every CLI, keyed by their bare spelling. */
+const ALWAYS_RESERVED: readonly (readonly [string, ReservedFlag])[] = [
+	...OUTPUT_RESERVED,
+	['help', HELP_RESERVED],
+	['h', HELP_RESERVED],
+];
+
+/** Tokens the root owns only once a version is configured. */
+const VERSION_TOKENS: readonly (readonly [string, ReservedFlag])[] = [
+	['version', VERSION_RESERVED],
+	['V', VERSION_RESERVED],
+];
+
+/** Reserved tokens with a version declared. */
+const RESERVED_WITH_VERSION: ReadonlyMap<string, ReservedFlag> = new Map([
+	...ALWAYS_RESERVED,
+	...VERSION_TOKENS,
+]);
+
+/** Reserved tokens without a version declared. */
+const RESERVED_WITHOUT_VERSION: ReadonlyMap<string, ReservedFlag> = new Map(ALWAYS_RESERVED);
+
+/** Which declaration on a flag produced a colliding spelling. @internal */
+type CollisionOrigin = 'name' | 'alias' | 'negation';
+
+/** One declared spelling that lands on a reserved token. @internal */
+interface ReservedCollision {
+	/** Command that declares the colliding flag. */
+	readonly commandName: string;
+	/** Canonical name of the colliding flag. */
+	readonly flagName: string;
+	/** Colliding spelling, dashes included. */
+	readonly spelling: string;
+	/** Which declaration on the flag produced the spelling. */
+	readonly origin: CollisionOrigin;
+	/** Root flag that owns the token. */
+	readonly reserved: ReservedFlag;
+}
+
+/** Render a bare token the way argv spells it. */
+function spellingOf(token: string): string {
+	return token.length === 1 ? `-${token}` : `--${token}`;
+}
+
+/** Every spelling one flag answers to, paired with the declaration it came from. */
+function flagSpellings(
+	flagName: string,
+	flagSchema: FlagSchema,
+): readonly (readonly [string, CollisionOrigin])[] {
+	const spellings: (readonly [string, CollisionOrigin])[] = [[flagName, 'name']];
+
+	for (const alias of getFlagAliasNames(flagSchema, { includeHidden: true })) {
+		spellings.push([alias, 'alias']);
+	}
+
+	const negated = getFlagNegatedName(flagName, flagSchema);
+	if (negated !== undefined) spellings.push([negated, 'negation']);
+
+	return spellings;
+}
+
+/**
+ * Find the first flag in a command tree whose spelling is reserved.
+ *
+ * @param schema - Command to walk, including its nested subcommands.
+ * @param reserved - Reserved tokens for the current CLI configuration.
+ * @returns The collision, or `undefined` when the tree is clean.
+ *
+ * @internal
+ */
+function findReservedCollision(
+	schema: CommandSchema,
+	reserved: ReadonlyMap<string, ReservedFlag>,
+): ReservedCollision | undefined {
+	for (const [flagName, flagSchema] of Object.entries(schema.flags)) {
+		for (const [token, origin] of flagSpellings(flagName, flagSchema)) {
+			const match = reserved.get(token);
+			if (match === undefined) continue;
+
+			return {
+				commandName: schema.name,
+				flagName,
+				spelling: spellingOf(token),
+				origin,
+				reserved: match,
+			};
+		}
+	}
+
+	for (const child of schema.commands) {
+		const nested = findReservedCollision(child, reserved);
+		if (nested !== undefined) return nested;
+	}
+
+	return undefined;
+}
+
+/** Describe the colliding declaration the way the error opens. */
+function subjectOf(collision: ReservedCollision): string {
+	switch (collision.origin) {
+		case 'name':
+			return `defines a '${collision.spelling}' flag`;
+		case 'alias':
+			return `defines a '${collision.spelling}' alias on flag '${collision.flagName}'`;
+		case 'negation':
+			return `defines a '${collision.spelling}' negated spelling on flag '${collision.flagName}'`;
+	}
+}
+
+/** Build the `RESERVED_FLAG` error for a collision. */
+function reservedFlagError(collision: ReservedCollision): CLIError {
+	return new CLIError(
+		`Command '${collision.commandName}' ${subjectOf(collision)}, which is reserved by the root '${collision.reserved.rootSpelling}' flag. ${collision.reserved.effect}, so the command can never receive it`,
+		{
+			code: 'RESERVED_FLAG',
+			details: { command: collision.commandName, flag: collision.flagName },
+			suggest: collision.reserved.remedy,
+		},
+	);
+}
+
+/**
+ * Reject command trees declaring a flag the CLI root already owns.
+ *
+ * @param version - The CLI's declared version; `undefined` leaves
+ *   `--version`/`-V` available to commands.
+ * @param commands - Command trees to walk. `undefined` entries are skipped so
+ *   callers can pass an absent default command directly.
+ * @throws {@linkcode CLIError} `RESERVED_FLAG` for the first collision found.
+ *
+ * @internal
+ */
+function assertNoReservedFlagCollisions(
+	version: string | undefined,
+	commands: readonly (CommandSchema | undefined)[],
+): void {
+	const reserved = version !== undefined ? RESERVED_WITH_VERSION : RESERVED_WITHOUT_VERSION;
+
+	for (const schema of commands) {
+		if (schema === undefined) continue;
+		const collision = findReservedCollision(schema, reserved);
+		if (collision !== undefined) throw reservedFlagError(collision);
+	}
+}
+
+export { assertNoReservedFlagCollisions };

--- a/src/core/cli/root-output-flags.ts
+++ b/src/core/cli/root-output-flags.ts
@@ -54,7 +54,7 @@ type RootOutputFlags = RootOutputFlagsOk | RootOutputFlagsFailed;
 type RootTokenMatch =
 	| { readonly kind: 'unrelated' }
 	| { readonly kind: 'flag'; readonly name: RootOutputFlagName; readonly selection: 'on' | 'off' }
-	| { readonly kind: 'invalid'; readonly error: ParseError };
+	| { readonly kind: 'invalid'; readonly name: RootOutputFlagName; readonly error: ParseError };
 
 /** The schema root `--json`/`--quiet` share with a command-level boolean flag. */
 const rootBooleanSchema = flag.boolean().schema;
@@ -90,7 +90,7 @@ function coerceRootValue(name: RootOutputFlagName, spelling: string, raw: string
 		const value = coerceFlagValue(name, raw, rootBooleanSchema, spelling);
 		return { kind: 'flag', name, selection: value === true ? 'on' : 'off' };
 	} catch (error: unknown) {
-		if (error instanceof ParseError) return { kind: 'invalid', error };
+		if (error instanceof ParseError) return { kind: 'invalid', name, error };
 		throw error;
 	}
 }
@@ -138,7 +138,7 @@ function readRootOutputFlags(argv: readonly string[]): RootOutputFlags {
 		quiet: 'absent',
 	};
 	const keptHead: string[] = [];
-	let error: ParseError | undefined;
+	const errors = new Map<RootOutputFlagName, ParseError>();
 	let stripped = false;
 
 	for (const token of head) {
@@ -149,10 +149,12 @@ function readRootOutputFlags(argv: readonly string[]): RootOutputFlags {
 		}
 		stripped = true;
 		if (match.kind === 'invalid') {
-			error ??= match.error;
+			errors.delete(match.name);
+			errors.set(match.name, match.error);
 			continue;
 		}
 		selections[match.name] = match.selection;
+		errors.delete(match.name);
 	}
 
 	const strippedArgv = !stripped
@@ -161,6 +163,7 @@ function readRootOutputFlags(argv: readonly string[]): RootOutputFlags {
 			? keptHead
 			: [...keptHead, ...argv.slice(separatorIndex)];
 	const resolved = { json: selections.json, quiet: selections.quiet, argv: strippedArgv };
+	const error = errors.values().next().value;
 
 	return error !== undefined ? { kind: 'failed', ...resolved, error } : { kind: 'ok', ...resolved };
 }

--- a/src/core/cli/root-output-flags.ts
+++ b/src/core/cli/root-output-flags.ts
@@ -68,6 +68,22 @@ const ROOT_LONG_SPELLINGS: ReadonlyMap<string, RootOutputFlagName> = new Map([
 /** Short spellings, which have no inline-value form. */
 const ROOT_SHORT_SPELLINGS: ReadonlyMap<string, RootOutputFlagName> = new Map([['-q', 'quiet']]);
 
+/**
+ * Every spelling this module strips, as a bare token without its dashes.
+ *
+ * The build-time `RESERVED_FLAG` guard reads this instead of restating the
+ * spellings, so a token added above is reserved on command flags in the same
+ * change.
+ *
+ * @internal
+ */
+const ROOT_OUTPUT_TOKENS: ReadonlyMap<string, RootOutputFlagName> = new Map(
+	[...ROOT_LONG_SPELLINGS, ...ROOT_SHORT_SPELLINGS].map(([spelling, name]) => [
+		spelling.replace(/^-+/, ''),
+		name,
+	]),
+);
+
 /** Coerce an inline `=value` the way a command-level boolean flag coerces it. */
 function coerceRootValue(name: RootOutputFlagName, spelling: string, raw: string): RootTokenMatch {
 	try {
@@ -183,5 +199,5 @@ function resolveRootVerbosity(
 	return override;
 }
 
-export type { RootOutputFlags };
-export { readRootOutputFlags, resolveRootJsonMode, resolveRootVerbosity };
+export type { RootOutputFlagName, RootOutputFlags };
+export { ROOT_OUTPUT_TOKENS, readRootOutputFlags, resolveRootJsonMode, resolveRootVerbosity };

--- a/src/core/cli/root-output-flags.ts
+++ b/src/core/cli/root-output-flags.ts
@@ -1,0 +1,187 @@
+/**
+ * The root output-flag layer: `--json` and `--quiet`/`-q`.
+ *
+ * These flags belong to the CLI root instead of any command schema, so every
+ * layer that needs the output mode (planner dispatch, `.execute()`, `.run()`
+ * preflight, `resolveRenderContext()`, testkit `runCommand()`) reads and strips
+ * them through {@linkcode readRootOutputFlags}. Values follow `flag.boolean()`:
+ * bare presence, `=true`/`=1`, `=false`/`=0`, last occurrence wins, and an
+ * invalid literal produces the parser's own `INVALID_VALUE` error.
+ *
+ * @module dreamcli/core/cli/root-output-flags
+ * @internal
+ */
+
+import { ParseError } from '#internals/core/errors/index.ts';
+import type { Verbosity } from '#internals/core/output/contracts.ts';
+import { coerceFlagValue } from '#internals/core/parse/index.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+
+/** Canonical name of a root output flag. @internal */
+type RootOutputFlagName = 'json' | 'quiet';
+
+/** What argv said about one root output flag. @internal */
+type RootFlagSelection = 'absent' | 'on' | 'off';
+
+/** Selections plus the argv the command layer should see. @internal */
+interface RootOutputFlagSelections {
+	/** Selection for `--json`. */
+	readonly json: RootFlagSelection;
+	/** Selection for `--quiet`/`-q`. */
+	readonly quiet: RootFlagSelection;
+	/** Argv with the pre-separator root output flags removed. */
+	readonly argv: readonly string[];
+}
+
+/** Every root output flag token carried a valid value. @internal */
+interface RootOutputFlagsOk extends RootOutputFlagSelections {
+	/** Discriminant. */
+	readonly kind: 'ok';
+}
+
+/** One token carried a value the boolean coercion rejected. @internal */
+interface RootOutputFlagsFailed extends RootOutputFlagSelections {
+	/** Discriminant. */
+	readonly kind: 'failed';
+	/** Error from the first rejected token. */
+	readonly error: ParseError;
+}
+
+/** Result of reading the root output flags out of argv. @internal */
+type RootOutputFlags = RootOutputFlagsOk | RootOutputFlagsFailed;
+
+/** One argv token resolved against the root output flags. */
+type RootTokenMatch =
+	| { readonly kind: 'unrelated' }
+	| { readonly kind: 'flag'; readonly name: RootOutputFlagName; readonly selection: 'on' | 'off' }
+	| { readonly kind: 'invalid'; readonly error: ParseError };
+
+/** The schema root `--json`/`--quiet` share with a command-level boolean flag. */
+const rootBooleanSchema = flag.boolean().schema;
+
+/** Long spellings, the only ones the tokenizer lets carry an inline `=value`. */
+const ROOT_LONG_SPELLINGS: ReadonlyMap<string, RootOutputFlagName> = new Map([
+	['--json', 'json'],
+	['--quiet', 'quiet'],
+]);
+
+/** Short spellings, which have no inline-value form. */
+const ROOT_SHORT_SPELLINGS: ReadonlyMap<string, RootOutputFlagName> = new Map([['-q', 'quiet']]);
+
+/** Coerce an inline `=value` the way a command-level boolean flag coerces it. */
+function coerceRootValue(name: RootOutputFlagName, spelling: string, raw: string): RootTokenMatch {
+	try {
+		const value = coerceFlagValue(name, raw, rootBooleanSchema, spelling);
+		return { kind: 'flag', name, selection: value === true ? 'on' : 'off' };
+	} catch (error: unknown) {
+		if (error instanceof ParseError) return { kind: 'invalid', error };
+		throw error;
+	}
+}
+
+/** Resolve one pre-separator argv token against the root output flags. */
+function matchRootToken(token: string): RootTokenMatch {
+	const shortName = ROOT_SHORT_SPELLINGS.get(token);
+	if (shortName !== undefined) return { kind: 'flag', name: shortName, selection: 'on' };
+
+	const bareName = ROOT_LONG_SPELLINGS.get(token);
+	if (bareName !== undefined) return { kind: 'flag', name: bareName, selection: 'on' };
+
+	const equals = token.indexOf('=');
+	if (equals === -1) return { kind: 'unrelated' };
+
+	const spelling = token.slice(0, equals);
+	const valuedName = ROOT_LONG_SPELLINGS.get(spelling);
+	if (valuedName === undefined) return { kind: 'unrelated' };
+
+	return coerceRootValue(valuedName, spelling, token.slice(equals + 1));
+}
+
+/**
+ * Read and strip the root output flags from argv.
+ *
+ * Only tokens before the `--` end-of-options separator are read or stripped, so
+ * a literal after `--` reaches the command unchanged (#28). Repeated
+ * occurrences follow the `'last'` duplicate policy `flag.boolean()` defaults to.
+ *
+ * A `'failed'` result still carries the selections and the stripped argv, so a
+ * valid `--json` governs how the failure renders and a help or version request
+ * can still be honoured ahead of it.
+ *
+ * @param argv - Raw argv tokens (excluding the binary/script path).
+ * @returns The selections, the stripped argv, and the first invalid value's
+ *   error when one occurred.
+ * @internal
+ */
+function readRootOutputFlags(argv: readonly string[]): RootOutputFlags {
+	const separatorIndex = argv.indexOf('--');
+	const head = separatorIndex === -1 ? argv : argv.slice(0, separatorIndex);
+
+	const selections: Record<RootOutputFlagName, RootFlagSelection> = {
+		json: 'absent',
+		quiet: 'absent',
+	};
+	const keptHead: string[] = [];
+	let error: ParseError | undefined;
+	let stripped = false;
+
+	for (const token of head) {
+		const match = matchRootToken(token);
+		if (match.kind === 'unrelated') {
+			keptHead.push(token);
+			continue;
+		}
+		stripped = true;
+		if (match.kind === 'invalid') {
+			error ??= match.error;
+			continue;
+		}
+		selections[match.name] = match.selection;
+	}
+
+	const strippedArgv = !stripped
+		? argv
+		: separatorIndex === -1
+			? keptHead
+			: [...keptHead, ...argv.slice(separatorIndex)];
+	const resolved = { json: selections.json, quiet: selections.quiet, argv: strippedArgv };
+
+	return error !== undefined ? { kind: 'failed', ...resolved, error } : { kind: 'ok', ...resolved };
+}
+
+/**
+ * Resolve JSON mode from the argv selection and an explicit override.
+ *
+ * An explicit `--json=false` wins over the override; the override applies when
+ * argv says nothing.
+ *
+ * @param flags - Result of {@linkcode readRootOutputFlags}.
+ * @param override - Caller-supplied `jsonMode`.
+ * @returns Whether the run renders JSON.
+ * @internal
+ */
+function resolveRootJsonMode(flags: RootOutputFlags, override: boolean | undefined): boolean {
+	if (flags.json === 'absent') return override === true;
+	return flags.json === 'on';
+}
+
+/**
+ * Resolve verbosity from the argv selection and an explicit override.
+ *
+ * @param flags - Result of {@linkcode readRootOutputFlags}.
+ * @param override - Caller-supplied verbosity.
+ * @returns `'quiet'` for `--quiet`, `'normal'` for `--quiet=false`, and the
+ *   override when argv says nothing.
+ * @internal
+ */
+function resolveRootVerbosity(
+	flags: RootOutputFlags,
+	override: Verbosity | undefined,
+): Verbosity | undefined {
+	if (flags.quiet === 'on') return 'quiet';
+	if (flags.quiet === 'off') return 'normal';
+	return override;
+}
+
+export type { RootOutputFlags };
+export { readRootOutputFlags, resolveRootJsonMode, resolveRootVerbosity };

--- a/src/core/cli/runtime-preflight.test.ts
+++ b/src/core/cli/runtime-preflight.test.ts
@@ -137,6 +137,33 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 		expect(preflight.schema.version).toBe('5.5.5');
 	});
 
+	it('rejects version flag collisions activated by discovered metadata', async () => {
+		const app = cli('myapp')
+			.manifest()
+			.command(
+				command('info')
+					.flag('version', flag.boolean())
+					.action(() => {}),
+			);
+		const adapter = createTestAdapter({
+			argv: ['node', 'test', 'info'],
+			readFile: async (path) => (path === '/test/package.json' ? '{"version":"5.5.5"}' : null),
+		});
+
+		const preflight = await prepareRuntimePreflight({
+			schema: app.schema,
+			compiled: compiledStateOf(app),
+			adapter,
+			options: undefined,
+			inheritedName: undefined,
+		});
+
+		expect(preflight.kind).toBe('config-error');
+		if (preflight.kind !== 'config-error') return;
+		expect(preflight.error.code).toBe('RESERVED_FLAG');
+		expect(preflight.error.details).toEqual({ command: 'info', flag: 'version' });
+	});
+
 	it('skips config discovery for completions invocations', async () => {
 		const readFile = vi.fn(async () => '{"deploy":{"region":"eu"}}');
 		const app = cli('myapp').config('myapp').completions();

--- a/src/core/cli/runtime-preflight.ts
+++ b/src/core/cli/runtime-preflight.ts
@@ -27,6 +27,7 @@ import type { CompiledCLI } from './compiled.ts';
 import type { HelpLinks } from './help-links.ts';
 import { deriveHelpLinks } from './help-links.ts';
 import { planInvocation } from './planner.ts';
+import { assertNoReservedFlagCollisions } from './reserved-flags.ts';
 import {
 	readRootOutputFlags,
 	resolveRootJsonMode,
@@ -426,6 +427,15 @@ async function prepareRuntimePreflight(
 		options.inheritedName,
 		isCompletions,
 	);
+	try {
+		assertNoReservedFlagCollisions(schema.version, [
+			options.compiled.defaultCommand?.schema,
+			...options.compiled.commands.map((compiled) => compiled.schema),
+		]);
+	} catch (error: unknown) {
+		if (error instanceof CLIError) return { kind: 'config-error', error, jsonMode };
+		throw error;
+	}
 	const loadedConfig = await loadRuntimeConfig(
 		schema,
 		options.adapter,

--- a/src/core/cli/runtime-preflight.ts
+++ b/src/core/cli/runtime-preflight.ts
@@ -18,7 +18,7 @@ import { CLIError, ParseError } from '#internals/core/errors/index.ts';
 import type { HelpThemeFactory } from '#internals/core/help/index.ts';
 import type { Verbosity } from '#internals/core/output/index.ts';
 import type { ParseOptions } from '#internals/core/parse/index.ts';
-import { includesBeforeSeparator, parse } from '#internals/core/parse/index.ts';
+import { parse } from '#internals/core/parse/index.ts';
 import type { PromptEngine } from '#internals/core/prompt/index.ts';
 import { createTerminalPrompter } from '#internals/core/prompt/index.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
@@ -27,6 +27,11 @@ import type { CompiledCLI } from './compiled.ts';
 import type { HelpLinks } from './help-links.ts';
 import { deriveHelpLinks } from './help-links.ts';
 import { planInvocation } from './planner.ts';
+import {
+	readRootOutputFlags,
+	resolveRootJsonMode,
+	resolveRootVerbosity,
+} from './root-output-flags.ts';
 
 /** Config discovery settings extracted from CLISchema for preflight use. @internal */
 interface RuntimeConfigSettings {
@@ -411,12 +416,9 @@ async function prepareRuntimePreflight(
 		options.schema.configSettings !== undefined
 			? extractConfigFlag(rawArgv)
 			: { configPath: undefined, filteredArgv: rawArgv };
-	// Only pre-separator occurrences count; a literal after `--` is a
-	// positional for the command (#28).
-	const hasJsonFlag = includesBeforeSeparator(filteredArgv, '--json');
-	const jsonMode = hasJsonFlag || options.options?.jsonMode === true;
-	const hasQuietFlag =
-		includesBeforeSeparator(filteredArgv, '--quiet') || includesBeforeSeparator(filteredArgv, '-q');
+	const rootOutputFlags = readRootOutputFlags(filteredArgv);
+	const jsonMode = resolveRootJsonMode(rootOutputFlags, options.options?.jsonMode);
+	const verbosity = resolveRootVerbosity(rootOutputFlags, options.options?.verbosity) ?? 'normal';
 	const isCompletions = isCompletionsInvocation(options.schema, options.compiled, filteredArgv);
 	const schema = await applyPackageJsonDiscovery(
 		options.schema,
@@ -458,7 +460,7 @@ async function prepareRuntimePreflight(
 			env: options.options?.env ?? options.adapter.env,
 			isTTY: options.options?.isTTY ?? options.adapter.isTTY,
 			jsonMode,
-			verbosity: hasQuietFlag ? 'quiet' : (options.options?.verbosity ?? 'normal'),
+			verbosity,
 			stat: options.options?.stat ?? options.adapter.stat,
 			mkdir: options.options?.mkdir ?? options.adapter.mkdir,
 			...(stdinData !== undefined ? { stdinData } : {}),

--- a/src/core/completion/completion.test.ts
+++ b/src/core/completion/completion.test.ts
@@ -2032,7 +2032,9 @@ describe('generateZshCompletion', () => {
 
 	describe('multi-short-alias exclusion groups', () => {
 		it('includes all short aliases in exclusion group', () => {
+			// `-V` is reserved by root `--version`, so this schema declares no version.
 			const schema = minimalSchema({
+				version: undefined,
 				commands: [
 					commandSchema({
 						name: 'deploy',

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -18,7 +18,7 @@ import { formatHelp } from '#internals/core/help/index.ts';
 import { generateCommandSchema } from '#internals/core/json-schema/index.ts';
 import type { CapturedOutput } from '#internals/core/output/index.ts';
 import { clearRequestedExitCode, getRequestedExitCode } from '#internals/core/output/index.ts';
-import { includesBeforeSeparator, parse } from '#internals/core/parse/index.ts';
+import { parse, requestsHelp } from '#internals/core/parse/index.ts';
 import { createTestPrompter } from '#internals/core/prompt/index.ts';
 import type { DeprecationWarning, ResolveOptions } from '#internals/core/resolve/index.ts';
 import { resolve } from '#internals/core/resolve/index.ts';
@@ -87,7 +87,7 @@ async function executeCommand(request: CommandExecutionRequest): Promise<Command
 	clearRequestedExitCode(out);
 
 	try {
-		if (includesBeforeSeparator(argv, '--help') || includesBeforeSeparator(argv, '-h')) {
+		if (requestsHelp(argv)) {
 			// `options.jsonMode` carries the resolved JSON mode from the CLI/testkit
 			// layer (root `--json` is stripped from argv pre-dispatch) — an injected
 			// `out` may predate it, so the channel flag alone is not authoritative.

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -500,12 +500,12 @@ describe('generateSchema — definition metadata', () => {
 			name: 'test',
 			flags: {
 				verbose: flagDef({ propagate: true }),
-				quiet: flagDef({ propagate: false }),
+				silent: flagDef({ propagate: false }),
 			},
 		});
 		const result = generateSchema(minimalCLI({ commands: [cmd] }));
 		expect(result).toHaveProperty(['commands', 0, 'flags', 'verbose', 'propagate'], true);
-		expect(result).not.toHaveProperty(['commands', 0, 'flags', 'quiet', 'propagate']);
+		expect(result).not.toHaveProperty(['commands', 0, 'flags', 'silent', 'propagate']);
 	});
 
 	it('serializes negation settings on negatable flags', () => {

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -128,6 +128,20 @@ function includesBeforeSeparator(argv: readonly string[], token: string): boolea
 }
 
 /**
+ * Whether argv asks for help before the `--` end-of-options separator.
+ *
+ * Help renders ahead of flag validation everywhere: a command short-circuits to
+ * its help text before `parse()` runs, and the root does the same before
+ * dispatch, so a malformed flag value never hides the text explaining the flags.
+ *
+ * @param argv - Raw argument strings.
+ * @returns `true` if `--help` or `-h` occurs before any `--` separator.
+ */
+function requestsHelp(argv: readonly string[]): boolean {
+	return includesBeforeSeparator(argv, '--help') || includesBeforeSeparator(argv, '-h');
+}
+
+/**
  * Remove every occurrence of `token` that appears before the `--` end-of-options
  * separator, leaving post-separator literals untouched.
  *
@@ -985,10 +999,12 @@ export type { FlagLookupEntry, ParseOptions, ParseResult, Token };
 export {
 	buildFlagLookup,
 	camelToKebab,
+	coerceFlagValue,
 	flagExpectsValue,
 	includesBeforeSeparator,
 	kebabToCamel,
 	parse,
+	requestsHelp,
 	stripBeforeSeparator,
 	tokenize,
 };

--- a/src/core/parse/parse.test.ts
+++ b/src/core/parse/parse.test.ts
@@ -6,7 +6,7 @@ import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { createCommandSchema } from '#internals/core/schema/command.ts';
 import type { FlagDefinitionOverrides, FlagSchema } from '#internals/core/schema/flag.ts';
 import { createFlagSchema } from '#internals/core/schema/flag.ts';
-import { includesBeforeSeparator, parse, tokenize } from './index.ts';
+import { includesBeforeSeparator, parse, requestsHelp, tokenize } from './index.ts';
 
 // --- Helpers — build minimal CommandSchema for testing
 
@@ -925,6 +925,23 @@ describe('includesBeforeSeparator()', () => {
 	it('returns false when the token is absent', () => {
 		expect(includesBeforeSeparator(['--other'], '--version')).toBe(false);
 		expect(includesBeforeSeparator([], '--version')).toBe(false);
+	});
+});
+
+describe('requestsHelp()', () => {
+	it('accepts both help spellings before the -- separator', () => {
+		expect(requestsHelp(['deploy', '--help'])).toBe(true);
+		expect(requestsHelp(['deploy', '-h'])).toBe(true);
+	});
+
+	it('ignores a post-separator help literal', () => {
+		expect(requestsHelp(['deploy', '--', '--help'])).toBe(false);
+		expect(requestsHelp(['deploy', '--', '-h'])).toBe(false);
+	});
+
+	it('returns false without a help token', () => {
+		expect(requestsHelp(['deploy', '--force'])).toBe(false);
+		expect(requestsHelp([])).toBe(false);
 	});
 });
 

--- a/src/core/testkit/index.ts
+++ b/src/core/testkit/index.ts
@@ -14,10 +14,15 @@
  * @module dreamcli/core/testkit
  */
 
+import {
+	readRootOutputFlags,
+	resolveRootJsonMode,
+	resolveRootVerbosity,
+} from '#internals/core/cli/root-output-flags.ts';
 import { buildRunResult, executeCommand } from '#internals/core/execution/index.ts';
 import type { CapturedOutput, Verbosity } from '#internals/core/output/index.ts';
 import { createCaptureOutput } from '#internals/core/output/index.ts';
-import { includesBeforeSeparator, stripBeforeSeparator } from '#internals/core/parse/index.ts';
+import { requestsHelp } from '#internals/core/parse/index.ts';
 import type { CommandMeta, Out, RunnableCommand } from '#internals/core/schema/command.ts';
 import type { InternalRunOptions, RunOptions, RunResult } from '#internals/core/schema/run.ts';
 
@@ -47,6 +52,8 @@ import type { InternalRunOptions, RunOptions, RunResult } from '#internals/core/
  *   and stripped here, just like the real CLI root — so `['--json']` enables
  *   JSON mode and `['--quiet']` sets quiet verbosity rather than failing as
  *   unknown flags. Equivalent to `{ jsonMode: true }` / `{ verbosity: 'quiet' }`.
+ *   Both accept an explicit value (`--json=false`), and an invalid one fails
+ *   with the same `INVALID_VALUE` error the CLI root produces.
  * @param options - Injectable runtime state
  * @returns Structured run result with exit code and captured output
  */
@@ -69,21 +76,18 @@ async function runCommandInternal(
 	argv: readonly string[],
 	options?: InternalRunOptions,
 ): Promise<RunResult> {
-	// Root-flag layer mirroring `CLIBuilder.execute()`: `--json` is owned by the
-	// CLI root, not the command schema, so it would otherwise reach `parse()` as
-	// an unknown flag (#33). Detect it before the `--` separator (a literal
-	// `--json` positional after `--` survives), enable JSON mode, and strip it so
-	// the command schema never sees it. The explicit `options.jsonMode` keeps
-	// working — either source enables JSON mode.
-	const hasJsonFlag = includesBeforeSeparator(argv, '--json');
-	const jsonMode = hasJsonFlag || options?.jsonMode === true;
-	const hasQuietFlag =
-		includesBeforeSeparator(argv, '--quiet') || includesBeforeSeparator(argv, '-q');
-	const verbosity: Verbosity | undefined = hasQuietFlag ? 'quiet' : options?.verbosity;
-	let effectiveArgv = hasJsonFlag ? stripBeforeSeparator(argv, '--json') : argv;
-	if (hasQuietFlag) {
-		effectiveArgv = stripBeforeSeparator(stripBeforeSeparator(effectiveArgv, '--quiet'), '-q');
-	}
+	// Root-flag layer mirroring `CLIBuilder.execute()`: `--json` and `--quiet`
+	// are owned by the CLI root, not the command schema, so they would otherwise
+	// reach `parse()` as unknown flags (#33). The shared reader detects them,
+	// strips them, and rejects an invalid `=value` exactly as dispatch does. The
+	// explicit `options.jsonMode` keeps working when argv says nothing.
+	const rootOutputFlags = readRootOutputFlags(argv);
+	const jsonMode = resolveRootJsonMode(rootOutputFlags, options?.jsonMode);
+	const verbosity: Verbosity | undefined = resolveRootVerbosity(
+		rootOutputFlags,
+		options?.verbosity,
+	);
+	const effectiveArgv = rootOutputFlags.argv;
 
 	let out: Out;
 	let captured: CapturedOutput;
@@ -99,6 +103,19 @@ async function runCommandInternal(
 		[out, captured] = createCaptureOutput(
 			Object.keys(captureOptions).length > 0 ? captureOptions : undefined,
 		);
+	}
+
+	if (rootOutputFlags.kind === 'failed' && !requestsHelp(effectiveArgv)) {
+		const { error } = rootOutputFlags;
+		if (jsonMode) {
+			out.json({ error: error.toJSON() });
+		} else {
+			out.error(error.message);
+			if (error.suggest !== undefined) {
+				out.error(`Suggestion: ${error.suggest}`);
+			}
+		}
+		return buildRunResult({ exitCode: error.exitCode, error }, captured);
 	}
 
 	// Use merged schema (with propagated flags) when provided by dispatch layer,

--- a/src/core/testkit/testkit-json.test.ts
+++ b/src/core/testkit/testkit-json.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { cli } from '#internals/core/cli/index.ts';
 import { CLIError } from '#internals/core/errors/index.ts';
 import { arg } from '#internals/core/schema/arg.ts';
 import { command } from '#internals/core/schema/command.ts';
@@ -332,6 +333,122 @@ describe('runCommand', () => {
 			// JSON mode redirects `log` to stderr; `status` stays suppressed.
 			expect(result.stdout).toEqual([]);
 			expect(result.stderr).toEqual(['result\n']);
+		});
+	});
+
+	// --- Root flags with an explicit value (#85)
+
+	describe('root-flag layer — explicit values (#85)', () => {
+		/** Command emitting one status line (quiet-suppressible) and one log line. */
+		function noisyCommand() {
+			return command('noisy').action(({ out }) => {
+				out.log('result');
+				out.status('working');
+			});
+		}
+
+		/** The same command run through real CLI dispatch, for parity assertions. */
+		async function throughCli(argv: readonly string[]) {
+			return cli('mycli').default(noisyCommand()).execute(argv);
+		}
+
+		it('--quiet=true suppresses status, --quiet=false keeps it', async () => {
+			const quiet = await runCommand(noisyCommand(), ['--quiet=true']);
+			expect(quiet.exitCode).toBe(0);
+			expect(quiet.stdout).toEqual(['result\n']);
+			expect(quiet.stderr).toEqual([]);
+
+			const loud = await runCommand(noisyCommand(), ['--quiet=false']);
+			expect(loud.stdout).toEqual(['result\n']);
+			expect(loud.stderr).toEqual(['working\n']);
+		});
+
+		it('--json=true redirects log to stderr, --json=false does not', async () => {
+			const json = await runCommand(noisyCommand(), ['--json=true']);
+			expect(json.stdout).toEqual([]);
+			expect(json.stderr).toEqual(['result\n', 'working\n']);
+
+			const human = await runCommand(noisyCommand(), ['--json=false']);
+			expect(human.stdout).toEqual(['result\n']);
+			expect(human.stderr).toEqual(['working\n']);
+		});
+
+		it('takes the last occurrence of a repeated flag', async () => {
+			const result = await runCommand(noisyCommand(), ['--quiet', '--quiet=false']);
+
+			expect(result.stderr).toEqual(['working\n']);
+		});
+
+		it('combines --json=true with --quiet=false', async () => {
+			const result = await runCommand(noisyCommand(), ['--json=true', '--quiet=false']);
+
+			expect(result.stdout).toEqual([]);
+			expect(result.stderr).toEqual(['result\n', 'working\n']);
+		});
+
+		it('leaves a post-separator --json=true for the command', async () => {
+			const cmd = command('echo')
+				.arg('value', arg.string())
+				.action(({ args, out }) => {
+					out.log(args.value);
+				});
+
+			const result = await runCommand(cmd, ['--', '--json=true']);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toEqual(['--json=true\n']);
+		});
+
+		it('rejects an invalid value exactly as CLI dispatch does', async () => {
+			const harness = await runCommand(noisyCommand(), ['--quiet=banana']);
+			const dispatched = await throughCli(['--quiet=banana']);
+
+			expect(harness.exitCode).toBe(2);
+			expect(harness.error?.code).toBe('INVALID_VALUE');
+			expect(harness.stderr).toEqual([
+				"Invalid boolean value 'banana' for flag --quiet. Use true/false or 1/0\n",
+			]);
+			expect(harness.exitCode).toBe(dispatched.exitCode);
+			expect(harness.stdout).toEqual(dispatched.stdout);
+			expect(harness.stderr).toEqual(dispatched.stderr);
+		});
+
+		it('renders an invalid value as JSON when --json is also set', async () => {
+			const harness = await runCommand(noisyCommand(), ['--json', '--quiet=banana']);
+			const dispatched = await throughCli(['--json', '--quiet=banana']);
+
+			expect(harness.exitCode).toBe(2);
+			expect(harness.stdout.length).toBe(1);
+			const parsed = JSON.parse(harness.stdout[0] ?? '');
+			expect(parsed.error.code).toBe('INVALID_VALUE');
+			expect(parsed.error.details).toEqual({
+				flag: 'quiet',
+				input: '--quiet',
+				value: 'banana',
+				expected: 'boolean',
+			});
+			expect(harness.stdout).toEqual(dispatched.stdout);
+			expect(harness.stderr).toEqual(dispatched.stderr);
+		});
+
+		it('renders --help ahead of an invalid value, as CLI dispatch does', async () => {
+			const harness = await runCommand(noisyCommand(), ['--help', '--quiet=banana']);
+			const dispatched = await throughCli(['--help', '--quiet=banana']);
+
+			expect(harness.exitCode).toBe(0);
+			expect(harness.stdout.join('')).toContain('Usage: noisy');
+			expect(harness.exitCode).toBe(dispatched.exitCode);
+			expect(harness.stderr).toEqual(dispatched.stderr);
+		});
+
+		it('leaves -q=true to the command, as CLI dispatch does', async () => {
+			const harness = await runCommand(noisyCommand(), ['-q=true']);
+			const dispatched = await throughCli(['-q=true']);
+
+			expect(harness.exitCode).toBe(2);
+			expect(harness.error?.code).toBe('UNKNOWN_FLAG');
+			expect(harness.exitCode).toBe(dispatched.exitCode);
+			expect(harness.stderr).toEqual(dispatched.stderr);
 		});
 	});
 });


### PR DESCRIPTION
Targets v4. Stacked on #106. Two commits, one per issue.

**`=value` forms at the root (#85)**
- `--quiet=value` and `--json=value` now parse with the exact `flag.boolean()` contract: same accepted literals (`true`/`1`/`false`/`0`), same `INVALID_VALUE` error and exit 2, same last-wins duplicate handling, coerced by the parser's own `coerceFlagValue` so there is one implementation. `-q=value` stays rejected because command-level short flags reject it too.
- All five former bare-token scan sites (planner, `executeCLI`, `resolveRenderContext`, runtime preflight, testkit) read through one shared `readRootOutputFlags` helper; the `--` separator tail stays untouched.
- Review escalation, fixed in this PR: the first cut let a malformed value pre-empt `--version`/`--help`, a regression against 3.x where the unknown token lost to interception. A shared `requestsHelp` predicate now keeps help/version winning, matching the command level.
- Explicit argv beats `RenderContextOptions` overrides now that argv can say `=false`; the option docs state the precedence.

**Breaking: RESERVED_FLAG guard (#84)**
- Registering a command whose flag name, alias, or negated spelling matches a root-owned token throws `CLIError` code `RESERVED_FLAG` at build time instead of leaving the flag silently dead (the importmapify failure mode). Reserved always: `quiet`, `json`, `q`, `help`, `h`. Reserved once a version exists: `version`, `V`, enforced in both call orders through `.version()` and `.manifest(data)`.
- Both construction paths (builder and `createCLISchema`) run the one guard; the reserved set derives from the root scanner's own token table so the two cannot drift.
- Review escalations, fixed in this PR: negated spellings (`.negatable({ alias: 'quiet' })`) slipped past the guard and silently broke; the completions guard had the identical hole plus a definition-path gap; the error text claimed help is "stripped" when a help request actually renders before flags are parsed.
- Known gap called out in the upgrade guide: bare `.manifest()` filesystem discovery injects a version at run time; #109 closes it.

Gates per commit: typecheck, lint, fmt, full suite (3024 then 3077 tests), build with attw+publint, docs build. Upgrade guide section included.

Closes #85
Closes #84
