### PR TITLE
feat: add `readFlags()` standalone typed flag evaluation (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,9 +91,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **`readFlags()` evaluates a record of flag builders outside a CLI**
   ([#107](https://github.com/kjanat/dreamcli/issues/107)). A build script or a
-  small tool that wants typed options without commands, handlers, output
-  channels, help, or process exit hands its flags straight to `readFlags()` and
-  awaits the resolved values, typed by `InferFlags`:
+  small tool that wants typed options without commands, handlers, or output
+  channels hands its flags straight to `readFlags()` and awaits the resolved
+  values, typed by `InferFlags`:
 
   ```ts
   const options = await readFlags({
@@ -116,15 +116,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `config` and `prompter` stay caller-supplied, since standalone flag reading
   has no application name to discover a file from and opens no terminal session.
   `ReadFlagsOptions` extends `ResolveOptions` with `argv`, `adapter`, `parse`,
-  and `onDeprecation`. The adapter is built on the first fact the caller left
+  `strict`, `help`, and `onDeprecation`. The adapter is built on the first fact
+  the caller left
   out, so a call given `argv` and `env` reads nothing from the host unless a
   `flag.path()` check needs the adapter's filesystem primitives. Failures throw
   `ParseError` and `ValidationError` instead of exiting, a colliding record or
   the definition key `__proto__` throws `CLIError` before argv is read, and
   `.deprecated()` notices reach `onDeprecation` rather than a warning stream,
-  since there is no output channel on this path. Root built-in spellings are not
-  reserved here either, so a record may declare `json`, `quiet`, or `help` as
-  ordinary flags. Positional arguments are not part of this API, and there is no
+  since there is no output channel on this path.
+
+  A pre-separator `--help` or `-h` prints generated help for the record to the
+  adapter's stdout and exits with code 0, with the script named from the
+  adapter's argv in the usage line. The built-in yields to a definition that
+  claims the `help` or `h` spelling through a name, alias, negated form, or
+  case-parity counterpart, and `help: 'off'` removes it entirely; `json` and
+  `quiet` are never reserved, so a record may declare them as ordinary flags.
+  `strict: false` drops undeclared argv content instead of rejecting it: unknown
+  long flags with their inline `=value`, unknown short-group characters,
+  positional arguments, and the `--` separator, while value tokens of declared
+  flags survive under the parser's own consumption rules and misuse of a
+  declared flag keeps its diagnostics.
+
+  Positional arguments are not part of this API, and there is no
   synchronous variant: prompts, async validators, and filesystem checks make the
   result a promise. `readFlags`, `ReadFlagsOptions`, and `FlagMap` are exported
   from the package root, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,48 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `generateCommandSchema()`, so that output gains `schemaVersion: 1` as its
   first key.
 
+- **`readFlags()` evaluates a record of flag builders outside a CLI**
+  ([#107](https://github.com/kjanat/dreamcli/issues/107)). A build script or a
+  small tool that wants typed options without commands, handlers, output
+  channels, help, or process exit hands its flags straight to `readFlags()` and
+  awaits the resolved values, typed by `InferFlags`:
+
+  ```ts
+  const options = await readFlags({
+  	watch: flag.boolean().alias('w').env('WATCH'),
+  	minify: flag.boolean().env('MINIFY').default(true),
+  	target: flag.enum(['node', 'browser']).env('TARGET').default('node'),
+  });
+
+  options.watch; // boolean
+  options.target; // 'node' | 'browser'
+  ```
+
+  Each object key is the canonical flag name, and evaluation runs through the
+  same command schema, parser, coercion, resolver, and validation a command
+  uses. Aliases, negated spellings, duplicate policy, case parity, unknown-flag
+  rejection, collisions between names, aliases and negated forms, the CLI, env,
+  config, prompt, default precedence, constraints, Standard Schema validators,
+  and `flag.path()` checks all behave as they do inside `.action()`. `argv`,
+  `env`, `stat`, and `mkdir` fall back to the detected `RuntimeAdapter`, while
+  `config` and `prompter` stay caller-supplied, since standalone flag reading
+  has no application name to discover a file from and opens no terminal session.
+  `ReadFlagsOptions` extends `ResolveOptions` with `argv`, `adapter`, `parse`,
+  and `onDeprecation`. The adapter is built on the first fact the caller left
+  out, so a call given `argv` and `env` reads nothing from the host unless a
+  `flag.path()` check needs the adapter's filesystem primitives. Failures throw
+  `ParseError` and `ValidationError` instead of exiting, a colliding record or
+  the definition key `__proto__` throws `CLIError` before argv is read, and
+  `.deprecated()` notices reach `onDeprecation` rather than a warning stream,
+  since there is no output channel on this path. Root built-in spellings are not
+  reserved here either, so a record may declare `json`, `quiet`, or `help` as
+  ordinary flags. Positional arguments are not part of this API, and there is no
+  synchronous variant: prompts, async validators, and filesystem checks make the
+  result a promise. `readFlags`, `ReadFlagsOptions`, and `FlagMap` are exported
+  from the package root, and
+  [Standalone Flag Evaluation](https://dreamcli.kjanat.dev/guide/read-flags)
+  walks the API with the build-script case it was added for.
+
 ### Changed
 
 - **Breaking: `CLISchema.commands` and `CLISchema.defaultCommand` hold

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -203,6 +203,10 @@ export default defineConfig({
 						{ text: 'Shell Completions', link: '/guide/completions' },
 						{ text: 'Interactive Prompts', link: '/guide/prompts' },
 						{ text: 'Runtime Support', link: '/guide/runtime' },
+						{
+							text: 'Standalone Flag Evaluation',
+							link: '/guide/read-flags',
+						},
 					],
 				},
 				{

--- a/docs/guide/limitations.md
+++ b/docs/guide/limitations.md
@@ -149,9 +149,10 @@ Why:
 Workarounds:
 
 - use dreamcli when you expect the CLI to grow or when typed multi-source behavior matters;
+- call `readFlags()` when a script wants typed flags and nothing else: no command, no handler, no output channel;
 - use a thinner parser when you only need a tiny wrapper script.
 
-References: [Why dreamcli](/guide/why), [Architecture Rationale](/guide/rationale)
+References: [Why dreamcli](/guide/why), [Architecture Rationale](/guide/rationale), [Standalone Flag Evaluation](/guide/read-flags)
 
 ## Adoption Guidance Lives Elsewhere On Purpose
 

--- a/docs/guide/read-flags.md
+++ b/docs/guide/read-flags.md
@@ -1,8 +1,9 @@
 # Standalone Flag Evaluation
 
 `readFlags()` takes a record of flag builders, evaluates it, and returns the
-resolved values. There is no command, no dispatch, no output channel, no help
-text, and no process exit. The call returns typed values or throws.
+resolved values. There is no command and no dispatch. The call returns typed
+values or throws, with one exception: `--help` prints generated help and exits,
+unless the record claims the spelling or the built-in is turned off.
 
 ## Build Scripts
 
@@ -149,6 +150,56 @@ reaches for `stat` or `mkdir`. Pass `adapter` to pin the runtime instead of
 detecting one. `createAdapter()` detects Node, Bun, and Deno, so the defaults
 work on all three.
 
+## Built-In Help
+
+A `--help` or `-h` before the `--` separator prints generated help for the
+record to the adapter's stdout and exits with code 0:
+
+```bash
+$ bun build.ts --help
+Usage: build.ts [flags]
+
+Flags:
+  -w, --watch    Rebuild on change
+      --minify   (default: true)
+```
+
+The usage line names the script from the adapter's argv. Help renders ahead of
+parsing, so a malformed value elsewhere in argv never hides the text explaining
+the flags.
+
+The built-in yields in two ways. Declaring a flag that answers to `help` or `h`
+through its name, an alias, a negated spelling, or a case-parity counterpart
+takes both spellings over, and they parse as that flag's own. Passing
+`help: 'off'` removes the built-in, and an undeclared `--help` is an unknown
+flag again.
+
+## Non-Strict Parsing
+
+`strict: false` drops undeclared argv content instead of rejecting it, so a
+script can read its own flags out of an argv it shares with another consumer:
+
+```ts twoslash
+import { flag, readFlags } from '@kjanat/dreamcli';
+// ---cut---
+const values = await readFlags(
+  { watch: flag.boolean() },
+  { argv: ['build', '--watch', '--unknown'], env: {}, strict: false },
+);
+
+values.watch; // true
+```
+
+Dropped are unknown long flags together with their inline `=value`, unknown
+characters inside a short group, positional arguments, and the `--` separator,
+which can only introduce positionals here. The filter walks the parser's own
+value consumption, so `--name booga` keeps `booga` as the value of a declared
+`--name` while the token after an unknown flag is dropped as a positional.
+
+Leniency covers undeclared input only. Misuse of a declared flag throws in
+either mode: a missing value, a failed coercion, a violated constraint, and a
+repeat under `.duplicates('error')` all keep their diagnostics.
+
 ## Deprecation Notices
 
 `.deprecated()` produces one notice per flag that actually sourced a value, in
@@ -176,8 +227,9 @@ so a call without `onDeprecation` drops them.
 
 Parse failures throw `ParseError`, resolution and constraint failures throw
 `ValidationError`, and a record that collides on a name, an alias, or a negated
-spelling throws `CLIError` before argv is read. Nothing is written anywhere and
-`adapter.exit` is never called, so the script owns what happens next:
+spelling throws `CLIError` before argv is read. Failure never writes output and
+never calls `adapter.exit`; only the built-in help path exits, and it exits
+with 0. The script owns what happens next:
 
 ```ts twoslash
 import { flag, isCLIError, readFlags } from '@kjanat/dreamcli';
@@ -204,17 +256,19 @@ try {
 **No config discovery.** Standalone flag reading has no application name and no
 discovery policy to guess from, so `config` is whatever the caller passes.
 
-**No root built-in flags.** `--help`, `--json`, and `--quiet` are neither
-reserved nor answered, so a record may declare any of them as an ordinary flag.
-Against a record that does not declare it, `--help` is an unknown flag.
+**No output built-ins.** `--json` and `--quiet` are neither reserved nor
+answered, so a record may declare either as an ordinary flag. `help` and `h`
+are answered by the built-in help, and declaring either spelling takes them
+over without a reservation error.
 
 **No synchronous variant.** Prompts, Standard Schema validators, and filesystem
 checks are asynchronous. A synchronous variant would either carry different
 semantics or reject part of the flag DSL, and either one means a second
 implementation of what this reuses.
 
-**No dispatch, actions, middleware, output, help, or completions.** Those belong
-to a CLI. Reach for [`cli()`](/guide/commands) when the script grows into one.
+**No dispatch, actions, middleware, output channel, or completions.** Those
+belong to a CLI. Reach for [`cli()`](/guide/commands) when the script grows into
+one.
 
 ## Related Pages
 

--- a/docs/guide/read-flags.md
+++ b/docs/guide/read-flags.md
@@ -1,0 +1,226 @@
+# Standalone Flag Evaluation
+
+`readFlags()` takes a record of flag builders, evaluates it, and returns the
+resolved values. There is no command, no dispatch, no output channel, no help
+text, and no process exit. The call returns typed values or throws.
+
+## Build Scripts
+
+A build script wants a few typed options and one direct action. Wrapping that in
+a `cli()` program costs a command, an action handler, and an output channel for
+behavior the script never uses, and calling `parse()` and `resolve()` by hand
+returns `Record<string, unknown>` and drops the types the builders carry.
+`readFlags()` is the flag layer on its own:
+
+```ts twoslash
+// build.ts
+import { flag, readFlags } from '@kjanat/dreamcli';
+
+const options = await readFlags({
+  watch: flag.boolean().alias('w').env('WATCH'),
+  minify: flag.boolean().env('MINIFY').default(true),
+  target: flag
+    .enum(['node', 'browser'])
+    .env('TARGET')
+    .default('node'),
+});
+
+options.target;
+//        ^?
+```
+
+Each of these invocations reaches the same three values:
+
+```bash
+WATCH=true bun build.ts
+bun build.ts --watch
+bun build.ts -w
+```
+
+## The Record API
+
+The object key is the `--name` spelling and the key on the returned record. The
+result is typed by `InferFlags`, the operator behind `flags` inside `.action()`,
+so kinds, enum literals, and presence rules carry over unchanged:
+
+```ts twoslash
+import { flag, readFlags } from '@kjanat/dreamcli';
+// ---cut---
+const values = await readFlags({
+  out: flag.string().required(),
+  tag: flag.string(),
+  verbose: flag.count().alias('v'),
+});
+
+values.tag;
+//      ^?
+```
+
+`out` is `string`, `tag` is `string | undefined`, and `verbose` is `number`.
+
+Evaluation is one pass over argv. The record is the complete flag surface, which
+is what makes unknown input detectable and what lets collisions between
+canonical names, aliases, and negated spellings be rejected. A per-flag reader
+would rescan argv and could not see either.
+
+## Semantics Come From The Command Path
+
+`readFlags()` compiles the record into a command schema and runs the same
+parser, coercion, resolver, and validation a command runs. Aliases,
+`--flag=value`, short-flag clustering, negated spellings declared with
+`.negatable()`, duplicate policy, kebab and camel spelling parity, unknown-flag
+rejection with suggestions, string and number constraints, Standard Schema
+validators, and `flag.path()` checks all behave as they do inside `.action()`.
+
+[CLI Semantics](/guide/semantics) is the rule set, and it applies here as
+written.
+
+## Precedence
+
+CLI argv, then environment variable, then config, then interactive prompt, then
+default. Each stage is opt-in per flag and the first source that supplies a
+value wins.
+
+Two stages need something from the caller. `config` is a plain object passed in;
+nothing is read from disk. `prompter` is a prompt engine passed in; none is
+built. A `.prompt()` flag with no prompter falls through to its default, on a
+TTY as well as off one.
+
+## Explicit Injection
+
+Supplying `argv` and `env` keeps the call away from the host, which is what a
+test wants:
+
+```ts twoslash
+import { flag, readFlags } from '@kjanat/dreamcli';
+// ---cut---
+const values = await readFlags(
+  { watch: flag.boolean().alias('w').env('WATCH') },
+  { argv: [], env: { WATCH: 'true' } },
+);
+
+values.watch; // true
+```
+
+`argv` is user arguments only, without the binary and script entries.
+
+A test adapter covers the whole runtime surface in one object, including the
+argv slicing a real process goes through:
+
+```ts twoslash
+import { flag, readFlags } from '@kjanat/dreamcli';
+import { createTestAdapter } from '@kjanat/dreamcli/testkit';
+
+const adapter = createTestAdapter({
+  argv: ['node', 'build.ts', '--target', 'browser'],
+  env: { MINIFY: 'false' },
+});
+
+const options = await readFlags(
+  {
+    minify: flag.boolean().env('MINIFY').default(true),
+    target: flag
+      .enum(['node', 'browser'])
+      .env('TARGET')
+      .default('node'),
+  },
+  { adapter },
+);
+
+expect(options).toEqual({
+  minify: false,
+  target: 'browser',
+});
+```
+
+## Adapter Defaults
+
+| Fact               | Source when the caller omits it                                   |
+| ------------------ | ----------------------------------------------------------------- |
+| `argv`             | the adapter's argv past its binary and script entries             |
+| `env`              | the adapter's environment snapshot                                |
+| `stat` and `mkdir` | the adapter's filesystem primitives, used by `flag.path()` checks |
+| `config`           | nothing, so the config stage is skipped                           |
+| `prompter`         | nothing, so the prompt stage is skipped                           |
+
+The adapter is built the first time a fact the caller left out is needed, so a
+call given `argv` and `env` builds none at all unless a `flag.path()` check
+reaches for `stat` or `mkdir`. Pass `adapter` to pin the runtime instead of
+detecting one. `createAdapter()` detects Node, Bun, and Deno, so the defaults
+work on all three.
+
+## Deprecation Notices
+
+`.deprecated()` produces one notice per flag that actually sourced a value, in
+resolution order. Each reaches `onDeprecation` as a `DeprecationWarning`:
+
+```ts twoslash
+import { flag, readFlags } from '@kjanat/dreamcli';
+// ---cut---
+await readFlags(
+  { minify: flag.boolean().deprecated('use --optimize') },
+  {
+    argv: ['--minify'],
+    env: {},
+    onDeprecation: (warning) => {
+      console.warn(`--${warning.name}: ${warning.message}`);
+    },
+  },
+);
+```
+
+A command prints these on its warning stream. There is no output channel here,
+so a call without `onDeprecation` drops them.
+
+## Errors
+
+Parse failures throw `ParseError`, resolution and constraint failures throw
+`ValidationError`, and a record that collides on a name, an alias, or a negated
+spelling throws `CLIError` before argv is read. Nothing is written anywhere and
+`adapter.exit` is never called, so the script owns what happens next:
+
+```ts twoslash
+import { flag, isCLIError, readFlags } from '@kjanat/dreamcli';
+
+try {
+  const options = await readFlags({
+    target: flag.enum(['node', 'browser']),
+  });
+  console.log(options.target);
+} catch (error) {
+  if (isCLIError(error)) {
+    console.error(error.message);
+    process.exit(error.exitCode);
+  }
+  throw error;
+}
+```
+
+## Non-Goals
+
+**No positional arguments.** A positional token throws
+`UNEXPECTED_POSITIONAL`. This API covers flags.
+
+**No config discovery.** Standalone flag reading has no application name and no
+discovery policy to guess from, so `config` is whatever the caller passes.
+
+**No root built-in flags.** `--help`, `--json`, and `--quiet` are neither
+reserved nor answered, so a record may declare any of them as an ordinary flag.
+Against a record that does not declare it, `--help` is an unknown flag.
+
+**No synchronous variant.** Prompts, Standard Schema validators, and filesystem
+checks are asynchronous. A synchronous variant would either carry different
+semantics or reject part of the flag DSL, and either one means a second
+implementation of what this reuses.
+
+**No dispatch, actions, middleware, output, help, or completions.** Those belong
+to a CLI. Reach for [`cli()`](/guide/commands) when the script grows into one.
+
+## Related Pages
+
+- [Flags](/guide/flags) for every flag kind and modifier
+- [CLI Semantics](/guide/semantics) for the exact parser and precedence rules
+- [Runtime Support](/guide/runtime) for what `createAdapter()` detects
+- [Testing Commands](/guide/testing) for the testkit adapter
+- [Stability Policy](/reference/stability) for the contract on `readFlags`,
+  `ReadFlagsOptions`, and `FlagMap`

--- a/docs/reference/main.md
+++ b/docs/reference/main.md
@@ -33,6 +33,7 @@ import {
   parse,
   tokenize,
   resolve,
+  readFlags,
 } from '@kjanat/dreamcli';
 ```
 
@@ -414,6 +415,31 @@ Parse argv against a command schema, returning `ParseResult`.
 ### `resolve(schema, parseResult, options)`
 
 Resolve flag values through the resolution chain.
+
+### `readFlags(definitions, options?)`
+
+Evaluate a record of flag builders outside a CLI and return the resolved values, typed by
+`InferFlags`. Runs the same schema, parser, coercion, resolver, and validation a command runs, with
+no dispatch, output channel, help, or process exit. See
+[Standalone Flag Evaluation](/guide/read-flags).
+
+- `definitions`: `FlagMap`, a record of `FlagBuilder` values keyed by canonical flag name
+- `options`: `ReadFlagsOptions`, which extends `ResolveOptions` with `argv`, `adapter`, `parse`, and
+  `onDeprecation`
+
+```ts twoslash
+import { flag, readFlags } from '@kjanat/dreamcli';
+
+const options = await readFlags(
+  {
+    watch: flag.boolean().alias('w').env('WATCH'),
+    target: flag
+      .enum(['node', 'browser'])
+      .default('node'),
+  },
+  { argv: ['-w'], env: {} },
+);
+```
 
 ## Schema Export
 

--- a/docs/reference/main.md
+++ b/docs/reference/main.md
@@ -418,9 +418,9 @@ Resolve flag values through the resolution chain.
 
 ### `readFlags(definitions, options?)`
 
-Evaluate a record of flag builders outside a CLI and return the resolved values, typed by
-`InferFlags`. Runs the same schema, parser, coercion, resolver, and validation a command runs, with
-no dispatch, output channel, help, or process exit. See
+Evaluate a record of flag builders outside a CLI and return a
+`Promise<InferFlags<F>>` of the resolved values. It runs the same schema, parser, coercion,
+resolver, and validation a command runs, with no dispatch, output channel, help, or process exit. See
 [Standalone Flag Evaluation](/guide/read-flags).
 
 - `definitions`: `FlagMap`, a record of `FlagBuilder` values keyed by canonical flag name

--- a/docs/reference/stability.md
+++ b/docs/reference/stability.md
@@ -153,9 +153,9 @@ Program and execution options: `CLIOptions`, `CLIExecuteOptions`, `CLIRunOptions
 `InferNameOption`, `ManifestDiscoveryOptions`, `ConfigDiscoveryOptions`, and
 `PackageRepositoryUrlOptions`.
 
-Pipeline and rendering options: `ParseOptions`, `ResolveOptions`, `OutputOptions`,
-`RenderContextOptions`, `HelpOptions`, `HelpTheme`, `CompletionOptions`, and
-`JsonSchemaOptions`.
+Pipeline and rendering options: `ParseOptions`, `ResolveOptions`,
+`ReadFlagsOptions`, `OutputOptions`, `RenderContextOptions`, `HelpOptions`,
+`HelpTheme`, `CompletionOptions`, and `JsonSchemaOptions`.
 
 Per-call output options: `SpinnerOptions`, `ProgressOptions`, `TableOptions`, and
 `TableColumn`.
@@ -515,7 +515,7 @@ Exported functions, by area:
   `plugin`.
 - Schema normalization: `createFlagSchema`, `createArgSchema`,
   `createCommandSchema`, `createCLISchema`.
-- Low-level pipeline: `tokenize`, `parse`, `resolve`, `formatHelp`,
+- Low-level pipeline: `tokenize`, `parse`, `resolve`, `readFlags`, `formatHelp`,
   `resolveRenderContext`, `resolvePromptConfig`, `includesBeforeSeparator`,
   `stripBeforeSeparator`, `getFlagNegatedName`, `resolveExampleCommand`.
 - Serialization: `generateSchema`, `generateCommandSchema`, `generateInputSchema`.
@@ -551,8 +551,8 @@ Class constructors follow the same rule as functions, with one exception.
 
 `InferFlag`, `InferFlags`, `InferArg`, `InferArgs`, `InferStandardInput`,
 `InferStandardOutput`, `ResolvedValue`, `ResolvedArgValue`, `WithPresence`,
-`WithArgPresence`, `WithVariadic`, and the builder state types `FlagConfig` and
-`ArgConfig`.
+`WithArgPresence`, `WithVariadic`, the builder state types `FlagConfig` and
+`ArgConfig`, and `FlagMap`, the record of flag builders `readFlags()` evaluates.
 
 These compute a type from another type. Most code reaches them through inference
 and never names one. `InferFlags<typeof flags>` in an extracted handler signature
@@ -563,6 +563,11 @@ carries the contract of whatever category that type belongs to. `FlagConfig` and
 `ArgConfig` are the compile-time state threaded through a builder chain, and a
 tracked property may be added to either in a minor release, since builders are
 obtained from `flag` and `arg` rather than written by hand.
+
+`FlagMap` constrains the type parameter of `readFlags()` rather than computing a
+type. It is a record of `FlagBuilder` values keyed by flag name, and the caller
+writes the record. Accepting more as a member is a minor release; accepting less
+is a major.
 
 ### Constants
 

--- a/src/core/read-flags/index.ts
+++ b/src/core/read-flags/index.ts
@@ -4,16 +4,25 @@
  * {@linkcode readFlags} runs a record of {@linkcode FlagBuilder} definitions through
  * the same command schema, parser, coercion, resolver, and validation that a
  * command uses, and returns the values typed by {@linkcode InferFlags}. There is
- * no command dispatch, output channel, help, or process exit here; parse and
- * resolution failures propagate as the framework's `ParseError` and
- * `ValidationError`.
+ * no command dispatch here; parse and resolution failures propagate as the
+ * framework's `ParseError` and `ValidationError`. The one output surface is the
+ * built-in `--help`: while it is on and no definition claims its spellings, a
+ * pre-separator `--help` or `-h` prints generated help to the adapter's stdout
+ * and exits the process with code 0.
  *
  * @module dreamcli/core/read-flags
  */
 
 import { CLIError } from '#internals/core/errors/index.ts';
-import type { ParseOptions } from '#internals/core/parse/index.ts';
-import { parse } from '#internals/core/parse/index.ts';
+import { formatHelp } from '#internals/core/help/index.ts';
+import type { FlagLookupEntry, ParseOptions } from '#internals/core/parse/index.ts';
+import {
+	buildFlagLookup,
+	flagExpectsValue,
+	parse,
+	requestsHelp,
+	tokenize,
+} from '#internals/core/parse/index.ts';
 import type { DeprecationWarning, ResolveOptions } from '#internals/core/resolve/index.ts';
 import { resolve } from '#internals/core/resolve/index.ts';
 import { createCommandSchema, validateCommandFlagTree } from '#internals/core/schema/command.ts';
@@ -55,6 +64,34 @@ interface ReadFlagsOptions extends ResolveOptions {
 	readonly parse?: ParseOptions;
 
 	/**
+	 * Reject argv content the definitions do not declare.
+	 *
+	 * `false` drops undeclared input from argv before parsing: unknown long
+	 * flags together with their inline `=value`, unknown characters inside a
+	 * short group, positional arguments, and the `--` separator, which can only
+	 * introduce positionals here. A value token of a declared flag is kept by
+	 * walking the same consumption rules the parser applies. Misuse of a
+	 * declared flag still fails: a missing value, a bad coercion, or a violated
+	 * duplicate policy throws in either mode.
+	 * @defaultValue `true`
+	 */
+	readonly strict?: boolean;
+
+	/**
+	 * The built-in `--help`/`-h` handling.
+	 *
+	 * While `'on'`, a pre-separator `--help` or `-h` prints generated help for
+	 * the definitions to the adapter's stdout and exits the process with
+	 * code 0. The built-in yields automatically when any definition claims the
+	 * `help` or `h` spelling through its name, an alias, a negated form, or a
+	 * case-parity counterpart; those spellings then parse as the definition's
+	 * own. `'off'` removes the built-in, and the spellings parse like any other
+	 * token.
+	 * @defaultValue `'on'`
+	 */
+	readonly help?: 'on' | 'off';
+
+	/**
 	 * Receiver for notices produced by `.deprecated()` flags.
 	 * @defaultValue `undefined`, which drops the notices
 	 */
@@ -76,6 +113,83 @@ function adapterReader(injected: RuntimeAdapter | undefined): () => RuntimeAdapt
 }
 
 /**
+ * The final path segment of the adapter's script entry, for the help usage
+ * line. Falls back to `script` when the adapter carries no script path.
+ */
+function scriptName(adapter: RuntimeAdapter): string {
+	const path = adapter.argv[1] ?? '';
+	const base = path.slice(Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\')) + 1);
+	return base === '' ? 'script' : base;
+}
+
+/**
+ * Drop argv entries the lookup does not declare: unknown long flags with their
+ * inline value, unknown characters inside a short group, positional arguments,
+ * and the `--` separator. The walk mirrors the parser's value consumption, so
+ * the token after a declared value-expecting flag survives as that flag's
+ * value while the token after an unknown flag is dropped as a positional.
+ */
+function withoutUndeclaredTokens(
+	argv: readonly string[],
+	lookup: ReadonlyMap<string, FlagLookupEntry>,
+): readonly string[] {
+	const tokens = tokenize(argv);
+	const kept: string[] = [];
+	let i = 0;
+	while (i < tokens.length) {
+		const token = tokens[i];
+		const raw = argv[i];
+		if (token === undefined || raw === undefined) break;
+
+		if (token.kind === 'positional' || token.kind === 'separator') {
+			i++;
+			continue;
+		}
+
+		if (token.kind === 'long-flag') {
+			const entry = lookup.get(token.name);
+			i++;
+			if (entry === undefined) continue;
+			kept.push(raw);
+			if (!entry.negated && token.value === undefined && flagExpectsValue(entry.schema)) {
+				const nextRaw = argv[i];
+				if (tokens[i]?.kind === 'positional' && nextRaw !== undefined) {
+					kept.push(nextRaw);
+					i++;
+				}
+			}
+			continue;
+		}
+
+		let declared = '';
+		let awaitsValue = false;
+		for (let ci = 0; ci < token.chars.length; ci++) {
+			const ch = token.chars.charAt(ci);
+			const entry = lookup.get(ch);
+			if (entry === undefined) continue;
+			declared += ch;
+			if (flagExpectsValue(entry.schema)) {
+				const inline = token.chars.slice(ci + 1);
+				if (inline.length > 0) declared += inline;
+				else awaitsValue = true;
+				break;
+			}
+		}
+		i++;
+		if (declared.length === 0) continue;
+		kept.push(`-${declared}`);
+		if (awaitsValue) {
+			const nextRaw = argv[i];
+			if (tokens[i]?.kind === 'positional' && nextRaw !== undefined) {
+				kept.push(nextRaw);
+				i++;
+			}
+		}
+	}
+	return kept;
+}
+
+/**
  * Evaluate a record of flag definitions and return the resolved values.
  *
  * The record is compiled into an anonymous command schema with no positional
@@ -83,6 +197,13 @@ function adapterReader(injected: RuntimeAdapter | undefined): () => RuntimeAdapt
  * resolution chain. Aliases, negated spellings, duplicate policy, case parity,
  * unknown-flag rejection, coercion, constraints, Standard Schema validators, and
  * `flag.path()` checks behave exactly as they do inside a command.
+ *
+ * A pre-separator `--help` or `-h` prints generated help to the adapter's
+ * stdout and exits with code 0, unless {@linkcode ReadFlagsOptions.help} is
+ * `'off'` or a definition claims either spelling. With
+ * {@linkcode ReadFlagsOptions.strict} set to `false`, undeclared argv content
+ * is dropped instead of rejected, so a script can read its own flags out of an
+ * argv it shares with another consumer.
  *
  * Anything the caller leaves out comes from the runtime adapter, which is built
  * on first use, so a call given `argv` and `env` reads nothing from the host
@@ -125,6 +246,16 @@ function adapterReader(injected: RuntimeAdapter | undefined): () => RuntimeAdapt
  *
  * values.watch; // true
  * ```
+ *
+ * @example
+ * ```ts
+ * const values = await readFlags(
+ *   { watch: flag.boolean() },
+ *   { argv: ['build', '--watch', '--unknown'], env: {}, strict: false },
+ * );
+ *
+ * values.watch; // true, with 'build' and '--unknown' dropped
+ * ```
  */
 async function readFlags<const F extends FlagMap>(
 	definitions: F,
@@ -147,7 +278,23 @@ async function readFlags<const F extends FlagMap>(
 
 	const host = adapterReader(options?.adapter);
 	const argv = options?.argv ?? host().argv.slice(2);
-	const parsed = parse(schema, argv, options?.parse);
+	const lookup = buildFlagLookup(schema.flags, options?.parse);
+
+	if (
+		(options?.help ?? 'on') === 'on' &&
+		!lookup.has('help') &&
+		!lookup.has('h') &&
+		requestsHelp(argv)
+	) {
+		host().stdout(formatHelp(schema, { binName: scriptName(host()), isDefaultHelp: true }));
+		host().exit(0);
+	}
+
+	const parsed = parse(
+		schema,
+		options?.strict === false ? withoutUndeclaredTokens(argv, lookup) : argv,
+		options?.parse,
+	);
 
 	const resolved = await resolve(schema, parsed, {
 		env: options?.env ?? host().env,

--- a/src/core/read-flags/index.ts
+++ b/src/core/read-flags/index.ts
@@ -1,0 +1,169 @@
+/**
+ * Standalone typed flag evaluation over the existing builder DSL.
+ *
+ * {@linkcode readFlags} runs a record of {@linkcode FlagBuilder} definitions through
+ * the same command schema, parser, coercion, resolver, and validation that a
+ * command uses, and returns the values typed by {@linkcode InferFlags}. There is
+ * no command dispatch, output channel, help, or process exit here; parse and
+ * resolution failures propagate as the framework's `ParseError` and
+ * `ValidationError`.
+ *
+ * @module dreamcli/core/read-flags
+ */
+
+import { CLIError } from '#internals/core/errors/index.ts';
+import type { ParseOptions } from '#internals/core/parse/index.ts';
+import { parse } from '#internals/core/parse/index.ts';
+import type { DeprecationWarning, ResolveOptions } from '#internals/core/resolve/index.ts';
+import { resolve } from '#internals/core/resolve/index.ts';
+import { createCommandSchema, validateCommandFlagTree } from '#internals/core/schema/command.ts';
+import type { FlagBuilder, FlagConfig, InferFlags } from '#internals/core/schema/flag.ts';
+import type { RuntimeAdapter } from '#internals/runtime/adapter.ts';
+import { createAdapter } from '#internals/runtime/auto.ts';
+
+/**
+ * A record of flag definitions keyed by canonical flag name.
+ *
+ * The object key is the `--name` spelling and the key on the resolved record.
+ */
+type FlagMap = Readonly<Record<string, FlagBuilder<FlagConfig>>>;
+
+/**
+ * External state and behavior toggles accepted by {@linkcode readFlags}.
+ *
+ * Extends {@linkcode ResolveOptions}, so `env`, `config`, `prompter`, `stat`,
+ * and `mkdir` carry the meaning they have during command resolution.
+ */
+interface ReadFlagsOptions extends ResolveOptions {
+	/**
+	 * User arguments only, without the binary and script entries.
+	 * @defaultValue the runtime adapter's argv past its binary and script entries
+	 */
+	readonly argv?: readonly string[];
+
+	/**
+	 * Runtime source for argv, environment, and filesystem primitives.
+	 * @defaultValue {@linkcode createAdapter | createAdapter()}, built on the
+	 *   first fact the caller left out
+	 */
+	readonly adapter?: RuntimeAdapter;
+
+	/**
+	 * Parser behavior such as kebab/camel case parity.
+	 * @defaultValue `undefined`, which keeps the parser defaults
+	 */
+	readonly parse?: ParseOptions;
+
+	/**
+	 * Receiver for notices produced by `.deprecated()` flags.
+	 * @defaultValue `undefined`, which drops the notices
+	 */
+	readonly onDeprecation?: (warning: DeprecationWarning) => void;
+}
+
+const INTERNAL_COMMAND_NAME = '<standalone>';
+
+/**
+ * Reader that yields the injected adapter, or builds one the first time a fact
+ * the caller did not supply is actually needed.
+ */
+function adapterReader(injected: RuntimeAdapter | undefined): () => RuntimeAdapter {
+	let adapter = injected;
+	return () => {
+		adapter ??= createAdapter();
+		return adapter;
+	};
+}
+
+/**
+ * Evaluate a record of flag definitions and return the resolved values.
+ *
+ * The record is compiled into an anonymous command schema with no positional
+ * arguments, parsed once, and run through the CLI, env, config, prompt, default
+ * resolution chain. Aliases, negated spellings, duplicate policy, case parity,
+ * unknown-flag rejection, coercion, constraints, Standard Schema validators, and
+ * `flag.path()` checks behave exactly as they do inside a command.
+ *
+ * Anything the caller leaves out comes from the runtime adapter, which is built
+ * on first use, so a call given `argv` and `env` reads nothing from the host
+ * unless a `flag.path()` check needs the adapter's filesystem primitives.
+ * `config` has no application name to discover a file from and stays
+ * caller-supplied. `prompter` stays caller-supplied as well, so a `.prompt()`
+ * flag with no prompter falls through to its default.
+ *
+ * @param definitions - Flag builders keyed by canonical flag name.
+ * @param options - Injected runtime state and behavior toggles.
+ * @returns The resolved flag values, typed from the definitions.
+ * @throws {ParseError} For unknown flags, missing values, and bad input.
+ * @throws {ValidationError} For missing required flags and failed validators.
+ * @throws {CLIError} With code `'FLAG_NAME_COLLISION'` when two definitions share
+ *   a name, an alias, or a negated spelling.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` for the definition key
+ *   `__proto__`, which JavaScript cannot carry as a plain record key.
+ *
+ * @example
+ * ```ts
+ * import { flag, readFlags } from '@kjanat/dreamcli';
+ *
+ * const options = await readFlags({
+ *   watch: flag.boolean().alias('w').env('WATCH').default(false),
+ *   minify: flag.boolean().env('MINIFY').default(true),
+ *   target: flag.enum(['node', 'browser']).env('TARGET').default('node'),
+ * });
+ *
+ * options.watch; // boolean
+ * options.minify; // boolean
+ * options.target; // 'node' | 'browser'
+ * ```
+ *
+ * @example
+ * ```ts
+ * const values = await readFlags(
+ *   { watch: flag.boolean().alias('w').env('WATCH') },
+ *   { argv: [], env: { WATCH: 'true' } },
+ * );
+ *
+ * values.watch; // true
+ * ```
+ */
+async function readFlags<const F extends FlagMap>(
+	definitions: F,
+	options?: ReadFlagsOptions,
+): Promise<InferFlags<F>> {
+	const entries = Object.entries(definitions);
+	for (const [name] of entries) {
+		if (name === '__proto__') {
+			throw new CLIError(`Flag name '${name}' is not usable as a flag`, {
+				code: 'INVALID_SCHEMA',
+				details: { flag: name },
+				suggest: 'Rename the definition key, for example to "proto"',
+			});
+		}
+	}
+
+	const flags = Object.fromEntries(entries.map(([name, builder]) => [name, builder.schema]));
+	const schema = createCommandSchema({ name: INTERNAL_COMMAND_NAME, flags });
+	validateCommandFlagTree(schema);
+
+	const host = adapterReader(options?.adapter);
+	const argv = options?.argv ?? host().argv.slice(2);
+	const parsed = parse(schema, argv, options?.parse);
+
+	const resolved = await resolve(schema, parsed, {
+		env: options?.env ?? host().env,
+		stat: options?.stat ?? ((path: string) => host().stat(path)),
+		mkdir: options?.mkdir ?? ((path: string) => host().mkdir(path)),
+		...(options?.config !== undefined ? { config: options.config } : {}),
+		...(options?.prompter !== undefined ? { prompter: options.prompter } : {}),
+		...(options?.stdinData !== undefined ? { stdinData: options.stdinData } : {}),
+	});
+
+	for (const warning of resolved.deprecations) {
+		options?.onDeprecation?.(warning);
+	}
+
+	return resolved.flags as InferFlags<F>;
+}
+
+export type { FlagMap, ReadFlagsOptions };
+export { readFlags };

--- a/src/core/read-flags/index.ts
+++ b/src/core/read-flags/index.ts
@@ -261,6 +261,14 @@ async function readFlags<const F extends FlagMap>(
 	definitions: F,
 	options?: ReadFlagsOptions,
 ): Promise<InferFlags<F>> {
+	for (const key of Reflect.ownKeys(definitions)) {
+		if (typeof key !== 'string' || !Object.prototype.propertyIsEnumerable.call(definitions, key)) {
+			throw new CLIError('Flag definitions must use enumerable string keys', {
+				code: 'INVALID_SCHEMA',
+			});
+		}
+	}
+
 	const entries = Object.entries(definitions);
 	for (const [name] of entries) {
 		if (name === '__proto__') {

--- a/src/core/read-flags/read-flags-types.test.ts
+++ b/src/core/read-flags/read-flags-types.test.ts
@@ -175,10 +175,11 @@ describe('readFlags() presence', () => {
 // === Call shape
 
 describe('readFlags() call shape', () => {
-	it('returns a promise of the resolved record', () => {
+	it('returns a promise of the resolved record', async () => {
 		const pending = readFlags({ watch: flag.boolean() }, empty);
 
 		expectTypeOf(pending).toEqualTypeOf<Promise<{ readonly watch: boolean }>>();
+		await pending;
 	});
 
 	it('accepts a definition record with no options', () => {

--- a/src/core/read-flags/read-flags-types.test.ts
+++ b/src/core/read-flags/read-flags-types.test.ts
@@ -1,0 +1,187 @@
+/**
+ * readFlags() compile-time inference: one resolved property per definition key,
+ * carrying the value type and presence its builder declares.
+ */
+
+import { describe, expectTypeOf, it } from 'vitest';
+import { flag } from '#internals/core/schema/flag.ts';
+import type { StandardSchemaV1 } from '#internals/core/schema/standard.ts';
+import { readFlags } from './index.ts';
+
+/** Minimal hand-rolled Standard Schema validator, no external dependency. */
+const numberSchema: StandardSchemaV1<unknown, number> = {
+	'~standard': { version: 1, vendor: 'test', validate: (value) => ({ value: Number(value) }) },
+};
+
+const empty = { argv: [], env: {} } as const;
+
+// === Value types per builder kind
+
+describe('readFlags() value types', () => {
+	it('infers one property per definition key', async () => {
+		const values = await readFlags({ name: flag.string(), port: flag.number() }, empty);
+
+		expectTypeOf(values).toEqualTypeOf<{
+			readonly name: string | undefined;
+			readonly port: number | undefined;
+		}>();
+		expectTypeOf<keyof typeof values>().toEqualTypeOf<'name' | 'port'>();
+	});
+
+	it('infers string, number, and boolean kinds', async () => {
+		const values = await readFlags(
+			{ name: flag.string(), port: flag.number(), watch: flag.boolean() },
+			empty,
+		);
+
+		expectTypeOf(values.name).toEqualTypeOf<string | undefined>();
+		expectTypeOf(values.port).toEqualTypeOf<number | undefined>();
+		expectTypeOf(values.watch).toEqualTypeOf<boolean>();
+	});
+
+	it('infers enum literals', async () => {
+		const values = await readFlags({ target: flag.enum(['node', 'browser']) }, empty);
+
+		expectTypeOf(values.target).toEqualTypeOf<'node' | 'browser' | undefined>();
+	});
+
+	it('infers array elements', async () => {
+		const values = await readFlags(
+			{ tag: flag.array(flag.string()), sizes: flag.array(flag.number()) },
+			empty,
+		);
+
+		expectTypeOf(values.tag).toEqualTypeOf<string[]>();
+		expectTypeOf(values.sizes).toEqualTypeOf<number[]>();
+	});
+
+	it('infers count and key-value kinds', async () => {
+		const values = await readFlags({ verbose: flag.count(), env: flag.keyValue() }, empty);
+
+		expectTypeOf(values.verbose).toEqualTypeOf<number>();
+		expectTypeOf(values.env).toEqualTypeOf<Record<string, string>>();
+	});
+
+	it('infers custom parse functions and Standard Schema outputs', async () => {
+		const values = await readFlags(
+			{
+				hex: flag.custom((raw) => Number.parseInt(String(raw), 16)),
+				pair: flag.custom((raw) => ({ host: String(raw), port: 0 })),
+				checked: flag.custom(numberSchema),
+			},
+			empty,
+		);
+
+		expectTypeOf(values.hex).toEqualTypeOf<number | undefined>();
+		expectTypeOf(values.pair).toEqualTypeOf<{ host: string; port: number } | undefined>();
+		expectTypeOf(values.checked).toEqualTypeOf<number | undefined>();
+	});
+
+	it('infers the sugar factories', async () => {
+		const values = await readFlags(
+			{
+				site: flag.url(),
+				out: flag.path(),
+				since: flag.date(),
+				timeout: flag.duration(),
+				limit: flag.bytes(),
+			},
+			empty,
+		);
+
+		expectTypeOf(values.site).toEqualTypeOf<URL | undefined>();
+		expectTypeOf(values.out).toEqualTypeOf<string | undefined>();
+		expectTypeOf(values.since).toEqualTypeOf<Date | undefined>();
+		expectTypeOf(values.timeout).toEqualTypeOf<number | undefined>();
+		expectTypeOf(values.limit).toEqualTypeOf<number | undefined>();
+	});
+
+	it('preserves non-identifier keys', async () => {
+		const values = await readFlags({ 'dry-run': flag.boolean() }, empty);
+
+		expectTypeOf(values['dry-run']).toEqualTypeOf<boolean>();
+	});
+});
+
+// === Presence
+
+describe('readFlags() presence', () => {
+	it('keeps optional flags nullable', async () => {
+		const values = await readFlags(
+			{ name: flag.string(), target: flag.enum(['a', 'b']), hex: flag.custom(Number) },
+			empty,
+		);
+
+		expectTypeOf(values.name).toEqualTypeOf<string | undefined>();
+		expectTypeOf(values.target).toEqualTypeOf<'a' | 'b' | undefined>();
+		expectTypeOf(values.hex).toEqualTypeOf<number | undefined>();
+	});
+
+	it('drops undefined for defaulted flags', async () => {
+		const values = await readFlags(
+			{
+				name: flag.string().default('booga'),
+				port: flag.number().default(8080),
+				target: flag.enum(['a', 'b']).default('a'),
+				tag: flag.array(flag.string()).default([]),
+			},
+			empty,
+		);
+
+		expectTypeOf(values.name).toEqualTypeOf<string>();
+		expectTypeOf(values.port).toEqualTypeOf<number>();
+		expectTypeOf(values.target).toEqualTypeOf<'a' | 'b'>();
+		expectTypeOf(values.tag).toEqualTypeOf<string[]>();
+	});
+
+	it('drops undefined for required flags', async () => {
+		const values = await readFlags(
+			{
+				name: flag.string().required(),
+				target: flag.enum(['a', 'b']).required(),
+				hex: flag.custom((raw) => String(raw)).required(),
+			},
+			{ argv: ['--name', 'booga', '--target', 'a', '--hex', 'ff'], env: {} },
+		);
+
+		expectTypeOf(values.name).toEqualTypeOf<string>();
+		expectTypeOf(values.target).toEqualTypeOf<'a' | 'b'>();
+		expectTypeOf(values.hex).toEqualTypeOf<string>();
+	});
+
+	it('keeps array and key-value fallbacks non-nullable', async () => {
+		const values = await readFlags({ tag: flag.array(flag.string()), env: flag.keyValue() }, empty);
+
+		expectTypeOf(values.tag).toEqualTypeOf<string[]>();
+		expectTypeOf(values.env).toEqualTypeOf<Record<string, string>>();
+	});
+
+	it('preserves inference through chained modifiers', async () => {
+		const values = await readFlags(
+			{
+				watch: flag.boolean().alias('w').env('WATCH').describe('Rebuild on change'),
+				region: flag.enum(['us', 'eu']).env('REGION').config('deploy.region').deprecated(),
+				minify: flag.boolean().default(true).negatable(),
+			},
+			empty,
+		);
+
+		expectTypeOf(values.watch).toEqualTypeOf<boolean>();
+		expectTypeOf(values.region).toEqualTypeOf<'us' | 'eu' | undefined>();
+		expectTypeOf(values.minify).toEqualTypeOf<boolean>();
+	});
+});
+
+// === Call shape
+
+describe('readFlags() call shape', () => {
+	it('returns a promise of the resolved record', () => {
+		const pending = readFlags({ watch: flag.boolean() }, empty);
+
+		expectTypeOf(pending).toEqualTypeOf<Promise<{ readonly watch: boolean }>>();
+	});
+
+	it('accepts a definition record with no options', () => {
+		expectTypeOf(readFlags).toBeCallableWith({ watch: flag.boolean() });
+	});
+});

--- a/src/core/read-flags/read-flags.test.ts
+++ b/src/core/read-flags/read-flags.test.ts
@@ -12,7 +12,7 @@ import { flag } from '#internals/core/schema/flag.ts';
 import type { StandardSchemaV1 } from '#internals/core/schema/standard.ts';
 import { runCommand } from '#internals/core/testkit/index.ts';
 import type { RuntimeAdapter } from '#internals/runtime/adapter.ts';
-import { createTestAdapter } from '#internals/runtime/adapter.ts';
+import { createTestAdapter, ExitError } from '#internals/runtime/adapter.ts';
 import type { DenoNamespace } from '#internals/runtime/deno.ts';
 import { createDenoAdapter } from '#internals/runtime/deno.ts';
 import type { NodeProcess } from '#internals/runtime/node.ts';
@@ -784,17 +784,253 @@ describe('readFlags() root-owned spellings', () => {
 		expect(values.quiet).toBe(true);
 		expect(values.help).toBe('topics');
 	});
+});
 
-	it('does not render help for --help', async () => {
+// === Built-in help
+
+describe('readFlags() built-in help', () => {
+	it('renders help to stdout and exits 0 for --help', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', '/repo/build.ts', '--help'],
+			stdout: (line) => written.push(line),
+		});
+
+		const error = await thrownBy(() =>
+			readFlags({ watch: flag.boolean(), port: flag.number().alias('p') }, { adapter }),
+		);
+
+		expect(error).toBeInstanceOf(ExitError);
+		expect(error instanceof ExitError && error.code).toBe(0);
+		const text = written.join('');
+		expect(text).toContain('Usage: build.ts');
+		expect(text).not.toContain('standalone');
+		expect(text).toContain('--watch');
+		expect(text).toContain('-p, --port');
+	});
+
+	it('renders help for -h', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '-h'],
+			stdout: (line) => written.push(line),
+		});
+
+		const error = await thrownBy(() => readFlags({ watch: flag.boolean() }, { adapter }));
+
+		expect(error instanceof ExitError && error.code).toBe(0);
+		expect(written.join('')).toContain('--watch');
+	});
+
+	it('renders help ahead of flag validation', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '--port', 'nope', '--help'],
+			stdout: (line) => written.push(line),
+		});
+
+		const error = await thrownBy(() => readFlags({ port: flag.number() }, { adapter }));
+
+		expect(error instanceof ExitError && error.code).toBe(0);
+		expect(written.join('')).toContain('--port');
+	});
+
+	it('falls back to a generic script name without a script entry', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({ argv: [], stdout: (line) => written.push(line) });
+
+		const error = await thrownBy(() =>
+			readFlags({ watch: flag.boolean() }, { adapter, argv: ['--help'] }),
+		);
+
+		expect(error instanceof ExitError && error.code).toBe(0);
+		expect(written.join('')).toContain('Usage: script');
+	});
+
+	it('ignores --help after the separator', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '--', '--help'],
+			stdout: (line) => written.push(line),
+		});
+
+		const error = await thrownBy(() => readFlags({ watch: flag.boolean() }, { adapter }));
+
+		expect(isParseError(error) && error.code).toBe('UNEXPECTED_POSITIONAL');
+		expect(written).toEqual([]);
+	});
+
+	it("does not fire when set to 'off'", async () => {
 		const written: string[] = [];
 		const adapter = createTestAdapter({
 			argv: ['node', 'build.ts', '--help'],
 			stdout: (line) => written.push(line),
 		});
 
-		const error = await thrownBy(() => readFlags({ watch: flag.boolean() }, { adapter }));
+		const error = await thrownBy(() =>
+			readFlags({ watch: flag.boolean() }, { adapter, help: 'off' }),
+		);
 
 		expect(isParseError(error) && error.code).toBe('UNKNOWN_FLAG');
+		expect(written).toEqual([]);
+	});
+
+	it('yields to a definition named help', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '--help', 'topics'],
+			stdout: (line) => written.push(line),
+		});
+
+		const values = await readFlags({ help: flag.string() }, { adapter });
+
+		expect(values.help).toBe('topics');
+		expect(written).toEqual([]);
+	});
+
+	it('yields entirely when a definition claims only the h spelling', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '--help'],
+			stdout: (line) => written.push(line),
+		});
+
+		const error = await thrownBy(() =>
+			readFlags({ verbose: flag.count().alias('h') }, { adapter }),
+		);
+
+		expect(isParseError(error) && error.code).toBe('UNKNOWN_FLAG');
+		expect(written).toEqual([]);
+	});
+});
+
+// === Non-strict parsing
+
+describe('readFlags() strict false', () => {
+	it('drops unknown long flags and their inline values', async () => {
+		const values = await readFlags(
+			{ watch: flag.boolean() },
+			{ argv: ['--unknown', '--other=x', '--watch'], env: {}, strict: false },
+		);
+
+		expect(values.watch).toBe(true);
+	});
+
+	it('drops positional arguments', async () => {
+		const values = await readFlags(
+			{ watch: flag.boolean() },
+			{ argv: ['build', '--watch', 'extra'], env: {}, strict: false },
+		);
+
+		expect(values.watch).toBe(true);
+	});
+
+	it('keeps the value token of a declared flag', async () => {
+		const values = await readFlags(
+			{ name: flag.string() },
+			{ argv: ['--junk', '--name', 'booga', 'stray'], env: {}, strict: false },
+		);
+
+		expect(values.name).toBe('booga');
+	});
+
+	it('does not consume a value for an unknown flag', async () => {
+		const values = await readFlags(
+			{ name: flag.string() },
+			{ argv: ['--unknown', 'value', '--name', 'booga'], env: {}, strict: false },
+		);
+
+		expect(values.name).toBe('booga');
+	});
+
+	it('drops unknown characters inside a short group', async () => {
+		const values = await readFlags(
+			{ verbose: flag.count().alias('v') },
+			{ argv: ['-zvv'], env: {}, strict: false },
+		);
+
+		expect(values.verbose).toBe(2);
+	});
+
+	it('drops a short group with no declared characters', async () => {
+		const values = await readFlags(
+			{ watch: flag.boolean() },
+			{ argv: ['-z', '--watch'], env: {}, strict: false },
+		);
+
+		expect(values.watch).toBe(true);
+	});
+
+	it('keeps the value of a declared short flag after dropped characters', async () => {
+		const values = await readFlags(
+			{ name: flag.string().alias('n') },
+			{ argv: ['-zn', 'booga'], env: {}, strict: false },
+		);
+
+		expect(values.name).toBe('booga');
+	});
+
+	it('keeps the inline value of a declared short flag', async () => {
+		const values = await readFlags(
+			{ name: flag.string().alias('n') },
+			{ argv: ['-znbooga'], env: {}, strict: false },
+		);
+
+		expect(values.name).toBe('booga');
+	});
+
+	it('drops everything at and after the separator', async () => {
+		const values = await readFlags(
+			{ name: flag.string() },
+			{ argv: ['--name', 'booga', '--', 'literal', '--name'], env: {}, strict: false },
+		);
+
+		expect(values.name).toBe('booga');
+	});
+
+	it('still rejects a bad value on a declared flag', async () => {
+		const error = await thrownBy(() =>
+			readFlags(
+				{ port: flag.number() },
+				{ argv: ['--junk', '--port', 'abc'], env: {}, strict: false },
+			),
+		);
+
+		expect(isParseError(error) && error.code).toBe('INVALID_VALUE');
+	});
+
+	it('still rejects a missing value on a declared flag', async () => {
+		const error = await thrownBy(() =>
+			readFlags({ name: flag.string() }, { argv: ['--junk', '--name'], env: {}, strict: false }),
+		);
+
+		expect(isParseError(error) && error.code).toBe('MISSING_VALUE');
+	});
+
+	it('still enforces the duplicate policy of a declared flag', async () => {
+		const error = await thrownBy(() =>
+			readFlags(
+				{ region: flag.string().duplicates('error') },
+				{ argv: ['--region', 'us', '--junk', '--region', 'eu'], env: {}, strict: false },
+			),
+		);
+
+		expect(isParseError(error) && error.code).toBe('DUPLICATE_FLAG');
+	});
+
+	it('drops --help silently when the built-in is off', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '--help', '--watch'],
+			stdout: (line) => written.push(line),
+		});
+
+		const values = await readFlags(
+			{ watch: flag.boolean() },
+			{ adapter, help: 'off', strict: false },
+		);
+
+		expect(values.watch).toBe(true);
 		expect(written).toEqual([]);
 	});
 });

