### PR TITLE
feat(cli): let consumers take over built-in flags with `.builtins()` (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,33 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `CommandArgEntryDefinition`; and `CLIDefinition` with
   `ConfigSettingsDefinition`. All of them are exported from the package root.
 
+- **`.builtins()` takes `--help`, `--json`, or `--quiet` over to the commands**
+  ([#86](https://github.com/kjanat/dreamcli/issues/86)). A CLI whose `--json`
+  names the document it operates on, whose `-q` means something domain-specific,
+  or whose `--help` is a routable topic browser can now claim the token.
+  `cli('mycli').builtins({ json: 'off' })` releases every spelling that built-in
+  answers to. The root stops reading and stripping it from argv, root help stops
+  listing it under `Global options:`, the `RESERVED_FLAG` guard stops reserving
+  it, and a command may declare it as an ordinary flag that parses and reaches
+  the handler. Releasing `help` also disables command-level `--help`/`-h`, the
+  bare `help` token, the `--help` footer hint, the
+  `Run '<bin> --help' for available commands` suggestion on dispatch errors, and
+  the synthetic `--help` in generated completion scripts. `version` and
+  `completions` have no entry, since `.version()` and `.completions()` are
+  opt-in and a CLI declines those by omission. Every built-in defaults to
+  `'on'`, repeated calls merge with the last mode per built-in winning, and
+  `RunOptions.jsonMode` / `RunOptions.verbosity` keep working regardless, since
+  only argv-driven activation is disabled. The state is normalized onto
+  `CLISchema.builtins` by both `.builtins()` and the `builtins` field of
+  `createCLISchema()`, an invalid mode throws `INVALID_SCHEMA`, and
+  `BuiltinsConfig`, `Builtins`, `BuiltinName`, and `BuiltinMode` are exported
+  from the package root. `runCommand()` from `/testkit` takes the same
+  `builtins` option so a command owning a released flag can be tested; its
+  options type is now `RunCommandOptions`. The `RESERVED_FLAG` error offers
+  `.builtins({ <name>: 'off' })` alongside renaming, and a version discovered by
+  `.manifest()` filesystem walking now runs the same guard at `.run()` time
+  instead of silently shadowing a command's `version` flag.
+
 - **Definition format v1 — versioned, typed documents** — `generateSchema()`
   and `generateCommandSchema()` now emit `schemaVersion: 1`, so a consumer can
   tell which format it is reading before parsing the rest. Both return typed

--- a/docs/.vitepress/data/symbol-pages.test.ts
+++ b/docs/.vitepress/data/symbol-pages.test.ts
@@ -106,8 +106,10 @@ describe('symbol page generation', () => {
 		const middlewareFactoryPage = pages.find((page) => page.id === '@kjanat/dreamcli:middleware');
 
 		expect(runCommandPage?.content).toContain('| Parameter | Type | Description |');
-		expect(runCommandPage?.content).toContain('| `options` | `RunOptions \\| undefined` |');
-		expect(runCommandPage?.content).not.toContain('| `options` | `RunOptions \\\\| undefined` |');
+		expect(runCommandPage?.content).toContain('| `options` | `RunCommandOptions \\| undefined` |');
+		expect(runCommandPage?.content).not.toContain(
+			'| `options` | `RunCommandOptions \\\\| undefined` |',
+		);
 		expect(runOptionsPage?.content).toContain('stdinData?: string | null;');
 		expect(cliRunOptionsPage?.content).toContain('stdinData?: string | null;');
 		expect(runtimeAdapterPage?.content).toContain('Promise<string | null>');

--- a/docs/guide/help.md
+++ b/docs/guide/help.md
@@ -4,6 +4,11 @@ Help text is generated from your schemas — usage line, arguments, flags,
 subcommands, and examples all render automatically for `--help`, `-h`,
 `help <command>`, and root help.
 
+Those three tokens belong to the root, so a command cannot declare a `help`
+flag or an `h` alias. A CLI that needs the token for itself releases it with
+`.builtins({ help: 'off' })`. See
+[Taking a built-in over](/guide/output#taking-a-built-in-over).
+
 ## Configuring Help
 
 `.help()` sets builder-level defaults; the same fields can be overridden per

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -86,8 +86,9 @@ the same way could never be set, so declaring one throws `RESERVED_FLAG`.
 Naming a flag `quiet`, `json`, or `help`, aliasing one to `q` or `h`, or giving
 one a negated spelling like `.negatable({ alias: 'quiet' })` is rejected by
 `.command()`, `.default()`, and `createCLISchema()`, and `version`/`V` join
-that set once a version is configured. Rename the flag, or use `out.status()`
-for status output that root `--quiet` suppresses.
+that set once a version is configured. Rename the flag, use `out.status()` for
+status output that root `--quiet` suppresses, or release the built-in with
+`.builtins()`.
 
 | Method   | Stream                      | Suppressed by quiet |
 | -------- | --------------------------- | ------------------- |
@@ -96,6 +97,85 @@ for status output that root `--quiet` suppresses.
 | `status` | stderr                     | yes                 |
 | `warn`   | stderr                     | no                  |
 | `error`  | stderr                     | no                  |
+
+### Taking a built-in over
+
+Some CLIs need the token for themselves. `--json` names the document the
+command operates on, `-q` means something domain-specific, `--help` is a
+routable topic browser. `.builtins()` releases a built-in to the commands.
+
+```ts twoslash
+import { cli, command, flag } from '@kjanat/dreamcli';
+
+const validate = command('validate')
+  .flag('json', flag.string().describe('Document to validate'))
+  .action(({ flags, out }) => {
+    out.log(`Validating ${flags.json}`);
+  });
+
+cli('schematool')
+  .builtins({ json: 'off' })
+  .command(validate);
+```
+
+```sh
+$ schematool validate --json schema.yaml
+Validating schema.yaml
+$ schematool validate --json=schema.yaml
+Validating schema.yaml
+```
+
+Every built-in starts `'on'`. Setting one to `'off'` releases every spelling it
+answers to. The root stops reading and stripping the token, `Global options:`
+stops listing it, the `RESERVED_FLAG` guard stops reserving it, and the
+command's own flag parses and reaches the handler. `quiet: 'off'` releases both
+`--quiet` and `-q`. `help: 'off'` releases `--help` and `-h` at the root and at
+the command level, along with the bare `help` token, the `--help` footer hint,
+the `Run '<bin> --help' for available commands` suggestion on dispatch errors,
+and the synthetic `--help` in generated completion scripts. A bare invocation
+is unaffected, so `schematool` with no arguments still renders root help when
+the CLI has no default command.
+
+Call `.builtins()` before registering the commands that declare a released
+flag. `.command()` checks against the state it has, so the reverse order throws
+`RESERVED_FLAG`:
+
+```
+Command 'validate' defines a '--json' flag, which is reserved by the root
+'--json' flag. The root strips that token before dispatch, so the command can
+never receive it
+```
+
+Its suggestion names both remedies, `Rename the flag, or release the built-in
+with .builtins({ json: 'off' }) before registering the command`. The `quiet`
+variant adds `use out.status() for output that root --quiet suppresses`.
+
+Repeated calls merge, the last mode per built-in winning, and taking a built-in
+back with `'on'` re-checks every registered command.
+
+`version` and `completions` have no entry. `.version()` and `.completions()`
+are opt-in, so a CLI declines those two by not calling them.
+
+Only argv-driven activation is disabled. `RunOptions.jsonMode` and
+`RunOptions.verbosity` keep working, so `.execute(argv, { jsonMode: true })`
+still renders JSON with `json: 'off'`. In tests, pass the same setting to
+`runCommand()` so the harness mirrors the CLI the command is registered on:
+
+```ts twoslash
+import { command, flag } from '@kjanat/dreamcli';
+
+const validate = command('validate')
+  .flag('json', flag.string())
+  .action(({ flags, out }) => {
+    out.log(`Validating ${flags.json}`);
+  });
+// ---cut---
+import { runCommand } from '@kjanat/dreamcli/testkit';
+
+const result = await runCommand(validate, ['--json', 'schema.yaml'], {
+  builtins: { json: 'off' },
+});
+```
 
 ## Tables
 

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -47,8 +47,11 @@ Command 'build' defines a '--quiet' flag, which is reserved by the root
 can never receive it
 ```
 
-Rename the flag, or drop it and let root `--quiet` govern the output through
-`out.status()`:
+The error's suggestion names the remedies, `Rename the flag, use out.status()
+for output that root --quiet suppresses, or release the built-in with
+.builtins({ quiet: 'off' }) before registering the command`.
+
+Renaming and `out.status()` cover a command that never wanted the token:
 
 ```ts
 // 4.0
@@ -58,13 +61,31 @@ const build = command('build').action(({ out }) => {
 });
 ```
 
+A command that really does own the token keeps its flag and takes the built-in
+over instead. `--json` naming a document and `-q` meaning something
+domain-specific are the usual cases:
+
+```ts
+// 4.0
+cli('mycli')
+  .builtins({ quiet: 'off' })
+  .command(build);
+```
+
+`.builtins()` has to come first, since `.command()` checks against the state it
+has. See [Taking a built-in over](/guide/output#taking-a-built-in-over) for
+what `'off'` releases.
+
 The check reads each flag's canonical name, every alias including hidden ones,
 and a custom negated spelling from `.negatable({ alias: 'quiet' })`, through
 the whole subcommand tree. `.command()`, `.default()`, `.version()`,
 `.manifest(data)`, and `createCLISchema()` all run it, so a `version` flag
-throws whether the command is registered before or after `.version()`.
-`--completions` is reserved on the same terms once
-`.completions({ as: 'flag' })` or `CLIDefinition.completionsFlag` is set.
+throws whether the command is registered before or after `.version()`. A
+version that `.manifest()` reads off the filesystem arrives past every one of
+those, so `.run()` runs the same guard again once discovery supplies it, and
+the startup fails with the identical error. `--completions` is reserved on the
+same terms once `.completions({ as: 'flag' })` or
+`CLIDefinition.completionsFlag` is set.
 
 Near misses stay legal: `quietMode` and `jsonOutput` as names, `-Q` and `-j` as
 aliases, the default `--no-<name>` negated spelling, and a `version` flag on a
@@ -365,6 +386,10 @@ Adopt at your own pace; none of these are required:
 - **Verbosity in handler code**: `out.verbosity` and
   `resolveRenderContext().verbosity` expose the active level for custom
   rendering built inside or before a run.
+- **Consumer-owned built-in flags**: `.builtins({ help | json | quiet: 'off' })`
+  hands a root-owned token to the commands, for a CLI whose `--json`, `-q`, or
+  `--help` means something of its own. See
+  [Taking a built-in over](/guide/output#taking-a-built-in-over).
 
 See the [CHANGELOG](https://github.com/kjanat/dreamcli/blob/master/CHANGELOG.md)
 for the complete record.

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -386,8 +386,9 @@ Adopt at your own pace; none of these are required:
 - **Verbosity in handler code**: `out.verbosity` and
   `resolveRenderContext().verbosity` expose the active level for custom
   rendering built inside or before a run.
-- **Consumer-owned built-in flags**: `.builtins({ help | json | quiet: 'off' })`
-  hands a root-owned token to the commands, for a CLI whose `--json`, `-q`, or
+- **Consumer-owned built-in flags**: `.builtins({ help: 'off' })`,
+  `.builtins({ json: 'off' })`, or `.builtins({ quiet: 'off' })` hands a
+  root-owned token to the commands, for a CLI whose `--json`, `-q`, or
   `--help` means something of its own. See
   [Taking a built-in over](/guide/output#taking-a-built-in-over).
 

--- a/docs/reference/stability.md
+++ b/docs/reference/stability.md
@@ -45,7 +45,7 @@ When the match is ambiguous, the stricter contract applies.
 ## Sealed framework values
 
 `Out`, `RenderContext`, `FlagSchema`, `ArgSchema`, `CommandSchema`, `CLISchema`,
-and `ConfigSettings`.
+`ConfigSettings`, and `Builtins`.
 
 Each carries a brand a consumer cannot spell. `Out` and `RenderContext` carry a
 `unique symbol` that no entrypoint exports. The schema family carries a
@@ -58,8 +58,8 @@ Obtain instances from the framework:
 - `RenderContext` from `resolveRenderContext()`.
 - `FlagSchema`, `ArgSchema`, `CommandSchema` from `createFlagSchema()`,
   `createArgSchema()`, `createCommandSchema()`, or the corresponding builders.
-- `CLISchema` and its `ConfigSettings` from `createCLISchema()`, or from
-  `cli(...).schema`.
+- `CLISchema` with its nested `ConfigSettings` and `Builtins` from
+  `createCLISchema()`, or from `cli(...).schema`.
 
 The guarantee is one-directional. New readonly members may appear in a minor
 release, and code that reads documented members keeps compiling. Code that
@@ -134,6 +134,12 @@ const [out] = createCaptureOutput();
 vi.spyOn(out, 'info');
 ```
 
+`Builtins` is the normalized built-in-flag state stored on `CLISchema.builtins`.
+Every key is present and typed `BuiltinMode` after normalization, whatever
+subset of them the caller supplied. The consumer-facing input form is
+`BuiltinsConfig`, which is a
+[transparent input definition](#transparent-input-definitions).
+
 The compiled execution graph behind a program is not in this category because it
 is not exported at all. See [Internal surface](#internal-surface).
 
@@ -142,9 +148,9 @@ is not exported at all. See [Internal surface](#internal-surface).
 Option objects the caller constructs and passes in.
 
 Program and execution options: `CLIOptions`, `CLIExecuteOptions`, `CLIRunOptions`,
-`RunOptions` (from `@kjanat/dreamcli/testkit`), `DefaultCommandOptions`,
-`ManifestSettings` with its name-inference value type `InferNameOption`,
-`ManifestDiscoveryOptions`, `ConfigDiscoveryOptions`, and
+`RunOptions` and `RunCommandOptions` (both from `@kjanat/dreamcli/testkit`),
+`DefaultCommandOptions`, `ManifestSettings` with its name-inference value type
+`InferNameOption`, `ManifestDiscoveryOptions`, `ConfigDiscoveryOptions`, and
 `PackageRepositoryUrlOptions`.
 
 Pipeline and rendering options: `ParseOptions`, `ResolveOptions`, `OutputOptions`,
@@ -180,7 +186,10 @@ major release.
 `CLIExecuteOptions` and `CLIRunOptions` sit on top of `RunOptions`.
 `CLIExecuteOptions` is the process-free surface with every input injected
 explicitly. `CLIRunOptions` adds the runtime adapter that `.run()` uses to reach
-the process.
+the process. `RunCommandOptions` extends `RunOptions` the same way for
+`runCommand()`, adding the `builtins` state the testkit harness mirrors from
+the CLI a command is registered on. The field stays off `RunOptions` itself,
+where the CLI schema is authoritative.
 
 `HelpTheme` is the one entry whose every member is required. A theme reaches the
 framework as the `Partial<HelpTheme>` returned by a `HelpThemeFactory`, so a new
@@ -191,13 +200,14 @@ compiling. The factory form is the supported way to supply one.
 
 Plain object types a consumer writes by hand or a code generator emits.
 
-`FlagDefinition`, `ArgDefinition`, `CommandDefinition`, `CLIDefinition`, and
-`ConfigSettingsDefinition`; the shared bases `FlagDefinitionBase` and
-`ArgDefinitionBase`; the per-kind variants `StringFlagDefinition`,
-`NumberFlagDefinition`, `BooleanFlagDefinition`, `EnumFlagDefinition`,
-`ArrayFlagDefinition`, `CustomFlagDefinition`, `CountFlagDefinition`,
-`KeyValueFlagDefinition`, `StringArgDefinition`, `NumberArgDefinition`,
-`EnumArgDefinition`, `CustomArgDefinition`; the kind-indexed maps
+`FlagDefinition`, `ArgDefinition`, `CommandDefinition`, `CLIDefinition`,
+`ConfigSettingsDefinition`, and `BuiltinsConfig`; the shared bases
+`FlagDefinitionBase` and `ArgDefinitionBase`; the per-kind variants
+`StringFlagDefinition`, `NumberFlagDefinition`, `BooleanFlagDefinition`,
+`EnumFlagDefinition`, `ArrayFlagDefinition`, `CustomFlagDefinition`,
+`CountFlagDefinition`, `KeyValueFlagDefinition`, `StringArgDefinition`,
+`NumberArgDefinition`, `EnumArgDefinition`, `CustomArgDefinition`; the
+kind-indexed maps
 `FlagDefinitionByKind` and `ArgDefinitionByKind`; the override forms
 `FlagDefinitionOverrides` and `ArgDefinitionOverrides`; the entry type
 `CommandArgEntryDefinition`; the values a definition embeds, `PathChecks`,
@@ -219,6 +229,13 @@ an already-built `FlagSchema`, and `CLIDefinition.commands` takes a
 complete structural tree and hand it to `createCLISchema()`. Second, each
 definition is a discriminated union indexed by `kind`, so a field belonging to
 another kind is unrepresentable rather than silently ignored.
+
+`BuiltinsConfig` is the input to `CLIBuilder.builtins()` and to the `builtins`
+field of `CLIDefinition`. Its keys are the members of `BuiltinName`, all
+optional, each taking a `BuiltinMode`. An absent key leaves that built-in
+`'on'`, so `{}` and an omitted `builtins` field mean the same thing. A new key
+arrives with a new `BuiltinName` member, which is a major release under
+[Closed unions](#closed-unions-and-discriminated-results).
 
 Adding a member to `FlagKind` or `ArgKind` widens these unions and is a major
 release. See [Closed unions](#closed-unions-and-discriminated-results).
@@ -305,9 +322,9 @@ The payload types the hooks receive are covered under
 ## Closed unions and discriminated results
 
 The kind and mode unions `Verbosity`, `Shell`, `ArgKind`, `FlagKind`,
-`PromptKind`, `ArgPresence`, `FlagPresence`, `DuplicatePolicy`, `Fallback`,
-`TableFormat`, `TableStream`, `ParseErrorCode`, `ValidationErrorCode`, and
-`Runtime` (from `@kjanat/dreamcli/runtime`).
+`PromptKind`, `BuiltinName`, `BuiltinMode`, `ArgPresence`, `FlagPresence`,
+`DuplicatePolicy`, `Fallback`, `TableFormat`, `TableStream`, `ParseErrorCode`,
+`ValidationErrorCode`, and `Runtime` (from `@kjanat/dreamcli/runtime`).
 
 The discriminated results `ActivityEvent`, `Token`, `PromptResult`,
 `NumberConstraintViolation`, `StringConstraintViolation`, and

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -1,6 +1,6 @@
 # cli — CLIBuilder, multi-command dispatch, plugins
 
-`index.ts` (~2167 lines) — heavily split: 11 `@internal` extraction files.
+`index.ts` (~2259 lines) — heavily split: 12 `@internal` extraction files.
 
 ## KEY TYPES
 
@@ -10,6 +10,7 @@
 | `cli(name)`                | Factory function -> `CLIBuilder`                                        |
 | `isMainModule(meta)`       | Entrypoint guard for ambient `ImportMeta` compatibility                 |
 | `CLISchema`                | Runtime descriptor for the full CLI, execution graph excluded           |
+| `Builtins`                 | Sealed `help`/`json`/`quiet` state on `CLISchema`, set by `.builtins()` |
 | `CLIExecuteOptions`        | Extends `RunOptions`; the process-free `.execute()` surface             |
 | `CLIRunOptions`            | Extends `CLIExecuteOptions` with the runtime `adapter`                  |
 | `ConfigSettings`           | Config file discovery settings for CLI                                  |
@@ -24,13 +25,14 @@
 
 | File                   | Lines | Purpose                                                               |
 | ---------------------- | ----: | --------------------------------------------------------------------- |
-| `index.ts`             |  2167 | CLIBuilder class + cli() factory + JSON error handling                |
-| `planner.ts`           |   669 | `@internal` — execution planner, command resolution strategy          |
-| `runtime-preflight.ts` |   490 | `@internal` — runtime adapter setup, env/config preflight             |
+| `index.ts`             |  2259 | CLIBuilder class + cli() factory + JSON error handling                |
+| `planner.ts`           |   695 | `@internal` — execution planner, command resolution strategy          |
+| `runtime-preflight.ts` |   526 | `@internal` — runtime adapter setup, env/config preflight             |
+| `root-help.ts`         |   383 | `@internal` — root-level help text + text helpers, structural schema  |
 | `dispatch.ts`          |   365 | `@internal` — command dispatch (value-flag-arity aware), levenshtein  |
-| `root-help.ts`         |   364 | `@internal` — root-level help text + text helpers, structural schema  |
-| `reserved-flags.ts`    |   220 | `@internal` — build-time `RESERVED_FLAG` guard for root-owned flags   |
-| `root-output-flags.ts` |   203 | `@internal` — `--json`/`--quiet` reader + strip, shared by all layers |
+| `reserved-flags.ts`    |   238 | `@internal` — build-time `RESERVED_FLAG` guard for root-owned flags   |
+| `root-output-flags.ts` |   214 | `@internal` — `--json`/`--quiet` reader + strip, shared by all layers |
+| `builtins.ts`          |   208 | Built-in spelling table + `.builtins()` normalization, shared by all  |
 | `compiled.ts`          |   138 | `@internal` — compiled execution graph + `compileCommand()`           |
 | `plugin.ts`            |   117 | `@internal` — plugin system + lifecycle hooks                         |
 | `propagate.ts`         |    97 | `@internal` — flag propagation through command tree                   |
@@ -91,14 +93,36 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
 - `createCLISchema()` normalizes commands through `createCommandSchema()`, which clones them. It
   builds descriptions only; `cli()` uses it just for the empty root schema, so the identity
   invariant above is never crossed.
+- `builtins.ts` holds `BUILTIN_SPECS`, the ONE spelling table for `help`/`json`/`quiet`. Every
+  built-in-aware layer reads it: `root-output-flags.ts` builds its long/short spelling maps from it,
+  `reserved-flags.ts` builds the reserved token set from it, `root-help.ts` renders
+  `Global options:` from it, and `completion/shells/shared.ts` gates the synthetic root `--help` on
+  it. Add a spelling to an existing entry and all four follow. Adding a whole built-in needs
+  `BUILTIN_NAMES` updated by hand as well: the `BuiltinName` union forces a `BUILTIN_SPECS` entry
+  through `Record` completeness, but nothing forces the `BUILTIN_NAMES` array, and the guard and the
+  `Global options:` block both walk that array. `version`/`V` is NOT a built-in — it is opt-in via
+  `.version()`, so it stays a local constant in `reserved-flags.ts` and an interception in
+  `planner.ts`.
+- `.builtins({ <name>: 'off' })` releases a built-in to the commands (#86). Normalized state lives on
+  `CLISchema.builtins` (sealed, all three keys present); readers take the partial `BuiltinsConfig`
+  and go through `builtinEnabled()`, which defaults an absent key to `'on'`, so an unthreaded reader
+  keeps today's behavior. Threading points: `readRootOutputFlags(argv, builtins)`,
+  `PlannerSchemaLike.builtins` (root `--help`/`-h`, bare `help`, the `requestsHelp` rescue),
+  `InternalRunOptions.builtins` (`executeCommand()`'s help short-circuit),
+  `RuntimePreflightSchemaLike.builtins`, `RenderContextOptions.builtins`, and testkit
+  `RunCommandOptions.builtins`. `.builtins()` must be called BEFORE the commands that declare a
+  released flag — `.command()` rejects the flag while the root still owns the token, and the
+  `RESERVED_FLAG` suggest says so.
 - `reserved-flags.ts` rejects a command flag spelled like a token the root already owns:
-  `quiet`/`q`, `json`, `help`/`h` always, plus `version`/`V` once `schema.version` is set (#84). It
-  checks canonical names, aliases (hidden included), and custom negated spellings from
-  `.negatable({ alias })`, since all three land in `buildFlagLookup` and any of them can spell a
-  reserved token. The output half of the reserved set is derived from `ROOT_OUTPUT_TOKENS` in
-  `root-output-flags.ts` rather than restated, so a token added to the strip list is reserved in the
-  same change. `help`/`h` and `version`/`V` come from `planner.ts` interception and are declared
-  here; adding one there needs a matching entry.
+  `quiet`/`q`, `json`, `help`/`h` while their built-in is on, plus `version`/`V` once
+  `schema.version` is set (#84). It checks canonical names, aliases (hidden included), and custom
+  negated spellings from `.negatable({ alias })`, since all three land in `buildFlagLookup` and any
+  of them can spell a reserved token. The guard is deliberately STRICTER than the root strip: it
+  rejects the bare `q`/`h`/`V` alias unconditionally, while the strip and interception match only
+  the exact `-q`/`-h`/`-V` tokens, so a short cluster like `-vq` still reaches the command. The
+  plain spelling is the one users type; `reserved-flags.test.ts` pins both halves.
+- `runtime-preflight.ts` re-runs the guard when `.manifest()` filesystem discovery injects a version
+  (`assertDiscoveredVersionIsFree`), the one path that lands a version past every build-time check.
 - The version half of the guard is bidirectional like the `--completions` guard:
   `.command()`/`.default()` check against the current `schema.version`, and
   `.version()`/`.manifest(data)` re-check every registered command because either can set the
@@ -155,3 +179,4 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
 | `root-help-theme.test.ts`         | Root help theming                       |
 | `render-context.test.ts`          | Render context construction             |
 | `reserved-flags.test.ts`          | `RESERVED_FLAG` guard for root flags    |
+| `builtins.test.ts`                | `.builtins()` release of root built-ins |

--- a/src/core/cli/builtins.test.ts
+++ b/src/core/cli/builtins.test.ts
@@ -88,6 +88,13 @@ describe('builtins — normalization', () => {
 		expect(app.schema.builtins).toEqual({ help: 'off', json: 'off', quiet: 'on' });
 	});
 
+	it('treats an explicit undefined as an omitted incremental setting', () => {
+		const looselyTyped = { json: undefined, quiet: 'off' } as unknown as BuiltinsConfig;
+		const app = cli('mycli').builtins({ json: 'off' }).builtins(looselyTyped);
+
+		expect(app.schema.builtins).toEqual({ help: 'on', json: 'off', quiet: 'off' });
+	});
+
 	it('rejects a value that is neither mode on the definition path', () => {
 		const definition: CLIDefinition = {
 			name: 'mycli',
@@ -251,6 +258,13 @@ describe("builtins — help: 'off'", () => {
 		expect((await app.execute(['show', '-h', 'flags'])).stdout.join('')).toBe('help=flags\n');
 	});
 
+	it('does not let released help bypass an invalid root output flag', async () => {
+		const result = await helpOwningApp().execute(['show', '--help', 'flags', '--json=banana']);
+
+		expect(result.exitCode).toBe(2);
+		expect(result.error?.code).toBe('INVALID_VALUE');
+	});
+
 	it('stops routing the bare help token', async () => {
 		const result = await helpOwningApp().execute(['help']);
 
@@ -364,5 +378,18 @@ describe('builtins — testkit runCommand', () => {
 		});
 
 		expect(result.stdout.join('')).toBe('help=topics\n');
+	});
+
+	it('bypasses an invalid root output value only while help is root-owned', async () => {
+		const cmd = echoFlag('target', flag.string());
+		const owned = await runCommand(cmd, ['--help', '--json=banana']);
+		expect(owned.exitCode).toBe(0);
+		expect(owned.error).toBeUndefined();
+
+		const released = await runCommand(cmd, ['--help', '--json=banana'], {
+			builtins: { help: 'off' },
+		});
+		expect(released.exitCode).toBe(2);
+		expect(released.error?.code).toBe('INVALID_VALUE');
 	});
 });

--- a/src/core/cli/builtins.test.ts
+++ b/src/core/cli/builtins.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tests for consumer-owned built-in flags — `.builtins()` and the released
+ * `--help`, `--json`, `--quiet` tokens (#86).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generateCompletion } from '#internals/core/completion/index.ts';
+import { CLIError } from '#internals/core/errors/index.ts';
+import { command } from '#internals/core/schema/command.ts';
+import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import { runCommand } from '#internals/core/testkit/index.ts';
+import type { BuiltinsConfig, CLIDefinition } from './index.ts';
+import { cli, createCLISchema, resolveRenderContext } from './index.ts';
+
+// === Helpers
+
+const ALL_ON = { help: 'on', json: 'on', quiet: 'on' };
+
+/** Echo one flag's value so an end-to-end delivery is observable in stdout. */
+function echoFlag<N extends string, B extends FlagBuilder<FlagConfig>>(flagName: N, builder: B) {
+	return command('show')
+		.flag(flagName, builder)
+		.action(({ flags, out }) => {
+			out.log(`${flagName}=${String(flags[flagName])}`);
+		});
+}
+
+/** Read the root-level word list out of a generated bash completion script. */
+function rootCompletionWords(script: string): string {
+	const lines = script.split('\n');
+	const marker = lines.findIndex((line) => line.includes('Root-level completions'));
+	expect(marker).toBeGreaterThan(-1);
+	return lines[marker + 1] ?? '';
+}
+
+/** Capture the {@link CLIError} a build-time call throws. */
+function buildError(build: () => unknown): CLIError {
+	let thrown: unknown;
+	try {
+		build();
+	} catch (error: unknown) {
+		thrown = error;
+	}
+
+	expect(thrown).toBeInstanceOf(CLIError);
+	if (!(thrown instanceof CLIError)) throw new Error('unreachable');
+	return thrown;
+}
+
+// === Normalization
+
+describe('builtins — normalization', () => {
+	it('defaults every built-in to on', () => {
+		expect(cli('mycli').schema.builtins).toEqual(ALL_ON);
+		expect(createCLISchema({ name: 'mycli' }).builtins).toEqual(ALL_ON);
+	});
+
+	it('fills the untouched built-ins in when one is released', () => {
+		expect(cli('mycli').builtins({ json: 'off' }).schema.builtins).toEqual({
+			help: 'on',
+			json: 'off',
+			quiet: 'on',
+		});
+	});
+
+	it('normalizes the builder and definition paths identically', () => {
+		const fromBuilder = cli('mycli').builtins({ help: 'off', quiet: 'off' }).schema.builtins;
+		const fromDefinition = createCLISchema({
+			name: 'mycli',
+			builtins: { help: 'off', quiet: 'off' },
+		}).builtins;
+
+		expect(fromBuilder).toEqual(fromDefinition);
+	});
+
+	it('re-feeding a built schema produces a deep-equal schema', () => {
+		const built = createCLISchema({ name: 'mycli', builtins: { json: 'off' } });
+
+		expect(createCLISchema(built)).toEqual(built);
+	});
+
+	it('merges repeated calls, last mode per built-in winning', () => {
+		const app = cli('mycli')
+			.builtins({ json: 'off', quiet: 'off' })
+			.builtins({ quiet: 'on', help: 'off' });
+
+		expect(app.schema.builtins).toEqual({ help: 'off', json: 'off', quiet: 'on' });
+	});
+
+	it('rejects a value that is neither mode on the definition path', () => {
+		const definition: CLIDefinition = {
+			name: 'mycli',
+			builtins: { json: 'yes' } as unknown as BuiltinsConfig,
+		};
+
+		expect(buildError(() => createCLISchema(definition)).code).toBe('INVALID_SCHEMA');
+	});
+
+	it('rejects a value that is neither mode on the builder path', () => {
+		const error = buildError(() =>
+			cli('mycli').builtins({ quiet: 'disabled' } as unknown as BuiltinsConfig),
+		);
+
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toContain("Built-in 'quiet' must be 'on' or 'off'");
+	});
+});
+
+// === json released to the commands
+
+describe("builtins — json: 'off'", () => {
+	it('delivers a command flag named json, bare and with a value', async () => {
+		const app = cli('mycli')
+			.builtins({ json: 'off' })
+			.command(echoFlag('json', flag.string().describe('Document to validate')));
+
+		const spaced = await app.execute(['show', '--json', 'doc.json']);
+		expect(spaced.exitCode).toBe(0);
+		expect(spaced.stdout.join('')).toBe('json=doc.json\n');
+
+		const inline = await app.execute(['show', '--json=doc.json']);
+		expect(inline.exitCode).toBe(0);
+		expect(inline.stdout.join('')).toBe('json=doc.json\n');
+	});
+
+	it('leaves the run in human mode when the released token is present', async () => {
+		const app = cli('mycli').builtins({ json: 'off' }).command(echoFlag('json', flag.boolean()));
+
+		const result = await app.execute(['show', '--json']);
+		expect(result.stdout.join('')).toBe('json=true\n');
+		expect(result.stderr).toEqual([]);
+	});
+
+	it('keeps the RunOptions jsonMode override working', async () => {
+		const app = cli('mycli')
+			.builtins({ json: 'off' })
+			.command(
+				command('show')
+					.flag('json', flag.string())
+					.action(({ out }) => {
+						out.json({ mode: out.jsonMode });
+					}),
+			);
+
+		const result = await app.execute(['show', '--json', 'doc.json'], { jsonMode: true });
+		expect(JSON.parse(result.stdout.join(''))).toEqual({ mode: true });
+	});
+
+	it('drops --json from the root Global options block', async () => {
+		const app = cli('mycli').builtins({ json: 'off' }).command(echoFlag('json', flag.string()));
+		const output = (await app.execute([])).stdout.join('');
+
+		expect(output).toContain('Global options:');
+		expect(output).not.toContain('--json');
+		expect(output).toContain('-q, --quiet');
+	});
+
+	it('renders the released flag in the command help flags block', async () => {
+		const app = cli('mycli')
+			.builtins({ json: 'off' })
+			.command(echoFlag('json', flag.string().describe('Document to validate')));
+		const output = (await app.execute(['show', '--help'])).stdout.join('');
+
+		expect(output).toContain('--json');
+		expect(output).toContain('Document to validate');
+	});
+
+	it('stops resolveRenderContext reading the released token', () => {
+		expect(resolveRenderContext(['--json']).jsonMode).toBe(true);
+		expect(resolveRenderContext(['--json'], { builtins: { json: 'off' } }).jsonMode).toBe(false);
+	});
+});
+
+// === quiet released to the commands
+
+describe("builtins — quiet: 'off'", () => {
+	it('delivers a command flag named quiet through both spellings', async () => {
+		const app = cli('mycli')
+			.builtins({ quiet: 'off' })
+			.command(echoFlag('quiet', flag.boolean().alias('q')));
+
+		expect((await app.execute(['show', '--quiet'])).stdout.join('')).toBe('quiet=true\n');
+		expect((await app.execute(['show', '-q'])).stdout.join('')).toBe('quiet=true\n');
+	});
+
+	it('keeps verbosity normal when argv carries the released token', async () => {
+		const app = cli('mycli')
+			.builtins({ quiet: 'off' })
+			.command(
+				command('show')
+					.flag('quiet', flag.boolean())
+					.action(({ out }) => {
+						out.log(out.verbosity);
+						out.status('still speaking');
+					}),
+			);
+
+		const result = await app.execute(['show', '--quiet']);
+		expect(result.stdout.join('')).toBe('normal\n');
+		expect(result.stderr.join('')).toContain('still speaking');
+	});
+
+	it('keeps the RunOptions verbosity override working', async () => {
+		const app = cli('mycli')
+			.builtins({ quiet: 'off' })
+			.command(
+				command('show')
+					.flag('quiet', flag.boolean())
+					.action(({ out }) => {
+						out.log(out.verbosity);
+					}),
+			);
+
+		const result = await app.execute(['show', '--quiet'], { verbosity: 'quiet' });
+		expect(result.stdout.join('')).toBe('quiet\n');
+	});
+
+	it('drops -q, --quiet from the root Global options block', async () => {
+		const app = cli('mycli').builtins({ quiet: 'off' }).command(echoFlag('quiet', flag.boolean()));
+		const output = (await app.execute([])).stdout.join('');
+
+		expect(output).not.toContain('--quiet');
+		expect(output).toContain('--json');
+	});
+});
+
+// === help released to the commands
+
+describe("builtins — help: 'off'", () => {
+	function helpOwningApp() {
+		return cli('mycli')
+			.builtins({ help: 'off' })
+			.command(echoFlag('help', flag.string().alias('h').describe('Topic to explain')));
+	}
+
+	it('stops root --help and -h interception', async () => {
+		const app = helpOwningApp();
+
+		for (const token of ['--help', '-h']) {
+			const result = await app.execute([token, 'topics']);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.stdout.join('')).not.toContain('Global options:');
+		}
+	});
+
+	it('stops command-level help and delivers the flag instead', async () => {
+		const app = helpOwningApp();
+
+		expect((await app.execute(['show', '--help', 'flags'])).stdout.join('')).toBe('help=flags\n');
+		expect((await app.execute(['show', '-h', 'flags'])).stdout.join('')).toBe('help=flags\n');
+	});
+
+	it('stops routing the bare help token', async () => {
+		const result = await helpOwningApp().execute(['help']);
+
+		expect(result.error?.code).toBe('UNKNOWN_COMMAND');
+	});
+
+	it('drops -h, --help from the root Global options block and the footer hint', async () => {
+		const output = (await helpOwningApp().execute([])).stdout.join('');
+
+		expect(output).toContain('Global options:');
+		expect(output).not.toContain('--help');
+		expect(output).not.toContain('for more information');
+		expect(output).toContain('--json');
+	});
+
+	it('keeps rendering root help for a bare invocation', async () => {
+		const output = (await helpOwningApp().execute([])).stdout.join('');
+
+		expect(output).toContain('Usage: mycli');
+		expect(output).toContain('Commands:');
+	});
+
+	it('stops offering --help in dispatch failures', async () => {
+		const app = helpOwningApp().command(command('grp').command(command('leaf').action(() => {})));
+
+		const unknownFlag = await app.execute(['--bogus']);
+		expect(unknownFlag.error?.code).toBe('UNKNOWN_FLAG');
+		expect(unknownFlag.error?.suggest).toBeUndefined();
+
+		const unknownCommand = await app.execute(['grp', 'nope']);
+		expect(unknownCommand.error?.code).toBe('UNKNOWN_COMMAND');
+		expect(unknownCommand.error?.suggest).toBeUndefined();
+	});
+
+	it('drops the synthetic --help from generated completion scripts', () => {
+		const plain = command('show').action(() => {});
+		const owned = cli('mycli').builtins({ help: 'off' }).command(plain);
+		const framework = cli('mycli').command(plain);
+
+		expect(rootCompletionWords(generateCompletion(framework.schema, 'bash'))).toContain('--help');
+		expect(rootCompletionWords(generateCompletion(owned.schema, 'bash'))).not.toContain('--help');
+	});
+
+	it('omits the Global options block entirely once nothing is left in it', async () => {
+		const app = cli('mycli')
+			.builtins({ help: 'off', json: 'off', quiet: 'off' })
+			.command(command('show').action(() => {}));
+		const output = (await app.execute([])).stdout.join('');
+
+		expect(output).not.toContain('Global options:');
+		expect(output).toContain('Commands:');
+	});
+});
+
+// === Interaction with the RESERVED_FLAG guard
+
+describe('builtins — reserved-flag guard', () => {
+	it('still rejects a flag colliding with a built-in that stays on', () => {
+		expect(() =>
+			cli('mycli').builtins({ json: 'off' }).command(echoFlag('quiet', flag.boolean())),
+		).toThrow(CLIError);
+	});
+
+	it('rejects the released flag when it is registered before the release', () => {
+		const error = buildError(() => cli('mycli').command(echoFlag('json', flag.string())));
+
+		expect(error.code).toBe('RESERVED_FLAG');
+		expect(error.suggest).toContain(".builtins({ json: 'off' }) before registering the command");
+	});
+
+	it('rejects taking a built-in back while a command still declares it', () => {
+		const app = cli('mycli').builtins({ json: 'off' }).command(echoFlag('json', flag.string()));
+
+		expect(() => app.builtins({ json: 'on' })).toThrow(CLIError);
+	});
+
+	it('accepts the released flag on the definition path', () => {
+		const schema = createCLISchema({
+			name: 'mycli',
+			builtins: { quiet: 'off' },
+			commands: [{ name: 'show', flags: { quiet: { kind: 'boolean' } } }],
+		});
+
+		expect(schema.commands[0]?.flags.quiet?.kind).toBe('boolean');
+	});
+});
+
+// === testkit mirror
+
+describe('builtins — testkit runCommand', () => {
+	it('mirrors the root strip by default', async () => {
+		const result = await runCommand(echoFlag('target', flag.string()), ['--json', '--target', 'x']);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('');
+		expect(result.stderr.join('')).toBe('target=x\n');
+	});
+
+	it('leaves a released token for the command under test', async () => {
+		const result = await runCommand(echoFlag('json', flag.string()), ['--json', 'doc.json'], {
+			builtins: { json: 'off' },
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toBe('json=doc.json\n');
+	});
+
+	it('leaves a released --help for the command under test', async () => {
+		const result = await runCommand(echoFlag('help', flag.string()), ['--help', 'topics'], {
+			builtins: { help: 'off' },
+		});
+
+		expect(result.stdout.join('')).toBe('help=topics\n');
+	});
+});

--- a/src/core/cli/builtins.ts
+++ b/src/core/cli/builtins.ts
@@ -1,0 +1,208 @@
+/**
+ * Consumer-owned built-in flags: `--help`/`-h`, `--json`, and `--quiet`/`-q`.
+ *
+ * The root owns these tokens by default. {@linkcode CLIBuilder.builtins} sets a
+ * built-in to `'off'`, which releases every spelling it answers to: the root
+ * scanner stops reading and stripping it, root help stops advertising it, and
+ * the `RESERVED_FLAG` guard stops reserving it, so a command may declare the
+ * flag and receive it (#86).
+ *
+ * This module is the single spelling table behind all three layers. A token
+ * added here reaches the scanner, the guard, and the help block in one change.
+ *
+ * @module dreamcli/core/cli/builtins
+ * @internal
+ */
+
+import { CLIError } from '#internals/core/errors/index.ts';
+import type { schemaBrand } from '#internals/core/schema/brand.ts';
+
+/** A built-in flag a consumer can take over. */
+type BuiltinName = 'help' | 'json' | 'quiet';
+
+/** Whether the root keeps a built-in or releases it to commands. */
+type BuiltinMode = 'on' | 'off';
+
+/**
+ * Built-in flag settings accepted by {@linkcode CLIBuilder.builtins} and the
+ * `builtins` field of {@link CLIDefinition}.
+ *
+ * `version` and `completions` are absent by design: `.version()` and
+ * `.completions()` are opt-in, so a CLI declines those two by not calling them.
+ */
+interface BuiltinsConfig {
+	/**
+	 * Root `--help`/`-h`, command-level `--help`/`-h`, and the bare `help` token.
+	 * @defaultValue `'on'`
+	 */
+	readonly help?: BuiltinMode;
+	/**
+	 * Root `--json`.
+	 * @defaultValue `'on'`
+	 */
+	readonly json?: BuiltinMode;
+	/**
+	 * Root `--quiet`/`-q`.
+	 * @defaultValue `'on'`
+	 */
+	readonly quiet?: BuiltinMode;
+}
+
+/**
+ * Normalized built-in flag state stored on {@link CLISchema}.
+ *
+ * Sealed by {@link createCLISchema}; every key is present after normalization.
+ */
+interface Builtins {
+	/** Type-only seal produced by {@link createCLISchema}. */
+	readonly [schemaBrand]: 'builtins';
+	/** Whether the root owns `--help`/`-h` and the bare `help` token. */
+	readonly help: BuiltinMode;
+	/** Whether the root owns `--json`. */
+	readonly json: BuiltinMode;
+	/** Whether the root owns `--quiet`/`-q`. */
+	readonly quiet: BuiltinMode;
+}
+
+/**
+ * {@link Builtins} before the type-only seal is applied.
+ *
+ * @internal
+ */
+type BuiltinsDraft = Omit<Builtins, typeof schemaBrand>;
+
+/** Everything the framework needs to know about one built-in flag. @internal */
+interface BuiltinSpec {
+	/** Spelling error messages and help entries name the built-in by. */
+	readonly spelling: string;
+	/** Long spellings, the only forms that carry an inline `=value`. */
+	readonly long: readonly string[];
+	/** Short spellings, which have no inline-value form. */
+	readonly short: readonly string[];
+	/** Description shown in the root-help `Global options:` block. */
+	readonly description: string;
+}
+
+/**
+ * The spelling table every built-in-aware layer reads.
+ *
+ * @internal
+ */
+const BUILTIN_SPECS: Readonly<Record<BuiltinName, BuiltinSpec>> = {
+	help: {
+		spelling: '--help',
+		long: ['--help'],
+		short: ['-h'],
+		description: 'Show this help message and exit',
+	},
+	json: {
+		spelling: '--json',
+		long: ['--json'],
+		short: [],
+		description: 'Emit machine-readable JSON output',
+	},
+	quiet: {
+		spelling: '--quiet',
+		long: ['--quiet'],
+		short: ['-q'],
+		description: 'Suppress informational output',
+	},
+};
+
+/** Built-in names in the order root help advertises them. @internal */
+const BUILTIN_NAMES: readonly BuiltinName[] = ['help', 'json', 'quiet'];
+
+/** Every built-in on, the state a CLI starts in. @internal */
+const DEFAULT_BUILTINS: BuiltinsDraft = { help: 'on', json: 'on', quiet: 'on' };
+
+/**
+ * Whether the root still owns a built-in.
+ *
+ * @param builtins - Normalized state, or `undefined` for the defaults.
+ * @param name - Built-in to check.
+ * @returns `true` when the root reads the token, `false` once it is released.
+ *
+ * @internal
+ */
+function builtinEnabled(builtins: BuiltinsConfig | undefined, name: BuiltinName): boolean {
+	return (builtins?.[name] ?? 'on') === 'on';
+}
+
+/**
+ * The argv spellings of one built-in, joined for a help entry.
+ *
+ * @param name - Built-in to render.
+ * @returns Short spellings first, e.g. `-h, --help`.
+ *
+ * @internal
+ */
+function builtinFlagForms(name: BuiltinName): string {
+	const spec = BUILTIN_SPECS[name];
+	return [...spec.short, ...spec.long].join(', ');
+}
+
+/**
+ * The spellings of one built-in as bare tokens, dashes removed.
+ *
+ * @param name - Built-in to read.
+ * @returns Tokens as a command flag would declare them, e.g. `help` and `h`.
+ *
+ * @internal
+ */
+function builtinTokens(name: BuiltinName): readonly string[] {
+	const spec = BUILTIN_SPECS[name];
+	return [...spec.long, ...spec.short].map((spelling) => spelling.replace(/^-+/, ''));
+}
+
+/**
+ * Read one built-in's mode out of a caller-supplied config.
+ *
+ * @param config - Caller input, which a JS caller may fill with anything.
+ * @param name - Built-in to read.
+ * @returns The declared mode, or `'on'` when the key is absent.
+ * @throws {@linkcode CLIError} `INVALID_SCHEMA` when the value is neither mode.
+ */
+function readBuiltinMode(config: BuiltinsConfig, name: BuiltinName): BuiltinMode {
+	const mode = config[name];
+	if (mode === undefined || mode === 'on' || mode === 'off') return mode ?? 'on';
+
+	throw new CLIError(`Built-in '${name}' must be 'on' or 'off'`, {
+		code: 'INVALID_SCHEMA',
+		details: { builtin: name, value: mode },
+		suggest: `Pass { ${name}: 'off' } to release the flag, or omit the key to keep it on`,
+	});
+}
+
+/**
+ * Normalize built-in settings into the fully populated schema state.
+ *
+ * Shared by {@link createCLISchema} and {@linkcode CLIBuilder.builtins}, so both
+ * construction paths produce identical state. Re-feeding a normalized value
+ * returns an equal value.
+ *
+ * @param config - Caller-supplied settings, or `undefined` for the defaults.
+ * @returns Every built-in resolved to a mode.
+ * @throws {@linkcode CLIError} `INVALID_SCHEMA` for a value that is neither
+ *   `'on'` nor `'off'`.
+ *
+ * @internal
+ */
+function normalizeBuiltins(config: BuiltinsConfig | undefined): BuiltinsDraft {
+	if (config === undefined) return DEFAULT_BUILTINS;
+	return {
+		help: readBuiltinMode(config, 'help'),
+		json: readBuiltinMode(config, 'json'),
+		quiet: readBuiltinMode(config, 'quiet'),
+	};
+}
+
+export type { BuiltinMode, BuiltinName, BuiltinSpec, Builtins, BuiltinsConfig, BuiltinsDraft };
+export {
+	BUILTIN_NAMES,
+	BUILTIN_SPECS,
+	builtinEnabled,
+	builtinFlagForms,
+	builtinTokens,
+	DEFAULT_BUILTINS,
+	normalizeBuiltins,
+};

--- a/src/core/cli/builtins.ts
+++ b/src/core/cli/builtins.ts
@@ -73,8 +73,6 @@ type BuiltinsDraft = Omit<Builtins, typeof schemaBrand>;
 
 /** Everything the framework needs to know about one built-in flag. @internal */
 interface BuiltinSpec {
-	/** Spelling error messages and help entries name the built-in by. */
-	readonly spelling: string;
 	/** Long spellings, the only forms that carry an inline `=value`. */
 	readonly long: readonly string[];
 	/** Short spellings, which have no inline-value form. */
@@ -90,24 +88,26 @@ interface BuiltinSpec {
  */
 const BUILTIN_SPECS: Readonly<Record<BuiltinName, BuiltinSpec>> = {
 	help: {
-		spelling: '--help',
 		long: ['--help'],
 		short: ['-h'],
 		description: 'Show this help message and exit',
 	},
 	json: {
-		spelling: '--json',
 		long: ['--json'],
 		short: [],
 		description: 'Emit machine-readable JSON output',
 	},
 	quiet: {
-		spelling: '--quiet',
 		long: ['--quiet'],
 		short: ['-q'],
 		description: 'Suppress informational output',
 	},
 };
+
+/** Spelling error messages and help entries name a built-in by. @internal */
+function builtinSpelling(name: BuiltinName): string {
+	return BUILTIN_SPECS[name].long[0] ?? BUILTIN_SPECS[name].short[0] ?? name;
+}
 
 /** Built-in names in the order root help advertises them. @internal */
 const BUILTIN_NAMES: readonly BuiltinName[] = ['help', 'json', 'quiet'];
@@ -202,6 +202,7 @@ export {
 	BUILTIN_SPECS,
 	builtinEnabled,
 	builtinFlagForms,
+	builtinSpelling,
 	builtinTokens,
 	DEFAULT_BUILTINS,
 	normalizeBuiltins,

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -49,6 +49,8 @@ import type { InternalRunOptions, RunOptions, RunResult } from '#internals/core/
 import type { RuntimeAdapter } from '#internals/runtime/adapter.ts';
 import { createAdapter } from '#internals/runtime/auto.ts';
 import { BACKSLASH, SLASH, stripTrailing } from '#internals/strings.ts';
+import type { Builtins, BuiltinsConfig, BuiltinsDraft } from './builtins.ts';
+import { normalizeBuiltins } from './builtins.ts';
 import type { CompiledCLI } from './compiled.ts';
 import { assertNoSiblingRouteConflict, commandRoutes, compileCommand } from './compiled.ts';
 import type { HelpLinks } from './help-links.ts';
@@ -234,6 +236,15 @@ interface CLISchema {
 	 * Set via the `cli(name, { flags })` / `cli({ flags })` factory forms.
 	 */
 	readonly flagSettings: ParseOptions | undefined;
+	/**
+	 * Which built-in flags the root still owns.
+	 *
+	 * Every built-in starts `'on'`. Set via the
+	 * {@linkcode CLIBuilder.builtins | .builtins()} builder method or the
+	 * `builtins` field of {@link CLIDefinition}; a built-in set to `'off'`
+	 * releases its tokens to the commands.
+	 */
+	readonly builtins: Builtins;
 }
 
 /**
@@ -524,6 +535,11 @@ interface CLIDefinition {
 	 */
 	readonly flagSettings?: ParseOptions | undefined;
 	/**
+	 * Which built-in flags the root keeps.
+	 * @defaultValue every built-in `'on'`
+	 */
+	readonly builtins?: BuiltinsConfig | undefined;
+	/**
 	 * Registered command definitions or built schemas, in registration order.
 	 * @defaultValue `[]`
 	 */
@@ -548,15 +564,17 @@ type ConfigSettingsDraft = Omit<ConfigSettings, typeof schemaBrand>;
  *
  * @internal
  */
-type CLISchemaDraft = Omit<CLISchema, typeof schemaBrand | 'configSettings'> & {
+type CLISchemaDraft = Omit<CLISchema, typeof schemaBrand | 'configSettings' | 'builtins'> & {
 	readonly configSettings: ConfigSettingsDraft | undefined;
+	readonly builtins: BuiltinsDraft;
 };
 
 /**
  * Apply the type-only seal to a fully populated CLI schema draft.
  *
  * The brand has no runtime value, so this is the single construction path for
- * {@link CLISchema} and {@link ConfigSettings} values in this module.
+ * {@link CLISchema}, {@link ConfigSettings}, and {@link Builtins} values in
+ * this module.
  *
  * @param draft - Draft carrying every schema field.
  * @returns The sealed schema.
@@ -598,6 +616,7 @@ function buildCLISchema(definition: CLIDefinition): CLISchema {
 		completionsFlag: definition.completionsFlag,
 		helpConfig: definition.helpConfig,
 		flagSettings: definition.flagSettings,
+		builtins: normalizeBuiltins(definition.builtins),
 	});
 }
 
@@ -614,11 +633,13 @@ function buildCLISchema(definition: CLIDefinition): CLISchema {
  *
  * @param definition - Program name plus optional metadata and commands.
  * @returns A fully populated {@link CLISchema}.
- * @throws {CLIError} With code `'INVALID_SCHEMA'` when the name is empty.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` when the name is empty or a
+ *   `builtins` entry is neither `'on'` nor `'off'`.
  * @throws {CLIError} With code `'RESERVED_FLAG'` when a command spells a flag
  *   the same way as a root-owned flag (`--json`, `--quiet`/`-q`, `--help`/`-h`,
  *   `--version`/`-V` once `version` is set, and `--completions` once
- *   `completionsFlag` is set), by name, alias, or negated spelling.
+ *   `completionsFlag` is set), by name, alias, or negated spelling. A built-in
+ *   set to `'off'` in `builtins` is not reserved.
  *
  * @example
  * ```ts
@@ -651,7 +672,7 @@ function createCLISchema(definition: CLIDefinition): CLISchema {
 		assertNoTopLevelRouteConflict(registered, schema.defaultCommand);
 	}
 	const allCommands = [schema.defaultCommand, ...schema.commands];
-	assertNoReservedFlagCollisions(schema.version, allCommands);
+	assertNoReservedFlagCollisions(schema.version, allCommands, schema.builtins);
 	if (schema.completionsFlag !== undefined) {
 		for (const cmd of allCommands) {
 			if (cmd !== undefined) assertNoCompletionsFlagCollision(cmd);
@@ -697,6 +718,8 @@ interface InternalCLIExecuteOptions extends CLIExecuteOptions {
 	readonly captured?: CapturedOutput;
 	/** CLI plugins registered on the builder. */
 	readonly plugins?: readonly CLIPlugin[];
+	/** Built-in flag state from the schema, threaded to the command executor. */
+	readonly builtins?: BuiltinsConfig;
 }
 
 // --- Render context
@@ -741,6 +764,14 @@ interface RenderContextOptions {
 	 * @defaultValue `{}`
 	 */
 	readonly env?: Readonly<Record<string, string | undefined>>;
+	/**
+	 * Which built-in flags the CLI still owns, matching its
+	 * {@linkcode CLIBuilder.builtins | .builtins()} call. A built-in set to
+	 * `'off'` is not read out of `argv` here either.
+	 *
+	 * @defaultValue every built-in `'on'`
+	 */
+	readonly builtins?: BuiltinsConfig;
 }
 
 /**
@@ -830,7 +861,7 @@ function resolveRenderContext(
 	argv: readonly string[],
 	options?: RenderContextOptions,
 ): RenderContext {
-	const rootOutputFlags = readRootOutputFlags(argv);
+	const rootOutputFlags = readRootOutputFlags(argv, options?.builtins);
 	const jsonMode = resolveRootJsonMode(rootOutputFlags, options?.jsonMode);
 	const verbosity = resolveRootVerbosity(rootOutputFlags, options?.verbosity) ?? 'normal';
 	const out = createOutput({
@@ -876,6 +907,7 @@ function buildCommandRunOptions(
 		help: helpOptions,
 		...(meta !== undefined ? { meta } : {}),
 		...(options?.plugins !== undefined ? { plugins: options.plugins } : {}),
+		...(options?.builtins !== undefined ? { builtins: options.builtins } : {}),
 		...(options?.env !== undefined ? { env: options.env } : {}),
 		...(options?.config !== undefined ? { config: options.config } : {}),
 		...(options?.stdinData !== undefined ? { stdinData: options.stdinData } : {}),
@@ -982,8 +1014,62 @@ class CLIBuilder {
 	 *   a flag named `version` or aliased `V`.
 	 */
 	version(v: string): CLIBuilder {
-		assertNoReservedFlagCollisions(v, [this.schema.defaultCommand, ...this.schema.commands]);
+		assertNoReservedFlagCollisions(
+			v,
+			[this.schema.defaultCommand, ...this.schema.commands],
+			this.schema.builtins,
+		);
 		return rebuild(this, { ...this.schema, version: v });
+	}
+
+	/**
+	 * Choose which built-in flags the root keeps.
+	 *
+	 * `--help`/`-h`, `--json`, and `--quiet`/`-q` are root-owned by default and
+	 * never reach a command handler. Setting one to `'off'` releases every
+	 * spelling it answers to: the root stops reading it out of argv, root help
+	 * stops advertising it under `Global options:`, and a command may declare it
+	 * as an ordinary flag. `RunOptions.jsonMode` and `RunOptions.verbosity`
+	 * keep working either way, since only argv-driven activation is disabled.
+	 *
+	 * `version` and `completions` are absent by design, since `.version()` and
+	 * `.completions()` are opt-in and a CLI declines those by omission.
+	 *
+	 * Call multiple times to set built-ins incrementally; the last mode given for
+	 * a built-in wins. Turning one back `'on'` re-checks every registered command
+	 * for a collision. Call this **before** registering the commands that declare
+	 * a released flag, since `.command()` rejects the flag while the root still
+	 * owns the token.
+	 *
+	 * @param config - Built-in modes to apply over the current state.
+	 * @returns The builder (for chaining).
+	 * @throws {@link CLIError} `INVALID_SCHEMA` when a value is neither `'on'` nor `'off'`.
+	 * @throws {@link CLIError} `RESERVED_FLAG` when a registered command already
+	 *   declares a flag spelled like a built-in this call keeps or restores.
+	 * @see {@link BuiltinsConfig} for the accepted keys and modes.
+	 * @see https://dreamcli.kjanat.dev/guide/output#taking-a-built-in-over
+	 *
+	 * @example
+	 * ```ts
+	 * // `--json` names the document the command validates.
+	 * cli('schematool')
+	 *   .builtins({ json: 'off' })
+	 *   .default(
+	 *     command('validate')
+	 *       .flag('json', flag.string().describe('Document to validate'))
+	 *       .action(({ flags, out }) => out.log(flags.json)),
+	 *   )
+	 *   .run();
+	 * ```
+	 */
+	builtins(config: BuiltinsConfig): CLIBuilder {
+		const builtins = normalizeBuiltins({ ...this.schema.builtins, ...config });
+		assertNoReservedFlagCollisions(
+			this.schema.version,
+			[this.schema.defaultCommand, ...this.schema.commands],
+			builtins,
+		);
+		return rebuild(this, sealCLISchema({ ...this.schema, builtins }));
 	}
 
 	/**
@@ -1239,7 +1325,11 @@ class CLIBuilder {
 	manifest(settings?: ManifestSettings): CLIBuilder;
 	manifest(input?: PackageJsonData | ManifestSettings): CLIBuilder {
 		const next = buildManifestSchema(this.schema, input, DEFAULT_MANIFEST_FILES);
-		assertNoReservedFlagCollisions(next.version, [next.defaultCommand, ...next.commands]);
+		assertNoReservedFlagCollisions(
+			next.version,
+			[next.defaultCommand, ...next.commands],
+			next.builtins,
+		);
 		return rebuild(this, next);
 	}
 
@@ -1256,7 +1346,8 @@ class CLIBuilder {
 	 * @throws {@link CLIError} `RESERVED_FLAG` when the command, or one of its
 	 *   nested subcommands, declares a flag named or aliased to a root-owned flag
 	 *   (`--json`, `--quiet`/`-q`, `--help`/`-h`, and `--version`/`-V` once
-	 *   {@link CLIBuilder.version | .version()} is set).
+	 *   {@link CLIBuilder.version | .version()} is set). A built-in released
+	 *   through {@link CLIBuilder.builtins | .builtins()} is not reserved.
 	 */
 	command<
 		F extends Record<string, FlagBuilder<FlagConfig>>,
@@ -1264,7 +1355,7 @@ class CLIBuilder {
 		C extends Record<string, unknown>,
 	>(cmd: CommandBuilder<F, A, C>): CLIBuilder {
 		assertNoTopLevelRouteConflict(this.schema.commands, cmd.schema, this.schema.defaultCommand);
-		assertNoReservedFlagCollisions(this.schema.version, [cmd.schema]);
+		assertNoReservedFlagCollisions(this.schema.version, [cmd.schema], this.schema.builtins);
 		if (this.schema.completionsFlag !== undefined) {
 			assertNoCompletionsFlagCollision(cmd.schema);
 		}
@@ -1333,7 +1424,8 @@ class CLIBuilder {
 	 * @throws {@link CLIError} `RESERVED_FLAG` when the command, or one of its
 	 *   nested subcommands, declares a flag named or aliased to a root-owned flag
 	 *   (`--json`, `--quiet`/`-q`, `--help`/`-h`, and `--version`/`-V` once
-	 *   {@link CLIBuilder.version | .version()} is set).
+	 *   {@link CLIBuilder.version | .version()} is set). A built-in released
+	 *   through {@link CLIBuilder.builtins | .builtins()} is not reserved.
 	 */
 	default<
 		F extends Record<string, FlagBuilder<FlagConfig>>,
@@ -1348,7 +1440,7 @@ class CLIBuilder {
 		}
 
 		assertNoTopLevelRouteConflict(this.schema.commands, cmd.schema);
-		assertNoReservedFlagCollisions(this.schema.version, [cmd.schema]);
+		assertNoReservedFlagCollisions(this.schema.version, [cmd.schema], this.schema.builtins);
 		if (this.schema.completionsFlag !== undefined) {
 			assertNoCompletionsFlagCollision(cmd.schema);
 		}
@@ -1607,7 +1699,7 @@ async function executeCLI(
 	options?: InternalCLIExecuteOptions,
 ): Promise<RunResult> {
 	// -- Detect global --json / --quiet before building output ----------------
-	const rootOutputFlags = readRootOutputFlags(argv);
+	const rootOutputFlags = readRootOutputFlags(argv, builder.schema.builtins);
 	const jsonMode = resolveRootJsonMode(rootOutputFlags, options?.jsonMode);
 	const verbosity: Verbosity | undefined = resolveRootVerbosity(
 		rootOutputFlags,
@@ -1656,6 +1748,7 @@ async function executeCLI(
 	const effectiveOptions: InternalCLIExecuteOptions = {
 		...options,
 		plugins: compiled.plugins,
+		builtins: builder.schema.builtins,
 		...(jsonMode ? { jsonMode } : {}),
 		...(verbosity !== undefined ? { verbosity } : {}),
 		...(flagSettings !== undefined ? { flags: flagSettings } : {}),
@@ -2139,6 +2232,7 @@ function isMainModule(meta: ImportMeta): boolean {
 
 // --- Exports
 
+export type { BuiltinMode, BuiltinName, Builtins, BuiltinsConfig } from './builtins.ts';
 export type { HelpLinks } from './help-links.ts';
 export type {
 	BeforeParseParams,

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -1063,7 +1063,12 @@ class CLIBuilder {
 	 * ```
 	 */
 	builtins(config: BuiltinsConfig): CLIBuilder {
-		const builtins = normalizeBuiltins({ ...this.schema.builtins, ...config });
+		const definedConfig: BuiltinsConfig = {
+			...(config.help !== undefined ? { help: config.help } : {}),
+			...(config.json !== undefined ? { json: config.json } : {}),
+			...(config.quiet !== undefined ? { quiet: config.quiet } : {}),
+		};
+		const builtins = normalizeBuiltins({ ...this.schema.builtins, ...definedConfig });
 		assertNoReservedFlagCollisions(
 			this.schema.version,
 			[this.schema.defaultCommand, ...this.schema.commands],

--- a/src/core/cli/planner.test.ts
+++ b/src/core/cli/planner.test.ts
@@ -46,6 +46,7 @@ function planFor(
 			version: '1.2.3',
 			defaultCommandRouted: false,
 			completionsFlag: undefined,
+			builtins: undefined,
 		},
 		compiled: { commands, defaultCommand, plugins: [] },
 		argv,

--- a/src/core/cli/planner.ts
+++ b/src/core/cli/planner.ts
@@ -23,6 +23,8 @@ import {
 	requestsHelp,
 } from '#internals/core/parse/index.ts';
 import type { CommandMeta, CommandSchema } from '#internals/core/schema/command.ts';
+import type { BuiltinsConfig } from './builtins.ts';
+import { builtinEnabled } from './builtins.ts';
 import type { CompiledCLI, CompiledCommand } from './compiled.ts';
 import { dispatch, findClosestCommand } from './dispatch.ts';
 import type { CLIPlugin } from './plugin.ts';
@@ -54,6 +56,11 @@ interface PlannerSchemaLike {
 		| undefined;
 	/** Flag-parsing behavior settings (case parity) applied to flag lookups. */
 	readonly flagSettings?: ParseOptions | undefined;
+	/**
+	 * Built-in flag state. `help: 'off'` stops root `--help`/`-h` interception
+	 * and bare `help` routing, and `json`/`quiet` stop being read out of argv.
+	 */
+	readonly builtins: BuiltinsConfig | undefined;
 }
 
 /** Root-level help interception outcome. */
@@ -330,7 +337,8 @@ interface RootHeadScan {
 	 * Mirrors the global reach of `--version` (#29): a help flag preceded only by
 	 * flags (no subcommand token) is a *root* help request. A help flag that
 	 * follows a subcommand token is left to that command's executor, so
-	 * `app sub --help` still renders the subcommand's help.
+	 * `app sub --help` still renders the subcommand's help. Always `false` once
+	 * the CLI releases `help` to its commands.
 	 */
 	readonly helpBeforeCommand: boolean;
 	/** First command-dispatch (positional) token, or `undefined` when the head is all flags. */
@@ -352,12 +360,13 @@ interface RootHeadScan {
 function scanRootHead(
 	head: readonly string[],
 	valueFlags: ReturnType<typeof buildFlagLookup> | undefined,
+	helpOwned: boolean,
 ): RootHeadScan {
 	for (let index = 0; index < head.length; index++) {
 		const token = head[index];
 		if (token === undefined) continue;
 
-		if (token === '--help' || token === '-h') {
+		if (helpOwned && (token === '--help' || token === '-h')) {
 			return { helpBeforeCommand: true, firstCommandToken: undefined, commandTokenIndex: -1 };
 		}
 
@@ -385,6 +394,23 @@ function scanRootHead(
 	}
 
 	return { helpBeforeCommand: false, firstCommandToken: undefined, commandTokenIndex: -1 };
+}
+
+/**
+ * Build the `Run '<scope> --help'` hint carried by a dispatch failure.
+ *
+ * A CLI that released `help` through `.builtins({ help: 'off' })` rejects the
+ * token, so the hint is dropped rather than pointing at a flag the program
+ * answers with `Unknown flag --help`.
+ *
+ * @param scopePath - Binary name plus any ancestor command names.
+ * @param helpOwned - Whether the root still owns `--help`.
+ * @returns The `suggest` field, or an empty object.
+ *
+ * @internal
+ */
+function helpHint(scopePath: string, helpOwned: boolean): { readonly suggest?: string } {
+	return helpOwned ? { suggest: `Run '${scopePath} --help' for available commands` } : {};
 }
 
 /**
@@ -452,7 +478,8 @@ function planCompletionsFlag(
  * @internal
  */
 function planInvocation(options: PlanInvocationOptions): InvocationPlan {
-	const rootOutputFlags = readRootOutputFlags(options.argv);
+	const helpOwned = builtinEnabled(options.schema.builtins, 'help');
+	const rootOutputFlags = readRootOutputFlags(options.argv, options.schema.builtins);
 	const filteredArgv = rootOutputFlags.argv;
 	const separatorIndex = filteredArgv.indexOf('--');
 	const filteredHead = separatorIndex === -1 ? filteredArgv : filteredArgv.slice(0, separatorIndex);
@@ -490,7 +517,7 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 	// A help flag *after* a subcommand token is left to that command's executor,
 	// keeping `app sub --help` scoped to the subcommand (version stays global by
 	// design — there is no per-command version).
-	const headScan = scanRootHead(filteredHead, rootValueFlags);
+	const headScan = scanRootHead(filteredHead, rootValueFlags, helpOwned);
 	if (headScan.helpBeforeCommand) {
 		return {
 			kind: 'root-help',
@@ -500,7 +527,7 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 
 	// Bare `help` token: a root help request (or `<command> --help` forwarding)
 	// when it is the first command token and no real `help` command is registered.
-	if (headScan.firstCommandToken === 'help') {
+	if (helpOwned && headScan.firstCommandToken === 'help') {
 		const hasRealHelpCommand = options.compiled.commands.some(
 			(command) => command.schema.name === 'help' || command.schema.aliases.includes('help'),
 		);
@@ -520,7 +547,7 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 		}
 	}
 
-	if (rootOutputFlags.kind === 'failed' && !requestsHelp(filteredArgv)) {
+	if (rootOutputFlags.kind === 'failed' && !(helpOwned && requestsHelp(filteredArgv))) {
 		return { kind: 'dispatch-error', error: rootOutputFlags.error };
 	}
 
@@ -587,7 +614,7 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 						kind: 'dispatch-error',
 						error: new ParseError(`Unknown flag ${unknownFlag}`, {
 							code: 'UNKNOWN_FLAG',
-							suggest: `Run '${options.schema.name} --help' for available commands`,
+							...helpHint(options.schema.name, helpOwned),
 						}),
 					};
 				}
@@ -606,7 +633,7 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 					kind: 'dispatch-error',
 					error: new ParseError(`Unknown flag ${unknownFlag}`, {
 						code: 'UNKNOWN_FLAG',
-						suggest: `Run '${options.schema.name} --help' for available commands`,
+						...helpHint(options.schema.name, helpOwned),
 					}),
 				};
 			}
@@ -621,10 +648,9 @@ function planInvocation(options: PlanInvocationOptions): InvocationPlan {
 				kind: 'dispatch-error',
 				error: new ParseError(`Unknown command: ${result.input}`, {
 					code: 'UNKNOWN_COMMAND',
-					suggest:
-						suggestion !== undefined
-							? `Did you mean '${suggestion}'?`
-							: `Run '${scopePath} --help' for available commands`,
+					...(suggestion !== undefined
+						? { suggest: `Did you mean '${suggestion}'?` }
+						: helpHint(scopePath, helpOwned)),
 				}),
 			};
 		}

--- a/src/core/cli/reserved-flags.test.ts
+++ b/src/core/cli/reserved-flags.test.ts
@@ -214,7 +214,7 @@ describe('reserved root flags', () => {
 			expect(error.message).toContain("reserved by the root '--quiet' flag");
 			expect(error.message).toContain('so the command can never receive it');
 			expect(error.suggest).toBe(
-				'Rename the flag, or use out.status() for output that root --quiet suppresses',
+				"Rename the flag, or use out.status() for output that root --quiet suppresses, or release the built-in with .builtins({ quiet: 'off' }) before registering the command",
 			);
 		});
 
@@ -236,8 +236,18 @@ describe('reserved root flags', () => {
 			expect(error.message).toContain("defines a '--quiet' negated spelling on flag 'loud'");
 		});
 
-		it('suggests renaming for the non-quiet reservations', () => {
+		it('suggests renaming or releasing for the non-quiet reservations', () => {
 			const error = reservedError(() => cli('mycli').command(booleanCommand('json')));
+
+			expect(error.suggest).toBe(
+				"Rename the flag, or release the built-in with .builtins({ json: 'off' }) before registering the command",
+			);
+		});
+
+		it('offers only renaming for the version reservation, which has no built-in switch', () => {
+			const error = reservedError(() =>
+				cli('mycli').version('1.0.0').command(booleanCommand('version')),
+			);
 
 			expect(error.suggest).toBe('Rename the flag');
 		});
@@ -314,6 +324,21 @@ describe('reserved root flags', () => {
 				expect(result.stdout.join('')).not.toContain('ran');
 				expect(result.stdout.join('')).toContain('Serve it');
 			}
+		});
+
+		it('reserves short aliases the root only strips as their own token', async () => {
+			expect(() =>
+				cli('mycli').command(commandWithFlag('quick', flag.boolean().alias('q'))),
+			).toThrow(CLIError);
+
+			const clustered = command('serve')
+				.flag('verbose', flag.boolean().alias('v'))
+				.flag('force', flag.boolean().alias('f'))
+				.action(({ flags, out }) => out.log(`${flags.verbose} ${flags.force}`));
+
+			const result = await cli('mycli').command(clustered).execute(['serve', '-vf']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.join('')).toBe('true true\n');
 		});
 
 		it('intercepts --version and -V only once a version is configured', async () => {

--- a/src/core/cli/reserved-flags.ts
+++ b/src/core/cli/reserved-flags.ts
@@ -7,6 +7,9 @@
  * {@linkcode CLIError} `RESERVED_FLAG` here rather than building a CLI whose
  * flag silently stays at its default (#84).
  *
+ * A built-in released through `.builtins({ <name>: 'off' })` drops out of the
+ * reserved set, which is what makes the flag declarable (#86).
+ *
  * @module dreamcli/core/cli/reserved-flags
  * @internal
  */
@@ -15,8 +18,8 @@ import { CLIError } from '#internals/core/errors/index.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import type { FlagSchema } from '#internals/core/schema/flag.ts';
 import { getFlagAliasNames, getFlagNegatedName } from '#internals/core/schema/flag.ts';
-import type { RootOutputFlagName } from './root-output-flags.ts';
-import { ROOT_OUTPUT_TOKENS } from './root-output-flags.ts';
+import type { BuiltinName, BuiltinsConfig } from './builtins.ts';
+import { BUILTIN_NAMES, BUILTIN_SPECS, builtinEnabled, builtinTokens } from './builtins.ts';
 
 /** What the root does with a token, and how a colliding command flag is fixed. @internal */
 interface ReservedFlag {
@@ -28,72 +31,83 @@ interface ReservedFlag {
 	readonly remedy: string;
 }
 
-/** Remedy for every reserved token whose only fix is a different spelling. */
+/** Remedy for a reserved token whose only fix is a different spelling. */
 const RENAME = 'Rename the flag';
 
-/** Remedy for the `--quiet`/`-q` tokens, which have a framework equivalent. */
-const RENAME_OR_STATUS =
-	'Rename the flag, or use out.status() for output that root --quiet suppresses';
+/** Why the root never hands a command the tokens it strips from argv. */
+const STRIPPED = 'The root strips that token before dispatch';
 
-/** Remedy per root output flag, keyed by the canonical name the root strips under. */
-const ROOT_OUTPUT_REMEDIES: Readonly<Record<RootOutputFlagName, string>> = {
-	json: RENAME,
-	quiet: RENAME_OR_STATUS,
+/** Why a command never receives `--help`, in either interception path. */
+const HELP_INTERCEPTED = 'A help request renders before flags are parsed';
+
+/** Why a command never receives `--version`. */
+const VERSION_INTERCEPTED = 'The root intercepts that token before dispatch';
+
+/** Extra clause offered for `--quiet`, which has a framework equivalent. */
+const STATUS_ALTERNATIVE = 'use out.status() for output that root --quiet suppresses';
+
+/** Offer the `.builtins()` opt-out alongside renaming. */
+function releaseRemedy(name: BuiltinName, ...alternatives: readonly string[]): string {
+	return [
+		RENAME,
+		...alternatives,
+		`release the built-in with .builtins({ ${name}: 'off' }) before registering the command`,
+	].join(', or ');
+}
+
+/** Why the root owns each built-in's tokens. */
+const BUILTIN_EFFECTS: Readonly<Record<BuiltinName, string>> = {
+	help: HELP_INTERCEPTED,
+	json: STRIPPED,
+	quiet: STRIPPED,
 };
 
-/** Reservations for the tokens {@linkcode ROOT_OUTPUT_TOKENS} strips from argv. */
-const OUTPUT_RESERVED: readonly (readonly [string, ReservedFlag])[] = [...ROOT_OUTPUT_TOKENS].map(
-	([token, name]) => [
-		token,
-		{
-			rootSpelling: `--${name}`,
-			effect: 'The root strips that token before dispatch',
-			remedy: ROOT_OUTPUT_REMEDIES[name],
-		},
-	],
-);
-
-/**
- * Reservation for `--help`/`-h`.
- *
- * The root intercepts the token when it precedes any command token, and the
- * command executor renders help ahead of `parse()` otherwise, so neither path
- * assigns the flag a value.
- */
-const HELP_RESERVED: ReservedFlag = {
-	rootSpelling: '--help',
-	effect: 'A help request renders before flags are parsed',
-	remedy: RENAME,
+/** How a collision with each built-in is fixed. */
+const BUILTIN_REMEDIES: Readonly<Record<BuiltinName, string>> = {
+	help: releaseRemedy('help'),
+	json: releaseRemedy('json'),
+	quiet: releaseRemedy('quiet', STATUS_ALTERNATIVE),
 };
 
 /** Reservation for `--version`/`-V`, active once the CLI declares a version. */
 const VERSION_RESERVED: ReservedFlag = {
 	rootSpelling: '--version',
-	effect: 'The root intercepts that token before dispatch',
+	effect: VERSION_INTERCEPTED,
 	remedy: RENAME,
 };
 
-/** Tokens the root owns on every CLI, keyed by their bare spelling. */
-const ALWAYS_RESERVED: readonly (readonly [string, ReservedFlag])[] = [
-	...OUTPUT_RESERVED,
-	['help', HELP_RESERVED],
-	['h', HELP_RESERVED],
-];
-
 /** Tokens the root owns only once a version is configured. */
-const VERSION_TOKENS: readonly (readonly [string, ReservedFlag])[] = [
-	['version', VERSION_RESERVED],
-	['V', VERSION_RESERVED],
-];
+const VERSION_TOKENS: readonly string[] = ['version', 'V'];
 
-/** Reserved tokens with a version declared. */
-const RESERVED_WITH_VERSION: ReadonlyMap<string, ReservedFlag> = new Map([
-	...ALWAYS_RESERVED,
-	...VERSION_TOKENS,
-]);
+/**
+ * The tokens a CLI's commands may not spell.
+ *
+ * Built by walking {@link BUILTIN_SPECS}, so the reserved set and the spellings
+ * the root actually reads cannot drift, and a released built-in is absent here
+ * by construction.
+ */
+function reservedTokens(
+	version: string | undefined,
+	builtins: BuiltinsConfig | undefined,
+): ReadonlyMap<string, ReservedFlag> {
+	const reserved = new Map<string, ReservedFlag>();
 
-/** Reserved tokens without a version declared. */
-const RESERVED_WITHOUT_VERSION: ReadonlyMap<string, ReservedFlag> = new Map(ALWAYS_RESERVED);
+	for (const name of BUILTIN_NAMES) {
+		if (!builtinEnabled(builtins, name)) continue;
+		const entry: ReservedFlag = {
+			rootSpelling: BUILTIN_SPECS[name].spelling,
+			effect: BUILTIN_EFFECTS[name],
+			remedy: BUILTIN_REMEDIES[name],
+		};
+		for (const token of builtinTokens(name)) reserved.set(token, entry);
+	}
+
+	if (version !== undefined) {
+		for (const token of VERSION_TOKENS) reserved.set(token, VERSION_RESERVED);
+	}
+
+	return reserved;
+}
 
 /** Which declaration on a flag produced a colliding spelling. @internal */
 type CollisionOrigin = 'name' | 'alias' | 'negation';
@@ -201,6 +215,8 @@ function reservedFlagError(collision: ReservedCollision): CLIError {
  *   `--version`/`-V` available to commands.
  * @param commands - Command trees to walk. `undefined` entries are skipped so
  *   callers can pass an absent default command directly.
+ * @param builtins - Built-in state; a released built-in reserves nothing.
+ *   `undefined` keeps every built-in on.
  * @throws {@linkcode CLIError} `RESERVED_FLAG` for the first collision found.
  *
  * @internal
@@ -208,8 +224,9 @@ function reservedFlagError(collision: ReservedCollision): CLIError {
 function assertNoReservedFlagCollisions(
 	version: string | undefined,
 	commands: readonly (CommandSchema | undefined)[],
+	builtins?: BuiltinsConfig,
 ): void {
-	const reserved = version !== undefined ? RESERVED_WITH_VERSION : RESERVED_WITHOUT_VERSION;
+	const reserved = reservedTokens(version, builtins);
 
 	for (const schema of commands) {
 		if (schema === undefined) continue;

--- a/src/core/cli/reserved-flags.ts
+++ b/src/core/cli/reserved-flags.ts
@@ -19,7 +19,7 @@ import type { CommandSchema } from '#internals/core/schema/command.ts';
 import type { FlagSchema } from '#internals/core/schema/flag.ts';
 import { getFlagAliasNames, getFlagNegatedName } from '#internals/core/schema/flag.ts';
 import type { BuiltinName, BuiltinsConfig } from './builtins.ts';
-import { BUILTIN_NAMES, BUILTIN_SPECS, builtinEnabled, builtinTokens } from './builtins.ts';
+import { BUILTIN_NAMES, builtinEnabled, builtinSpelling, builtinTokens } from './builtins.ts';
 
 /** What the root does with a token, and how a colliding command flag is fixed. @internal */
 interface ReservedFlag {
@@ -82,7 +82,7 @@ const VERSION_TOKENS: readonly string[] = ['version', 'V'];
 /**
  * The tokens a CLI's commands may not spell.
  *
- * Built by walking {@link BUILTIN_SPECS}, so the reserved set and the spellings
+ * Built from the shared built-in spelling table, so the reserved set and the spellings
  * the root actually reads cannot drift, and a released built-in is absent here
  * by construction.
  */
@@ -95,7 +95,7 @@ function reservedTokens(
 	for (const name of BUILTIN_NAMES) {
 		if (!builtinEnabled(builtins, name)) continue;
 		const entry: ReservedFlag = {
-			rootSpelling: BUILTIN_SPECS[name].spelling,
+			rootSpelling: builtinSpelling(name),
 			effect: BUILTIN_EFFECTS[name],
 			remedy: BUILTIN_REMEDIES[name],
 		};

--- a/src/core/cli/root-help.ts
+++ b/src/core/cli/root-help.ts
@@ -16,6 +16,8 @@ import type { CommandSchema } from '#internals/core/schema/command.ts';
 import { command } from '#internals/core/schema/command.ts';
 import type { FlagSchema } from '#internals/core/schema/flag.ts';
 import { createFlagSchema } from '#internals/core/schema/flag.ts';
+import type { BuiltinName, BuiltinsConfig } from './builtins.ts';
+import { BUILTIN_SPECS, builtinEnabled, builtinFlagForms } from './builtins.ts';
 import { resolveRootSurface } from './root-surface.ts';
 
 // Re-use CLISchema inline to avoid circular import through the barrel.
@@ -43,6 +45,12 @@ interface CLISchemaLike {
 	 * advertises it in `Global options:`.
 	 */
 	readonly configSettings?: { readonly appName: string } | undefined;
+	/**
+	 * Built-in flag state. A built-in set to `'off'` belongs to the commands, so
+	 * `Global options:` stops advertising it. Optional so hand-built schema-like
+	 * objects keep every built-in.
+	 */
+	readonly builtins?: BuiltinsConfig | undefined;
 }
 
 // --- Root help formatter
@@ -56,6 +64,9 @@ interface CLISchemaLike {
  * omitted from the `Commands:` list unless `showDefaultInCommands` is set. When
  * `.completions({ as: 'flag' })` is active, the eager `--completions <shell>`
  * flag is advertised in the `Flags:` section.
+ *
+ * A built-in released through `.builtins({ <name>: 'off' })` drops out of
+ * `Global options:`, and releasing `help` also drops the `--help` footer hint.
  *
  * @internal
  */
@@ -173,7 +184,8 @@ function formatRootHelp(schema: CLISchemaLike, options?: HelpOptions): string {
 	}
 
 	// ---- Footer -------------------------------------------------------------
-	const footerVisible = options?.footer ?? surface.hasVisibleSubcommands;
+	const footerVisible =
+		builtinEnabled(schema.builtins, 'help') && (options?.footer ?? surface.hasVisibleSubcommands);
 	if (footerVisible) {
 		const footerPlaceholder = surface.hasVisibleSubcommands
 			? defaultCommand !== undefined
@@ -300,15 +312,17 @@ function formatRootCommandsSection(
 /**
  * Build the `Global options:` section advertising the active built-in flags.
  *
- * `--help, -h` and `--json` are always available; `--version, -V` is shown only
- * when the program declares a version; `--config <path>` only when `.config()`
- * enabled config discovery. The eager `--completions` flag is intentionally
- * omitted — it is advertised via the inline surface when active.
+ * `--help, -h`, `--json`, and `-q, --quiet` are listed while the root owns them;
+ * `.builtins({ <name>: 'off' })` hands the token to the commands and drops the
+ * entry. `--version, -V` is shown only when the program declares a version;
+ * `--config <path>` only when `.config()` enabled config discovery. The eager
+ * `--completions` flag is intentionally omitted, since it is advertised via the
+ * inline surface when active.
  *
- * @param schema - The CLI schema (read for `version` and `configSettings`).
+ * @param schema - The CLI schema (read for `version`, `configSettings`, and `builtins`).
  * @param width - Terminal width for description wrapping.
  * @param theme - Theme applied to the title and flag forms.
- * @returns Formatted `Global options:` block (always non-empty).
+ * @returns Formatted `Global options:` block, or `''` when nothing is active.
  * @internal
  */
 function formatGlobalOptionsSection(
@@ -316,26 +330,31 @@ function formatGlobalOptionsSection(
 	width: number,
 	theme: HelpTheme,
 ): string {
-	const entries: FlagEntry[] = [
-		{ left: theme.flag('-h, --help'), description: 'Show this help message and exit' },
-	];
+	const entries: FlagEntry[] = [];
+	const pushBuiltin = (name: BuiltinName): void => {
+		if (!builtinEnabled(schema.builtins, name)) return;
+		entries.push({
+			left: theme.flag(builtinFlagForms(name)),
+			description: BUILTIN_SPECS[name].description,
+		});
+	};
+
+	pushBuiltin('help');
 	if (schema.version !== undefined) {
 		entries.push({
 			left: theme.flag('-V, --version'),
 			description: 'Print the version number and exit',
 		});
 	}
-	entries.push({ left: theme.flag('--json'), description: 'Emit machine-readable JSON output' });
-	entries.push({
-		left: theme.flag('-q, --quiet'),
-		description: 'Suppress informational output',
-	});
+	pushBuiltin('json');
+	pushBuiltin('quiet');
 	if (schema.configSettings !== undefined) {
 		entries.push({
 			left: `${theme.flag('--config')} ${theme.placeholder('<path>')}`,
 			description: 'Load configuration from the given file',
 		});
 	}
+	if (entries.length === 0) return '';
 	return formatFlagEntriesBlock(theme.sectionTitle('Global options:'), entries, width);
 }
 

--- a/src/core/cli/root-output-flags.ts
+++ b/src/core/cli/root-output-flags.ts
@@ -8,6 +8,9 @@
  * bare presence, `=true`/`=1`, `=false`/`=0`, last occurrence wins, and an
  * invalid literal produces the parser's own `INVALID_VALUE` error.
  *
+ * A built-in released through `.builtins({ json: 'off' })` is neither read nor
+ * stripped here, so its tokens reach normal command parsing (#86).
+ *
  * @module dreamcli/core/cli/root-output-flags
  * @internal
  */
@@ -16,6 +19,8 @@ import { ParseError } from '#internals/core/errors/index.ts';
 import type { Verbosity } from '#internals/core/output/contracts.ts';
 import { coerceFlagValue } from '#internals/core/parse/index.ts';
 import { flag } from '#internals/core/schema/flag.ts';
+import type { BuiltinsConfig } from './builtins.ts';
+import { BUILTIN_SPECS, builtinEnabled } from './builtins.ts';
 
 /** Canonical name of a root output flag. @internal */
 type RootOutputFlagName = 'json' | 'quiet';
@@ -59,30 +64,23 @@ type RootTokenMatch =
 /** The schema root `--json`/`--quiet` share with a command-level boolean flag. */
 const rootBooleanSchema = flag.boolean().schema;
 
+/** The built-ins whose tokens this module reads, in stable order. */
+const ROOT_OUTPUT_NAMES: readonly RootOutputFlagName[] = ['json', 'quiet'];
+
+/** Index the spellings of one kind, taken from the shared built-in table. */
+function spellingIndex(kind: 'long' | 'short'): ReadonlyMap<string, RootOutputFlagName> {
+	const index = new Map<string, RootOutputFlagName>();
+	for (const name of ROOT_OUTPUT_NAMES) {
+		for (const spelling of BUILTIN_SPECS[name][kind]) index.set(spelling, name);
+	}
+	return index;
+}
+
 /** Long spellings, the only ones the tokenizer lets carry an inline `=value`. */
-const ROOT_LONG_SPELLINGS: ReadonlyMap<string, RootOutputFlagName> = new Map([
-	['--json', 'json'],
-	['--quiet', 'quiet'],
-]);
+const ROOT_LONG_SPELLINGS: ReadonlyMap<string, RootOutputFlagName> = spellingIndex('long');
 
 /** Short spellings, which have no inline-value form. */
-const ROOT_SHORT_SPELLINGS: ReadonlyMap<string, RootOutputFlagName> = new Map([['-q', 'quiet']]);
-
-/**
- * Every spelling this module strips, as a bare token without its dashes.
- *
- * The build-time `RESERVED_FLAG` guard reads this instead of restating the
- * spellings, so a token added above is reserved on command flags in the same
- * change.
- *
- * @internal
- */
-const ROOT_OUTPUT_TOKENS: ReadonlyMap<string, RootOutputFlagName> = new Map(
-	[...ROOT_LONG_SPELLINGS, ...ROOT_SHORT_SPELLINGS].map(([spelling, name]) => [
-		spelling.replace(/^-+/, ''),
-		name,
-	]),
-);
+const ROOT_SHORT_SPELLINGS: ReadonlyMap<string, RootOutputFlagName> = spellingIndex('short');
 
 /** Coerce an inline `=value` the way a command-level boolean flag coerces it. */
 function coerceRootValue(name: RootOutputFlagName, spelling: string, raw: string): RootTokenMatch {
@@ -95,19 +93,30 @@ function coerceRootValue(name: RootOutputFlagName, spelling: string, raw: string
 	}
 }
 
+/** Look up a spelling, skipping built-ins the CLI released to its commands. */
+function ownedName(
+	index: ReadonlyMap<string, RootOutputFlagName>,
+	spelling: string,
+	builtins: BuiltinsConfig | undefined,
+): RootOutputFlagName | undefined {
+	const name = index.get(spelling);
+	if (name === undefined || !builtinEnabled(builtins, name)) return undefined;
+	return name;
+}
+
 /** Resolve one pre-separator argv token against the root output flags. */
-function matchRootToken(token: string): RootTokenMatch {
-	const shortName = ROOT_SHORT_SPELLINGS.get(token);
+function matchRootToken(token: string, builtins: BuiltinsConfig | undefined): RootTokenMatch {
+	const shortName = ownedName(ROOT_SHORT_SPELLINGS, token, builtins);
 	if (shortName !== undefined) return { kind: 'flag', name: shortName, selection: 'on' };
 
-	const bareName = ROOT_LONG_SPELLINGS.get(token);
+	const bareName = ownedName(ROOT_LONG_SPELLINGS, token, builtins);
 	if (bareName !== undefined) return { kind: 'flag', name: bareName, selection: 'on' };
 
 	const equals = token.indexOf('=');
 	if (equals === -1) return { kind: 'unrelated' };
 
 	const spelling = token.slice(0, equals);
-	const valuedName = ROOT_LONG_SPELLINGS.get(spelling);
+	const valuedName = ownedName(ROOT_LONG_SPELLINGS, spelling, builtins);
 	if (valuedName === undefined) return { kind: 'unrelated' };
 
 	return coerceRootValue(valuedName, spelling, token.slice(equals + 1));
@@ -125,11 +134,13 @@ function matchRootToken(token: string): RootTokenMatch {
  * can still be honoured ahead of it.
  *
  * @param argv - Raw argv tokens (excluding the binary/script path).
+ * @param builtins - Built-in state; a released built-in's tokens are left in
+ *   argv untouched. `undefined` keeps both built-ins on.
  * @returns The selections, the stripped argv, and the first invalid value's
  *   error when one occurred.
  * @internal
  */
-function readRootOutputFlags(argv: readonly string[]): RootOutputFlags {
+function readRootOutputFlags(argv: readonly string[], builtins?: BuiltinsConfig): RootOutputFlags {
 	const separatorIndex = argv.indexOf('--');
 	const head = separatorIndex === -1 ? argv : argv.slice(0, separatorIndex);
 
@@ -142,7 +153,7 @@ function readRootOutputFlags(argv: readonly string[]): RootOutputFlags {
 	let stripped = false;
 
 	for (const token of head) {
-		const match = matchRootToken(token);
+		const match = matchRootToken(token, builtins);
 		if (match.kind === 'unrelated') {
 			keptHead.push(token);
 			continue;
@@ -203,4 +214,4 @@ function resolveRootVerbosity(
 }
 
 export type { RootOutputFlagName, RootOutputFlags };
-export { ROOT_OUTPUT_TOKENS, readRootOutputFlags, resolveRootJsonMode, resolveRootVerbosity };
+export { readRootOutputFlags, resolveRootJsonMode, resolveRootVerbosity };

--- a/src/core/cli/runtime-preflight.test.ts
+++ b/src/core/cli/runtime-preflight.test.ts
@@ -164,6 +164,34 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 		expect(preflight.error.details).toEqual({ command: 'info', flag: 'version' });
 	});
 
+	it('leaves a discovered version alone when no command flag collides', async () => {
+		const app = cli('myapp')
+			.manifest()
+			.command(
+				command('info')
+					.flag('versionTag', flag.string())
+					.action(() => {}),
+			);
+
+		const adapter = createTestAdapter({
+			argv: ['node', 'test', 'info'],
+			cwd: '/work',
+			readFile: async (path) => (path === '/work/package.json' ? '{"version":"6.6.6"}' : null),
+		});
+
+		const preflight = await prepareRuntimePreflight({
+			schema: app.schema,
+			compiled: compiledStateOf(app),
+			adapter,
+			options: undefined,
+			inheritedName: undefined,
+		});
+
+		expect(preflight.kind).toBe('ready');
+		if (preflight.kind !== 'ready') return;
+		expect(preflight.schema.version).toBe('6.6.6');
+	});
+
 	it('skips config discovery for completions invocations', async () => {
 		const readFile = vi.fn(async () => '{"deploy":{"region":"eu"}}');
 		const app = cli('myapp').config('myapp').completions();

--- a/src/core/cli/runtime-preflight.ts
+++ b/src/core/cli/runtime-preflight.ts
@@ -23,6 +23,8 @@ import type { PromptEngine } from '#internals/core/prompt/index.ts';
 import { createTerminalPrompter } from '#internals/core/prompt/index.ts';
 import type { CommandSchema } from '#internals/core/schema/command.ts';
 import type { RuntimeAdapter } from '#internals/runtime/adapter.ts';
+import type { BuiltinsConfig, BuiltinsDraft } from './builtins.ts';
+import { builtinEnabled } from './builtins.ts';
 import type { CompiledCLI } from './compiled.ts';
 import type { HelpLinks } from './help-links.ts';
 import { deriveHelpLinks } from './help-links.ts';
@@ -108,6 +110,8 @@ interface RuntimePreflightSchemaLike {
 		| undefined;
 	/** Flag-parsing behavior settings (e.g. case parity). */
 	readonly flagSettings: ParseOptions | undefined;
+	/** Which built-in flags the root still owns; a released one is left in argv. */
+	readonly builtins: BuiltinsDraft;
 }
 
 /**
@@ -264,8 +268,9 @@ function commandInvocationNeedsStdin(
 	schema: CommandSchema,
 	argv: readonly string[],
 	flagSettings?: ParseOptions,
+	builtins?: BuiltinsConfig,
 ): boolean {
-	if (argv.includes('--help') || argv.includes('-h')) {
+	if (builtinEnabled(builtins, 'help') && (argv.includes('--help') || argv.includes('-h'))) {
 		return false;
 	}
 
@@ -303,6 +308,7 @@ function invocationNeedsStdin(
 				plan.plan.mergedSchema,
 				plan.plan.argv,
 				schema.flagSettings,
+				schema.builtins,
 			);
 		case 'dispatch-error':
 		case 'needs-subcommand':
@@ -374,6 +380,34 @@ async function applyPackageJsonDiscovery(
 	return inheritedName !== undefined ? { ...packageSchema, name: inheritedName } : packageSchema;
 }
 
+/**
+ * Re-run the `RESERVED_FLAG` guard when discovery supplied the version.
+ *
+ * `.manifest()` reads a version off the filesystem at `.run()` time, past every
+ * build-time check, so a command flag named `version` or aliased `V` would
+ * become unreachable without ever being rejected. Running the same guard here
+ * fails the startup with the identical error the build paths raise (#86).
+ *
+ * @param discovered - Schema after manifest discovery merged its metadata in.
+ * @param declared - Schema as the builder had it before discovery.
+ * @param compiled - Compiled graph carrying every registered command schema.
+ * @throws {@linkcode CLIError} `RESERVED_FLAG` for the first collision found.
+ *
+ * @internal
+ */
+function assertDiscoveredVersionIsFree(
+	discovered: RuntimePreflightSchemaLike,
+	declared: RuntimePreflightSchemaLike,
+	compiled: CompiledCLI,
+): void {
+	if (discovered.version === declared.version) return;
+	assertNoReservedFlagCollisions(
+		discovered.version,
+		[compiled.defaultCommand?.schema, ...compiled.commands.map((command) => command.schema)],
+		discovered.builtins,
+	);
+}
+
 async function loadRuntimeConfig(
 	schema: RuntimePreflightSchemaLike,
 	adapter: RuntimeAdapter,
@@ -417,7 +451,7 @@ async function prepareRuntimePreflight(
 		options.schema.configSettings !== undefined
 			? extractConfigFlag(rawArgv)
 			: { configPath: undefined, filteredArgv: rawArgv };
-	const rootOutputFlags = readRootOutputFlags(filteredArgv);
+	const rootOutputFlags = readRootOutputFlags(filteredArgv, options.schema.builtins);
 	const jsonMode = resolveRootJsonMode(rootOutputFlags, options.options?.jsonMode);
 	const verbosity = resolveRootVerbosity(rootOutputFlags, options.options?.verbosity) ?? 'normal';
 	const isCompletions = isCompletionsInvocation(options.schema, options.compiled, filteredArgv);
@@ -428,10 +462,7 @@ async function prepareRuntimePreflight(
 		isCompletions,
 	);
 	try {
-		assertNoReservedFlagCollisions(schema.version, [
-			options.compiled.defaultCommand?.schema,
-			...options.compiled.commands.map((compiled) => compiled.schema),
-		]);
+		assertDiscoveredVersionIsFree(schema, options.schema, options.compiled);
 	} catch (error: unknown) {
 		if (error instanceof CLIError) return { kind: 'config-error', error, jsonMode };
 		throw error;

--- a/src/core/completion/shells/shared.ts
+++ b/src/core/completion/shells/shared.ts
@@ -9,6 +9,8 @@
  * @internal
  */
 
+import type { BuiltinsConfig } from '#internals/core/cli/builtins.ts';
+import { builtinEnabled } from '#internals/core/cli/builtins.ts';
 import { collectPropagatedFlags } from '#internals/core/cli/propagate.ts';
 import { resolveRootSurface } from '#internals/core/cli/root-surface.ts';
 import { createFlagSchema, getFlagNegatedName } from '#internals/core/schema/flag.ts';
@@ -104,6 +106,12 @@ interface RootCompletionSchemaLike {
 	readonly commands: readonly CommandSchema[];
 	readonly defaultCommand: CommandSchema | undefined;
 	readonly version: string | undefined;
+	/**
+	 * Built-in flag state. `help: 'off'` drops the synthetic root `--help` so a
+	 * command's own `help` flag is the only one completed. Optional so
+	 * hand-built schema-like objects keep every built-in.
+	 */
+	readonly builtins?: BuiltinsConfig | undefined;
 }
 
 /**
@@ -116,7 +124,10 @@ function resolveRootCompletionSurface(
 	rootMode: CompletionOptions['rootMode'] = 'subcommands',
 ): RootCompletionSurface {
 	const rootSurface = resolveRootSurface(schema);
-	const rootFlags = createRootFlags(schema.version !== undefined);
+	const rootFlags = createRootFlags(
+		builtinEnabled(schema.builtins, 'help'),
+		schema.version !== undefined,
+	);
 	const defaultFlags = rootSurface.visibleDefaultCommand?.flags ?? {};
 	// Default flags surface at the root either always (`surface`) or only when
 	// the default is the sole surface (`subcommands`).
@@ -151,13 +162,17 @@ function resolveRootCompletionSurface(
 /**
  * Build the synthetic root-level flags (`--help`, optionally `--version`).
  *
+ * @param hasHelp - Whether the root still owns `--help`.
  * @param hasVersion - Whether to include a `--version` flag.
  * @returns A record of root flag schemas.
  * @internal
  */
-function createRootFlags(hasVersion: boolean): Readonly<Record<string, FlagSchema>> {
+function createRootFlags(
+	hasHelp: boolean,
+	hasVersion: boolean,
+): Readonly<Record<string, FlagSchema>> {
 	return {
-		help: createSyntheticRootFlag('Show help text'),
+		...(hasHelp ? { help: createSyntheticRootFlag('Show help text') } : {}),
 		...(hasVersion ? { version: createSyntheticRootFlag('Show version') } : {}),
 	};
 }

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -8,6 +8,7 @@
  * @internal
  */
 
+import { builtinEnabled } from '#internals/core/cli/builtins.ts';
 import type {
 	BeforeParseParams,
 	CLIPlugin,
@@ -87,7 +88,7 @@ async function executeCommand(request: CommandExecutionRequest): Promise<Command
 	clearRequestedExitCode(out);
 
 	try {
-		if (requestsHelp(argv)) {
+		if (builtinEnabled(options?.builtins, 'help') && requestsHelp(argv)) {
 			// `options.jsonMode` carries the resolved JSON mode from the CLI/testkit
 			// layer (root `--json` is stripped from argv pre-dispatch) — an injected
 			// `out` may predate it, so the channel flag alone is not authoritative.

--- a/src/core/schema/brand.ts
+++ b/src/core/schema/brand.ts
@@ -13,6 +13,6 @@
 declare const schemaBrand: unique symbol;
 
 /** Discriminator literals carried by the sealed schema types. */
-type SchemaBrandKind = 'flag' | 'arg' | 'command' | 'cli' | 'config';
+type SchemaBrandKind = 'flag' | 'arg' | 'command' | 'cli' | 'config' | 'builtins';
 
 export type { SchemaBrandKind, schemaBrand };

--- a/src/core/schema/run.ts
+++ b/src/core/schema/run.ts
@@ -8,6 +8,7 @@
  * @module dreamcli/core/schema/run
  */
 
+import type { BuiltinsConfig } from '#internals/core/cli/builtins.ts';
 import type { CLIPlugin } from '#internals/core/cli/plugin.ts';
 import type { CLIError } from '#internals/core/errors/index.ts';
 import type { HelpOptions } from '#internals/core/help/index.ts';
@@ -183,6 +184,14 @@ export interface InternalRunOptions extends RunOptions {
 
 	/** CLI plugins registered on the parent `CLIBuilder`. */
 	readonly plugins?: readonly CLIPlugin[];
+
+	/**
+	 * Built-in flag state from the CLI schema.
+	 *
+	 * `help: 'off'` releases the command-level `--help`/`-h` short-circuit so a
+	 * command's own `help` flag parses. Absent means every built-in is on.
+	 */
+	readonly builtins?: BuiltinsConfig;
 }
 
 /**

--- a/src/core/schema/schema-sealing.test.ts
+++ b/src/core/schema/schema-sealing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import type { CLISchema, ConfigSettings } from '#internals/core/cli/index.ts';
+import type { Builtins, CLISchema, ConfigSettings } from '#internals/core/cli/index.ts';
 import { createCLISchema } from '#internals/core/cli/index.ts';
 import { CLIError } from '#internals/core/errors/index.ts';
 import type { ArgSchema } from './arg.ts';
@@ -22,9 +22,13 @@ type UnbrandedCommandSchema = Omit<CommandSchema, typeof schemaBrand>;
 /** {@link ConfigSettings} with the type-only brand removed. */
 type UnbrandedConfigSettings = Omit<ConfigSettings, typeof schemaBrand>;
 
+/** {@link Builtins} with the type-only brand removed. */
+type UnbrandedBuiltins = Omit<Builtins, typeof schemaBrand>;
+
 /** {@link CLISchema} with the type-only brands removed, nested settings included. */
-type UnbrandedCLISchema = Omit<CLISchema, typeof schemaBrand | 'configSettings'> & {
+type UnbrandedCLISchema = Omit<CLISchema, typeof schemaBrand | 'configSettings' | 'builtins'> & {
 	readonly configSettings: UnbrandedConfigSettings | undefined;
+	readonly builtins: UnbrandedBuiltins;
 };
 
 const spelledFlagFields: UnbrandedFlagSchema = {
@@ -85,6 +89,12 @@ const spelledConfigSettingsFields: UnbrandedConfigSettings = {
 	loaders: undefined,
 };
 
+const spelledBuiltinsFields: UnbrandedBuiltins = {
+	help: 'on',
+	json: 'on',
+	quiet: 'on',
+};
+
 const spelledCLIFields: UnbrandedCLISchema = {
 	name: 'mycli',
 	inheritName: false,
@@ -100,6 +110,7 @@ const spelledCLIFields: UnbrandedCLISchema = {
 	completionsFlag: undefined,
 	helpConfig: undefined,
 	flagSettings: undefined,
+	builtins: spelledBuiltinsFields,
 };
 
 /**
@@ -168,6 +179,16 @@ describe('schema sealing', () => {
 			expect(sealed.appName).toBe('mycli');
 		});
 
+		it('spells every built-in field a caller can reach', () => {
+			expect(createCLISchema({ name: 'mycli' }).builtins).toEqual(spelledBuiltinsFields);
+		});
+
+		it('rejects a fully spelled built-ins literal', () => {
+			// @ts-expect-error the builtins brand key is unspellable outside createCLISchema
+			const sealed: Builtins = spelledBuiltinsFields;
+			expect(sealed.help).toBe('on');
+		});
+
 		it('spells every CLI field a caller can reach', () => {
 			expect(spelledCLIFields).toEqual(createCLISchema({ name: 'mycli' }));
 		});
@@ -187,6 +208,8 @@ describe('schema sealing', () => {
 			expectTypeOf<UnbrandedCommandSchema>().not.toExtend<CommandSchema>();
 			expectTypeOf<ConfigSettings>().toExtend<UnbrandedConfigSettings>();
 			expectTypeOf<UnbrandedConfigSettings>().not.toExtend<ConfigSettings>();
+			expectTypeOf<Builtins>().toExtend<UnbrandedBuiltins>();
+			expectTypeOf<UnbrandedBuiltins>().not.toExtend<Builtins>();
 			expectTypeOf<CLISchema>().toExtend<UnbrandedCLISchema>();
 			expectTypeOf<UnbrandedCLISchema>().not.toExtend<CLISchema>();
 		});

--- a/src/core/testkit/index.ts
+++ b/src/core/testkit/index.ts
@@ -14,6 +14,8 @@
  * @module dreamcli/core/testkit
  */
 
+import type { BuiltinsConfig } from '#internals/core/cli/builtins.ts';
+import { builtinEnabled } from '#internals/core/cli/builtins.ts';
 import {
 	readRootOutputFlags,
 	resolveRootJsonMode,
@@ -31,6 +33,27 @@ import type { InternalRunOptions, RunOptions, RunResult } from '#internals/core/
 // for public testkit continuity.
 
 // --- Core execution pipeline
+
+/**
+ * Options for {@linkcode runCommand}.
+ *
+ * Extends {@linkcode RunOptions} with the CLI-root state `runCommand()` mirrors,
+ * following the way `CLIRunOptions` extends `CLIExecuteOptions` with the fields
+ * only that layer needs.
+ */
+interface RunCommandOptions extends RunOptions {
+	/**
+	 * Which built-in flags the harness mirrors, matching the CLI the command is
+	 * registered on.
+	 *
+	 * A command that owns a released built-in (`cli(...).builtins({ json: 'off' })`
+	 * plus a `json` flag) must be tested with the same setting, otherwise the
+	 * harness strips the token before `parse()` sees it.
+	 *
+	 * @defaultValue every built-in `'on'`, mirroring an unconfigured CLI root
+	 */
+	readonly builtins?: BuiltinsConfig;
+}
 
 /**
  * Run a command builder against the given argv with injected options.
@@ -53,14 +76,16 @@ import type { InternalRunOptions, RunOptions, RunResult } from '#internals/core/
  *   JSON mode and `['--quiet']` sets quiet verbosity rather than failing as
  *   unknown flags. Equivalent to `{ jsonMode: true }` / `{ verbosity: 'quiet' }`.
  *   Both accept an explicit value (`--json=false`), and an invalid one fails
- *   with the same `INVALID_VALUE` error the CLI root produces.
+ *   with the same `INVALID_VALUE` error the CLI root produces. Pass
+ *   `options.builtins` to mirror a CLI that released one of these tokens to its
+ *   commands.
  * @param options - Injectable runtime state
  * @returns Structured run result with exit code and captured output
  */
 async function runCommand(
 	cmd: RunnableCommand,
 	argv: readonly string[],
-	options?: RunOptions,
+	options?: RunCommandOptions,
 ): Promise<RunResult> {
 	return runCommandInternal(cmd, argv, options);
 }
@@ -81,7 +106,7 @@ async function runCommandInternal(
 	// reach `parse()` as unknown flags (#33). The shared reader detects them,
 	// strips them, and rejects an invalid `=value` exactly as dispatch does. The
 	// explicit `options.jsonMode` keeps working when argv says nothing.
-	const rootOutputFlags = readRootOutputFlags(argv);
+	const rootOutputFlags = readRootOutputFlags(argv, options?.builtins);
 	const jsonMode = resolveRootJsonMode(rootOutputFlags, options?.jsonMode);
 	const verbosity: Verbosity | undefined = resolveRootVerbosity(
 		rootOutputFlags,
@@ -105,7 +130,10 @@ async function runCommandInternal(
 		);
 	}
 
-	if (rootOutputFlags.kind === 'failed' && !requestsHelp(effectiveArgv)) {
+	if (
+		rootOutputFlags.kind === 'failed' &&
+		!(builtinEnabled(options?.builtins, 'help') && requestsHelp(effectiveArgv))
+	) {
 		const { error } = rootOutputFlags;
 		if (jsonMode) {
 			out.json({ error: error.toJSON() });
@@ -181,6 +209,6 @@ async function runCommandInternal(
  * expect(result.error).toBeUndefined();
  * ```
  */
-export type { RunOptions, RunResult };
+export type { RunCommandOptions, RunOptions, RunResult };
 
 export { runCommand, runCommandInternal };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@
 export type { Colors } from 'ansispeck';
 export type {
 	BeforeParseParams,
+	BuiltinMode,
+	BuiltinName,
+	Builtins,
+	BuiltinsConfig,
 	CLIDefinition,
 	CLIExecuteOptions,
 	CLIOptions,

--- a/src/testkit.ts
+++ b/src/testkit.ts
@@ -20,6 +20,6 @@ export {
 	type TestAnswer,
 	type TestPrompterOptions,
 } from './core/prompt/index.ts';
-export type { RunOptions, RunResult } from './core/testkit/index.ts';
+export type { RunCommandOptions, RunOptions, RunResult } from './core/testkit/index.ts';
 export { runCommand } from './core/testkit/index.ts';
 export { createTestAdapter, type TestAdapterOptions } from './runtime/index.ts';


### PR DESCRIPTION
Targets v4. Stacked on #108. Implements consumer ownership of built-in flags, the second half of the contract #108's guard started (its property 2: "leaving a built-in on and colliding with it is an error").

**`.builtins()` (#86)**
- `cli().builtins({ help | json | quiet: 'on' | 'off' })`, also accepted on `CLIDefinition`, normalized onto the sealed `CLISchema` as a required branded value with `INVALID_SCHEMA` boundary validation. Repeat calls merge last-wins, following `.help()`.
- Releasing a built-in stops interception and stripping (bare and `=value` forms), removes it from `Global options:` at root and command level, drops every hint that advertises the token (help footer, dispatch-failure suggestions, bare `help` routing, synthetic `--help` in generated completion scripts), and un-reserves it in the RESERVED_FLAG guard, so a command's own flag with that name works end to end. Programmatic `RunOptions` overrides keep working; `version`/`completions` stay governed by their opt-in methods.
- One `BUILTIN_SPECS` table feeds the scanner, the guard, help rendering, and completions; nothing restates a spelling.
- `.builtins()` must precede the colliding `.command()` registration; the guard's suggest text says so.
- Testkit: `RunCommandOptions extends RunOptions` carries the same knob; default behavior unchanged.
- Carry-overs from #108's review, closed here: bare `.manifest()` filesystem discovery now runs the reserved-flag guard at startup instead of leaving a `version` flag silently dead, and the short-cluster asymmetry (`-vq` reaches the command while bare `-q` is stripped; the guard is deliberately stricter) is pinned by test.
- Review escalation, fixed in this PR: dispatch errors still suggested `Run 'mycli --help'` after help was released.

Gates: typecheck, lint, fmt, full suite (3115 tests), build with attw+publint, docs build, meta-descriptions check. Guide section, upgrade-guide update, and stability classifications for `Builtins`, `BuiltinsConfig`, `BuiltinName`, `BuiltinMode`, `RunCommandOptions` included.

Closes #86