--- a/src/core/read-flags/read-flags.test.ts
+++ b/src/core/read-flags/read-flags.test.ts
@@ -427,6 +427,27 @@ describe('readFlags() prototype keys', () => {
 		expect(error instanceof CLIError && error.code).toBe('INVALID_SCHEMA');
 	});
 
+	it('rejects symbol and non-enumerable definition keys instead of dropping them', async () => {
+		const symbolDefinitions = { [Symbol('hidden')]: flag.string(), keep: flag.string() };
+		const symbolError = await thrownBy(() =>
+			readFlags(symbolDefinitions as never, { argv: [], env: {} }),
+		);
+
+		const nonEnumerableDefinitions = { keep: flag.string() };
+		Object.defineProperty(nonEnumerableDefinitions, 'hidden', {
+			value: flag.string(),
+			enumerable: false,
+		});
+		const nonEnumerableError = await thrownBy(() =>
+			readFlags(nonEnumerableDefinitions, { argv: [], env: {} }),
+		);
+
+		expect(symbolError instanceof CLIError && symbolError.code).toBe('INVALID_SCHEMA');
+		expect(nonEnumerableError instanceof CLIError && nonEnumerableError.code).toBe(
+			'INVALID_SCHEMA',
+		);
+	});
+
 	it('resolves other Object.prototype key names', async () => {
 		const values = await readFlags(
 			{ constructor: flag.string(), toString: flag.string(), valueOf: flag.string() },
@@ -755,6 +776,16 @@ describe('readFlags() adapter defaults', () => {
 
 		expect(values.watch).toBe(true);
 		expect(values.region).toBe('eu');
+	});
+
+	it('uses explicit argv and env without an injected adapter', async () => {
+		const values = await readFlags(
+			{ watch: flag.boolean(), path: flag.string().env('PATH') },
+			{ argv: ['--watch'], env: { PATH: '/injected/bin' } },
+		);
+
+		expect(values.watch).toBe(true);
+		expect(values.path).toBe('/injected/bin');
 	});
 
 	it('never exits the process on failure', async () => {

--- a/src/core/read-flags/read-flags.test.ts
+++ b/src/core/read-flags/read-flags.test.ts
@@ -501,7 +501,8 @@ describe('readFlags() command parity', () => {
 		try {
 			return { flags: { ...(await readFlags(definitions, { argv, env: {} })) }, code: undefined };
 		} catch (error: unknown) {
-			return { flags: undefined, code: error instanceof CLIError ? error.code : undefined };
+			if (!(error instanceof CLIError)) throw error;
+			return { flags: undefined, code: error.code };
 		}
 	}
 

--- a/src/core/read-flags/read-flags.test.ts
+++ b/src/core/read-flags/read-flags.test.ts
@@ -1,0 +1,835 @@
+/**
+ * readFlags() runtime behavior: parsing, precedence, diagnostics, and the
+ * runtime-adapter defaults, all with explicit injection.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { CLIError, isParseError, isValidationError } from '#internals/core/errors/index.ts';
+import { createTestPrompter } from '#internals/core/prompt/index.ts';
+import type { DeprecationWarning } from '#internals/core/resolve/index.ts';
+import { command } from '#internals/core/schema/command.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import type { StandardSchemaV1 } from '#internals/core/schema/standard.ts';
+import { runCommand } from '#internals/core/testkit/index.ts';
+import type { RuntimeAdapter } from '#internals/runtime/adapter.ts';
+import { createTestAdapter } from '#internals/runtime/adapter.ts';
+import type { DenoNamespace } from '#internals/runtime/deno.ts';
+import { createDenoAdapter } from '#internals/runtime/deno.ts';
+import type { NodeProcess } from '#internals/runtime/node.ts';
+import { createNodeAdapter } from '#internals/runtime/node.ts';
+import { createMockDenoNamespace } from '#internals/runtime/test-helpers.ts';
+import { readFlags } from './index.ts';
+
+/** What one argv produced: the resolved values, or the error code that replaced them. */
+interface Outcome {
+	readonly flags: Record<string, unknown> | undefined;
+	readonly code: string | undefined;
+}
+
+// === Test helpers
+
+/** Minimal hand-rolled Standard Schema validator, no external dependency. */
+function standard<Output>(
+	validate: StandardSchemaV1<unknown, Output>['~standard']['validate'],
+): StandardSchemaV1<unknown, Output> {
+	return { '~standard': { version: 1, vendor: 'test', validate } };
+}
+
+/** Async validator accepting a string longer than two characters. */
+const asyncName = standard<string>(async (value) => {
+	if (typeof value !== 'string' || value.length <= 2) {
+		return { issues: [{ message: 'must be longer than two characters' }] };
+	}
+	return { value };
+});
+
+/** Minimal Node process stub for the Node adapter. */
+function nodeProcess(
+	argv: readonly string[],
+	env: Readonly<Record<string, string | undefined>>,
+): NodeProcess {
+	return {
+		argv,
+		env,
+		versions: { node: '22.22.2' },
+		cwd: () => '/',
+		platform: 'linux',
+		stdin: {
+			[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+				return { next: () => Promise.resolve({ done: true, value: new Uint8Array(0) }) };
+			},
+		},
+		stdout: { write: () => true },
+		stderr: { write: () => true },
+		exit: (code: number): never => {
+			throw new Error(`process exited with code ${code}`);
+		},
+	};
+}
+
+/** Capture the error thrown by an awaited promise. */
+async function thrownBy(run: () => Promise<unknown>): Promise<unknown> {
+	try {
+		await run();
+	} catch (error: unknown) {
+		return error;
+	}
+	throw new Error('expected the call to reject');
+}
+
+// === Values and kinds
+
+describe('readFlags() values', () => {
+	it('resolves CLI values for every builder kind', async () => {
+		const values = await readFlags(
+			{
+				name: flag.string(),
+				port: flag.number(),
+				watch: flag.boolean(),
+				target: flag.enum(['node', 'browser']),
+				tag: flag.array(flag.string()),
+				verbose: flag.count().alias('v'),
+				env: flag.keyValue(),
+				hex: flag.custom((raw) => Number.parseInt(String(raw), 16)),
+				site: flag.url(),
+				out: flag.path(),
+				since: flag.date(),
+				timeout: flag.duration(),
+				limit: flag.bytes(),
+			},
+			{
+				argv: [
+					'--name',
+					'booga',
+					'--port',
+					'8080',
+					'--watch',
+					'--target',
+					'browser',
+					'--tag',
+					'a',
+					'--tag',
+					'b',
+					'-vv',
+					'--env',
+					'A=1',
+					'--env',
+					'B=2',
+					'--hex',
+					'ff',
+					'--site',
+					'https://example.com/',
+					'--out',
+					'dist',
+					'--since',
+					'2026-07-10',
+					'--timeout',
+					'30s',
+					'--limit',
+					'64kb',
+				],
+				env: {},
+			},
+		);
+
+		expect(values.name).toBe('booga');
+		expect(values.port).toBe(8080);
+		expect(values.watch).toBe(true);
+		expect(values.target).toBe('browser');
+		expect(values.tag).toEqual(['a', 'b']);
+		expect(values.verbose).toBe(2);
+		expect(values.env).toEqual({ A: '1', B: '2' });
+		expect(values.hex).toBe(255);
+		expect(values.site).toBeInstanceOf(URL);
+		expect(values.site?.href).toBe('https://example.com/');
+		expect(values.out).toBe('dist');
+		expect(values.since).toEqual(new Date('2026-07-10'));
+		expect(values.timeout).toBe(30_000);
+		expect(values.limit).toBe(65_536);
+	});
+
+	it('applies kind-specific fallbacks for absent flags', async () => {
+		const values = await readFlags(
+			{
+				name: flag.string(),
+				tag: flag.array(flag.string()),
+				env: flag.keyValue(),
+				verbose: flag.count(),
+				watch: flag.boolean(),
+			},
+			{ argv: [], env: {} },
+		);
+
+		expect(values.name).toBeUndefined();
+		expect(values.tag).toEqual([]);
+		expect(values.env).toEqual({});
+		expect(values.verbose).toBe(0);
+		expect(values.watch).toBe(false);
+	});
+
+	it('resolves an empty definition record to an empty object', async () => {
+		expect(await readFlags({}, { argv: [], env: {} })).toEqual({});
+	});
+});
+
+// === Precedence
+
+describe('readFlags() precedence', () => {
+	const definitions = {
+		region: flag.string().env('REGION').config('deploy.region').prompt({
+			kind: 'input',
+			message: 'Region?',
+		}),
+	};
+
+	it('CLI beats env, config, prompt, and default', async () => {
+		const values = await readFlags(definitions, {
+			argv: ['--region', 'cli'],
+			env: { REGION: 'env' },
+			config: { deploy: { region: 'config' } },
+			prompter: createTestPrompter(['prompt'], { onExhausted: 'cancel' }),
+		});
+
+		expect(values.region).toBe('cli');
+	});
+
+	it('env beats config, prompt, and default', async () => {
+		const values = await readFlags(definitions, {
+			argv: [],
+			env: { REGION: 'env' },
+			config: { deploy: { region: 'config' } },
+			prompter: createTestPrompter(['prompt'], { onExhausted: 'cancel' }),
+		});
+
+		expect(values.region).toBe('env');
+	});
+
+	it('config beats prompt and default', async () => {
+		const values = await readFlags(definitions, {
+			argv: [],
+			env: {},
+			config: { deploy: { region: 'config' } },
+			prompter: createTestPrompter(['prompt'], { onExhausted: 'cancel' }),
+		});
+
+		expect(values.region).toBe('config');
+	});
+
+	it('prompt beats default', async () => {
+		const values = await readFlags(
+			{
+				region: flag
+					.string()
+					.env('REGION')
+					.config('deploy.region')
+					.prompt({ kind: 'input', message: 'Region?' })
+					.default('fallback'),
+			},
+			{
+				argv: [],
+				env: {},
+				config: {},
+				prompter: createTestPrompter(['prompt']),
+			},
+		);
+
+		expect(values.region).toBe('prompt');
+	});
+
+	it('falls back to the default when nothing else resolves', async () => {
+		const values = await readFlags(
+			{ region: flag.string().env('REGION').config('deploy.region').default('fallback') },
+			{ argv: [], env: {}, config: {} },
+		);
+
+		expect(values.region).toBe('fallback');
+	});
+});
+
+// === Parser behavior
+
+describe('readFlags() parser behavior', () => {
+	it('accepts short and long aliases', async () => {
+		const definitions = { watch: flag.boolean().alias('w').alias('follow') };
+
+		expect((await readFlags(definitions, { argv: ['-w'], env: {} })).watch).toBe(true);
+		expect((await readFlags(definitions, { argv: ['--follow'], env: {} })).watch).toBe(true);
+	});
+
+	it('accepts the negated spelling of a negatable boolean', async () => {
+		const definitions = { minify: flag.boolean().default(true).negatable() };
+
+		expect((await readFlags(definitions, { argv: ['--no-minify'], env: {} })).minify).toBe(false);
+		expect((await readFlags(definitions, { argv: [], env: {} })).minify).toBe(true);
+	});
+
+	it('rejects a value on the negated spelling', async () => {
+		const error = await thrownBy(() =>
+			readFlags({ minify: flag.boolean().negatable() }, { argv: ['--no-minify=true'], env: {} }),
+		);
+
+		expect(isParseError(error)).toBe(true);
+		expect(isParseError(error) && error.code).toBe('INVALID_VALUE');
+	});
+
+	it('keeps the last occurrence by default', async () => {
+		const values = await readFlags(
+			{ region: flag.string() },
+			{ argv: ['--region', 'us', '--region', 'eu'], env: {} },
+		);
+
+		expect(values.region).toBe('eu');
+	});
+
+	it('keeps the first occurrence under the first policy', async () => {
+		const values = await readFlags(
+			{ region: flag.string().duplicates('first') },
+			{ argv: ['--region', 'us', '--region', 'eu'], env: {} },
+		);
+
+		expect(values.region).toBe('us');
+	});
+
+	it('rejects a repeat under the error policy', async () => {
+		const error = await thrownBy(() =>
+			readFlags(
+				{ region: flag.string().duplicates('error') },
+				{ argv: ['--region', 'us', '--region', 'eu'], env: {} },
+			),
+		);
+
+		expect(isParseError(error)).toBe(true);
+		expect(isParseError(error) && error.code).toBe('DUPLICATE_FLAG');
+	});
+
+	it('accepts the camel counterpart of a kebab name', async () => {
+		const values = await readFlags({ 'dry-run': flag.boolean() }, { argv: ['--dryRun'], env: {} });
+
+		expect(values['dry-run']).toBe(true);
+	});
+
+	it('rejects the counterpart when case parity is off', async () => {
+		const error = await thrownBy(() =>
+			readFlags(
+				{ 'dry-run': flag.boolean() },
+				{
+					argv: ['--dryRun'],
+					env: {},
+					parse: { caseParity: false },
+				},
+			),
+		);
+
+		expect(isParseError(error) && error.code).toBe('UNKNOWN_FLAG');
+	});
+
+	it('rejects an unknown flag and suggests a declared spelling', async () => {
+		const error = await thrownBy(() =>
+			readFlags({ watch: flag.boolean() }, { argv: ['--wathc'], env: {} }),
+		);
+
+		expect(isParseError(error)).toBe(true);
+		expect(isParseError(error) && error.code).toBe('UNKNOWN_FLAG');
+		expect(isParseError(error) && error.message).toContain('Did you mean --watch?');
+	});
+
+	it('rejects positional arguments', async () => {
+		const error = await thrownBy(() =>
+			readFlags({ watch: flag.boolean() }, { argv: ['build'], env: {} }),
+		);
+
+		expect(isParseError(error) && error.code).toBe('UNEXPECTED_POSITIONAL');
+	});
+
+	it('accepts the inline value form', async () => {
+		const values = await readFlags(
+			{ name: flag.string(), port: flag.number(), target: flag.enum(['node', 'browser']) },
+			{ argv: ['--name=booga', '--port=8080', '--target=browser'], env: {} },
+		);
+
+		expect(values.name).toBe('booga');
+		expect(values.port).toBe(8080);
+		expect(values.target).toBe('browser');
+	});
+
+	it('ignores a trailing end-of-options separator', async () => {
+		const values = await readFlags(
+			{ name: flag.string() },
+			{ argv: ['--name', 'booga', '--'], env: {} },
+		);
+
+		expect(values.name).toBe('booga');
+	});
+
+	it('treats a token after the separator as a positional', async () => {
+		const error = await thrownBy(() =>
+			readFlags({ name: flag.string() }, { argv: ['--', '--name'], env: {} }),
+		);
+
+		expect(isParseError(error) && error.code).toBe('UNEXPECTED_POSITIONAL');
+	});
+
+	it('keeps the internal command name out of parse diagnostics', async () => {
+		const error = await thrownBy(() =>
+			readFlags({ watch: flag.boolean() }, { argv: ['--unknown'], env: {} }),
+		);
+
+		expect(isParseError(error) && error.message).not.toContain('standalone');
+	});
+});
+
+// === Flag-form collisions
+
+describe('readFlags() collisions', () => {
+	it('rejects two definitions sharing an alias', async () => {
+		const error = await thrownBy(() =>
+			readFlags(
+				{ watch: flag.boolean().alias('v'), verbose: flag.boolean().alias('v') },
+				{ argv: [], env: {} },
+			),
+		);
+
+		expect(isParseError(error)).toBe(false);
+		expect(error).toBeInstanceOf(Error);
+		expect(error instanceof Error && error.message).toContain('collides');
+	});
+
+	it('rejects an alias colliding with another canonical name', async () => {
+		const error = await thrownBy(() =>
+			readFlags(
+				{ watch: flag.boolean(), follow: flag.boolean().alias('watch') },
+				{ argv: [], env: {} },
+			),
+		);
+
+		expect(error instanceof Error && error.message).toContain('collides');
+	});
+
+	it('rejects a negated spelling colliding with a canonical name', async () => {
+		const error = await thrownBy(() =>
+			readFlags(
+				{ minify: flag.boolean().negatable(), 'no-minify': flag.boolean() },
+				{ argv: [], env: {} },
+			),
+		);
+
+		expect(error instanceof Error && error.message).toContain('collides');
+	});
+});
+
+// === Definition keys that collide with Object.prototype
+
+describe('readFlags() prototype keys', () => {
+	it('rejects a __proto__ definition instead of dropping it', async () => {
+		const definitions = { ['__proto__']: flag.string(), keep: flag.string() };
+		const error = await thrownBy(() => readFlags(definitions, { argv: [], env: {} }));
+
+		expect(error instanceof CLIError && error.code).toBe('INVALID_SCHEMA');
+	});
+
+	it('resolves other Object.prototype key names', async () => {
+		const values = await readFlags(
+			{ constructor: flag.string(), toString: flag.string(), valueOf: flag.string() },
+			{ argv: ['--constructor', 'a', '--toString', 'b', '--valueOf', 'c'], env: {} },
+		);
+
+		expect(values.constructor).toBe('a');
+		expect(values.toString).toBe('b');
+		expect(values.valueOf).toBe('c');
+	});
+});
+
+// === Parity with a command action
+
+describe('readFlags() command parity', () => {
+	const definitions = {
+		name: flag.string().alias('n'),
+		port: flag.number().alias('p'),
+		minify: flag.boolean().default(true).negatable(),
+		target: flag.enum(['node', 'browser']).default('node'),
+		tag: flag.array(flag.string()),
+		verbose: flag.count().alias('v'),
+		define: flag.keyValue(),
+		'dry-run': flag.boolean(),
+		strict: flag.string().duplicates('error'),
+	};
+
+	/** Resolved values and error code produced by the same definitions on a command. */
+	async function viaCommand(argv: readonly string[]): Promise<Outcome> {
+		let flags: Record<string, unknown> | undefined;
+		const cmd = command('parity')
+			.flag('name', definitions.name)
+			.flag('port', definitions.port)
+			.flag('minify', definitions.minify)
+			.flag('target', definitions.target)
+			.flag('tag', definitions.tag)
+			.flag('verbose', definitions.verbose)
+			.flag('define', definitions.define)
+			.flag('dry-run', definitions['dry-run'])
+			.flag('strict', definitions.strict)
+			.action((params) => {
+				flags = { ...params.flags };
+			});
+
+		const result = await runCommand(cmd, argv, { env: {} });
+		return { flags, code: result.error?.code };
+	}
+
+	/** The same two facts produced by readFlags, with the throw caught. */
+	async function viaReadFlags(argv: readonly string[]): Promise<Outcome> {
+		try {
+			return { flags: { ...(await readFlags(definitions, { argv, env: {} })) }, code: undefined };
+		} catch (error: unknown) {
+			return { flags: undefined, code: error instanceof CLIError ? error.code : undefined };
+		}
+	}
+
+	const cases: readonly (readonly [string, readonly string[]])[] = [
+		['long values', ['--name', 'booga', '--port', '8080']],
+		['inline value form', ['--name=booga', '--port=8080', '--target=browser']],
+		['short aliases', ['-n', 'booga', '-p', '8080', '-vv']],
+		['clustered short with inline value', ['-nbooga']],
+		['negated boolean', ['--no-minify']],
+		['negated boolean with a value', ['--no-minify=true']],
+		['case-parity counterpart', ['--dryRun']],
+		['duplicate under the last policy', ['--name', 'a', '--name', 'b']],
+		['duplicate under the error policy', ['--strict', 'a', '--strict', 'b']],
+		['unknown long flag', ['--nope']],
+		['unknown short flag', ['-z']],
+		['array accumulation', ['--tag', 'a', '--tag', 'b']],
+		['key-value accumulation', ['--define', 'A=1', '--define', 'B=2']],
+		['missing value', ['--name']],
+		['unparsable number', ['--port', 'abc']],
+		['value outside the enum', ['--target', 'deno']],
+		['trailing separator', ['--name', 'booga', '--']],
+		['token after the separator', ['--', '--name']],
+		['empty argv', []],
+	];
+
+	for (const [label, argv] of cases) {
+		it(`matches the command path for ${label}`, async () => {
+			const fromCommand = await viaCommand(argv);
+			const fromReadFlags = await viaReadFlags(argv);
+
+			expect(fromReadFlags.code).toBe(fromCommand.code);
+			expect(fromReadFlags.flags).toEqual(fromCommand.flags);
+		});
+	}
+});
+
+// === Coercion, constraints, and validation
+
+describe('readFlags() validation', () => {
+	it('reports a missing required flag', async () => {
+		const error = await thrownBy(() =>
+			readFlags({ name: flag.string().required() }, { argv: [], env: {} }),
+		);
+
+		expect(isValidationError(error)).toBe(true);
+	});
+
+	it('enforces number constraints during parsing', async () => {
+		const error = await thrownBy(() =>
+			readFlags({ port: flag.number({ min: 1, max: 10 }) }, { argv: ['--port', '99'], env: {} }),
+		);
+
+		expect(isParseError(error) && error.code).toBe('INVALID_VALUE');
+	});
+
+	it('enforces string constraints on env values', async () => {
+		const error = await thrownBy(() =>
+			readFlags(
+				{ name: flag.string({ minLength: 4 }).env('NAME') },
+				{
+					argv: [],
+					env: { NAME: 'ab' },
+				},
+			),
+		);
+
+		expect(isValidationError(error)).toBe(true);
+	});
+
+	it('awaits an async Standard Schema validator', async () => {
+		const values = await readFlags(
+			{ name: flag.custom(asyncName) },
+			{ argv: ['--name', 'booga'], env: {} },
+		);
+
+		expect(values.name).toBe('booga');
+
+		const error = await thrownBy(() =>
+			readFlags({ name: flag.custom(asyncName) }, { argv: ['--name', 'no'], env: {} }),
+		);
+
+		expect(isValidationError(error)).toBe(true);
+		expect(error instanceof Error && error.message).toContain('must be longer than two characters');
+	});
+
+	it('runs path checks through an injected stat probe', async () => {
+		const probed: string[] = [];
+		const stat = (path: string): Promise<'file' | 'directory' | null> => {
+			probed.push(path);
+			return Promise.resolve(path === '/data' ? 'directory' : null);
+		};
+
+		const values = await readFlags(
+			{ out: flag.path({ mustExist: true, type: 'directory' }) },
+			{ argv: ['--out', '/data'], env: {}, stat },
+		);
+
+		expect(values.out).toBe('/data');
+		expect(probed).toEqual(['/data']);
+
+		const error = await thrownBy(() =>
+			readFlags(
+				{ out: flag.path({ mustExist: true, type: 'directory' }) },
+				{ argv: ['--out', '/missing'], env: {}, stat },
+			),
+		);
+
+		expect(isValidationError(error)).toBe(true);
+	});
+
+	it('creates directories through an injected mkdir', async () => {
+		const created: string[] = [];
+		const values = await readFlags(
+			{ out: flag.path({ type: 'directory', create: true }) },
+			{
+				argv: ['--out', '/build'],
+				env: {},
+				stat: () => Promise.resolve(null),
+				mkdir: (path: string) => {
+					created.push(path);
+					return Promise.resolve();
+				},
+			},
+		);
+
+		expect(values.out).toBe('/build');
+		expect(created).toEqual(['/build']);
+	});
+});
+
+// === Deprecations
+
+describe('readFlags() deprecations', () => {
+	it('forwards a custom deprecation message', async () => {
+		const seen: DeprecationWarning[] = [];
+
+		await readFlags(
+			{ dest: flag.string().deprecated('Use --target instead') },
+			{
+				argv: ['--dest', 'staging'],
+				env: {},
+				onDeprecation: (warning) => seen.push(warning),
+			},
+		);
+
+		expect(seen).toEqual([{ kind: 'flag', name: 'dest', message: 'Use --target instead' }]);
+	});
+
+	it('forwards a bare deprecation as message true', async () => {
+		const seen: DeprecationWarning[] = [];
+
+		await readFlags(
+			{ dest: flag.string().deprecated().env('DEST') },
+			{ argv: [], env: { DEST: 'staging' }, onDeprecation: (warning) => seen.push(warning) },
+		);
+
+		expect(seen).toEqual([{ kind: 'flag', name: 'dest', message: true }]);
+	});
+
+	it('forwards one notice per deprecated flag that resolved a value', async () => {
+		const seen: DeprecationWarning[] = [];
+
+		await readFlags(
+			{
+				dest: flag.string().deprecated('gone'),
+				old: flag.string().deprecated('also gone'),
+				kept: flag.string().deprecated('never sourced'),
+			},
+			{
+				argv: ['--dest', 'a', '--old', 'b'],
+				env: {},
+				onDeprecation: (warning) => seen.push(warning),
+			},
+		);
+
+		expect(seen.map((warning) => warning.name)).toEqual(['dest', 'old']);
+	});
+
+	it('resolves without a receiver and writes nothing', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '--dest', 'staging'],
+			stdout: (line) => written.push(line),
+			stderr: (line) => written.push(line),
+		});
+
+		const values = await readFlags({ dest: flag.string().deprecated('gone') }, { adapter });
+
+		expect(values.dest).toBe('staging');
+		expect(written).toEqual([]);
+	});
+});
+
+// === Runtime adapter defaults
+
+describe('readFlags() adapter defaults', () => {
+	it('reads argv past the binary and script entries', async () => {
+		const adapter = createTestAdapter({ argv: ['node', 'build.ts', '--watch', '-p', '8080'] });
+
+		const values = await readFlags(
+			{ watch: flag.boolean(), port: flag.number().alias('p') },
+			{ adapter },
+		);
+
+		expect(values.watch).toBe(true);
+		expect(values.port).toBe(8080);
+	});
+
+	it('reads environment variables from the adapter', async () => {
+		const adapter = createTestAdapter({ argv: ['node', 'build.ts'], env: { WATCH: 'true' } });
+
+		const values = await readFlags({ watch: flag.boolean().env('WATCH') }, { adapter });
+
+		expect(values.watch).toBe(true);
+	});
+
+	it('reads path-check primitives from the adapter', async () => {
+		const probed: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '--out', '/data'],
+			stat: (path: string) => {
+				probed.push(path);
+				return Promise.resolve(path === '/data' ? 'directory' : null);
+			},
+		});
+
+		const values = await readFlags(
+			{ out: flag.path({ mustExist: true, type: 'directory' }) },
+			{ adapter },
+		);
+
+		expect(values.out).toBe('/data');
+		expect(probed).toEqual(['/data']);
+	});
+
+	it('lets explicit argv and env override the adapter', async () => {
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '--region', 'adapter'],
+			env: { REGION: 'adapter' },
+		});
+
+		const values = await readFlags(
+			{ region: flag.string().env('REGION') },
+			{
+				adapter,
+				argv: [],
+				env: { REGION: 'explicit' },
+			},
+		);
+
+		expect(values.region).toBe('explicit');
+	});
+
+	it('reads no runtime source when every fact is injected', async () => {
+		const base = createTestAdapter();
+		const tripwire: RuntimeAdapter = {
+			...base,
+			get argv(): readonly string[] {
+				throw new Error('adapter argv was read');
+			},
+			get env(): Readonly<Record<string, string | undefined>> {
+				throw new Error('adapter env was read');
+			},
+			stat: () => Promise.reject(new Error('adapter stat was called')),
+			mkdir: () => Promise.reject(new Error('adapter mkdir was called')),
+		};
+
+		const values = await readFlags(
+			{ watch: flag.boolean(), region: flag.string().env('REGION') },
+			{ adapter: tripwire, argv: ['--watch'], env: { REGION: 'eu' } },
+		);
+
+		expect(values.watch).toBe(true);
+		expect(values.region).toBe('eu');
+	});
+
+	it('never exits the process on failure', async () => {
+		const adapter = createTestAdapter({ argv: ['node', 'build.ts', '--unknown'] });
+
+		const error = await thrownBy(() => readFlags({ watch: flag.boolean() }, { adapter }));
+
+		expect(isParseError(error)).toBe(true);
+		expect(error instanceof Error && error.name).toBe('ParseError');
+	});
+});
+
+// === Root-owned spellings
+
+describe('readFlags() root-owned spellings', () => {
+	it('accepts json, quiet, and help as ordinary flags', async () => {
+		const values = await readFlags(
+			{
+				json: flag.boolean(),
+				quiet: flag.boolean().alias('q'),
+				help: flag.string(),
+			},
+			{ argv: ['--json', '-q', '--help', 'topics'], env: {} },
+		);
+
+		expect(values.json).toBe(true);
+		expect(values.quiet).toBe(true);
+		expect(values.help).toBe('topics');
+	});
+
+	it('does not render help for --help', async () => {
+		const written: string[] = [];
+		const adapter = createTestAdapter({
+			argv: ['node', 'build.ts', '--help'],
+			stdout: (line) => written.push(line),
+		});
+
+		const error = await thrownBy(() => readFlags({ watch: flag.boolean() }, { adapter }));
+
+		expect(isParseError(error) && error.code).toBe('UNKNOWN_FLAG');
+		expect(written).toEqual([]);
+	});
+});
+
+// === Concrete host adapters
+
+describe('readFlags() host adapters', () => {
+	it('reads argv and env from the Node adapter, which Bun shares', async () => {
+		const adapter = createNodeAdapter(
+			nodeProcess(['node', 'build.ts', '--watch'], { REGION: 'eu' }),
+		);
+
+		const values = await readFlags(
+			{ watch: flag.boolean(), region: flag.string().env('REGION') },
+			{ adapter },
+		);
+
+		expect(values.watch).toBe(true);
+		expect(values.region).toBe('eu');
+	});
+
+	it('reads argv and env from the Deno adapter', async () => {
+		const namespace: DenoNamespace = {
+			...createMockDenoNamespace(),
+			args: ['--watch'],
+			env: { get: () => 'eu', toObject: () => ({ REGION: 'eu' }) },
+		};
+		const adapter = createDenoAdapter(namespace);
+
+		const values = await readFlags(
+			{ watch: flag.boolean(), region: flag.string().env('REGION') },
+			{ adapter },
+		);
+
+		expect(values.watch).toBe(true);
+		expect(values.region).toBe('eu');
+	});
+});

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -896,6 +896,15 @@ function buildInheritedFlagsForChildren(
 	return next;
 }
 
+/**
+ * Reject a command whose flags collide on any spelling, walking subcommands.
+ *
+ * @param command - Command schema to validate.
+ * @param inheritedFlags - Propagated ancestor flags visible at this level.
+ * @throws {@link CLIError} `FLAG_NAME_COLLISION` or `PROPAGATED_FLAG_COLLISION`.
+ *
+ * @internal
+ */
 function validateCommandFlagTree(
 	command: CommandSchema,
 	inheritedFlags: Readonly<Record<string, FlagSchema>> = {},
@@ -1681,4 +1690,12 @@ export type {
 	WidenContext,
 	WidenDerivedContext,
 };
-export { CommandBuilder, command, createCommandSchema, group, outBrand, resolveExampleCommand };
+export {
+	CommandBuilder,
+	command,
+	createCommandSchema,
+	group,
+	outBrand,
+	resolveExampleCommand,
+	validateCommandFlagTree,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,8 @@ export type {
 	ResolvedSelectPromptConfig,
 } from './core/prompt/index.ts';
 export { createTerminalPrompter, resolvePromptConfig } from './core/prompt/index.ts';
+export type { FlagMap, ReadFlagsOptions } from './core/read-flags/index.ts';
+export { readFlags } from './core/read-flags/index.ts';
 export type { DeprecationWarning, ResolveOptions, ResolveResult } from './core/resolve/index.ts';
 export { resolve } from './core/resolve/index.ts';
 export type {


### PR DESCRIPTION
Targets v4. Stacked on #109.

**`readFlags()` (#107)**
- New package-root `readFlags(definitions, options?)` resolving a record of existing `FlagBuilder` values to `Promise<InferFlags<F>>` for build scripts and small tools: typed options without commands, handlers, or output channels.
- Zero reimplementation: the module maps builders to their schemas and calls the same `createCommandSchema`, `validateCommandFlagTree`, `parse`, and `resolve` the command path uses. A 19-case parity table pins identical values and identical error codes against a real command (aliases, negation, duplicates, case parity, `=value` forms, `--` separator, unknown flags, collisions).
- Process-free by construction: the runtime adapter is built lazily, so explicit `argv`/`env` injection never touches `process` (proven by a tripwire adapter with throwing getters). Adapter defaults cover Node, Bun, and Deno. One exception documented in the guide: a `flag.path()` existence check with no injected `stat` builds an adapter to reach the filesystem.
- Deprecation notices forward to `onDeprecation` in resolution order; with no receiver they are dropped (readFlags has no output channel; the CLI path keeps printing via `out.warn`).
- Type tests cover all 13 flag kinds plus optional/defaulted/required presence, enforced by typecheck (deliberately broken once to prove they fail).
- Review escalation, fixed in this PR: a `__proto__` definitions key was silently dropped through the prototype setter and mutated the accumulator; it now throws `INVALID_SCHEMA`, and `constructor`/`toString`/`valueOf` keys are tested to work.
- One sanctioned type assertion at the return boundary, matching the factory-cast pattern.

**Built-in overrideable `--help`**
- A pre-separator `--help`/`-h` prints generated help for the record to the adapter's stdout and exits 0, with the script named from the adapter's argv in the usage line (`isDefaultHelp` rendering, so the internal schema name never prints). Help renders ahead of parsing, matching the CLI's rule that a malformed value never hides the help text.
- Overrideable both ways: the built-in yields automatically when any definition claims the `help` or `h` spelling through a name, alias, negated form, or case-parity counterpart (checked against the parser's own `buildFlagLookup`), and `help: 'off'` removes it. `json` and `quiet` stay unreserved; #108's guard and #109's builtins verifiedly do not interfere in either direction.
- Failure paths still never write or exit; only the help path does, and only with 0. `ExitError`-based pins cover trigger, `-h`, pre-parse ordering, post-separator immunity, both yield modes, and `'off'`.

**`strict: false`**
- Drops undeclared argv content instead of rejecting it: unknown long flags with their inline `=value`, unknown short-group characters, positionals, and the `--` separator. Implemented as a pre-parse argv filter over the parser's exported primitives (`tokenize`, `buildFlagLookup`, `flagExpectsValue`), walking the parser's own value consumption, so `--name booga` keeps `booga` while the token after an unknown flag drops as a positional and short groups are rebuilt from their declared characters (`-zvv` parses as `-vv`).
- Leniency covers undeclared input only: missing values, failed coercions, violated constraints, and `.duplicates('error')` repeats keep their diagnostics in either mode.

Gates: typecheck, lint, fmt, full suite (3216 tests), build with attw+publint, docs build. New Standalone Flag Evaluation guide page (sidebar-registered, twoslash-verified examples) with Built-In Help and Non-Strict Parsing sections, and stability classifications for `readFlags`, `ReadFlagsOptions`, `FlagMap` included.

Closes #107
