### PR TITLE
v4 review follow ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,12 +358,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **`out.table()` printed a native method for a column key named after an
   `Object.prototype` member** — a column keyed `toString`, `constructor`, or any
-  other member name read the row without checking own keys, so a row that
-  carried no such key rendered `[Function: toString]` in place of the empty cell
-  every other missing key produces. Dynamic rows typed as
-  `Record<string, unknown>` are the reachable case, including columns inferred
-  from a first row that does carry the key. Both the text renderer and the JSON
-  projection now test own keys.
+  other member name read the row with a bare lookup, so a row that carried no
+  such key rendered `[Function: toString]` in place of the empty cell every
+  other missing key produces. Dynamic rows typed as `Record<string, unknown>`
+  are the reachable case, including columns inferred from a first row that does
+  carry the key. Both the text renderer and the JSON projection now treat a key
+  that only `Object.prototype` carries as absent. A key held anywhere earlier in
+  the row's prototype chain still renders, so a class getter and an
+  `Object.create(defaults)` fallback reach the table as before.
+
+- **A Standard Schema validator ran against a native method on a failed
+  resolution** — when a required flag or arg was missing, `resolve()` still ran
+  the Standard Schema pass before rethrowing, over a values record the failed
+  resolver had left empty. The pass read each declared name without checking own
+  keys, so a flag or arg named after an `Object.prototype` member handed its
+  `flag.custom()` / `arg.custom()` validator the inherited method. The user saw a
+  second, invented `CONSTRAINT_VIOLATED` beside the real error. The pass now
+  tests own keys.
 
 - **Quiet mode leaked spinner and progress output** — activity handles now
   resolve to no-ops under quiet verbosity, including interactive TTYs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   options type is now `RunCommandOptions`. The `RESERVED_FLAG` error offers
   `.builtins({ <name>: 'off' })` alongside renaming, and a version discovered by
   `.manifest()` filesystem walking now runs the same guard at `.run()` time
-  instead of silently shadowing a command's `version` flag.
+  instead of silently shadowing a command's `version` flag. That startup failure
+  is reported the way every other `.run()` startup failure is: the message and
+  its suggestion go to stderr, `--json` puts the serialized error on stdout, and
+  the process exits with the error's exit code rather than rejecting the
+  `.run()` promise.
 
 - **Definition format v1 — versioned, typed documents** — `generateSchema()`
   and `generateCommandSchema()` now emit `schemaVersion: 1`, so a consumer can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,8 +124,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the caller left
   out, so a call given `argv` and `env` reads nothing from the host unless a
   `flag.path()` check needs the adapter's filesystem primitives. Failures throw
-  `ParseError` and `ValidationError` instead of exiting, a colliding record or
-  the definition key `__proto__` throws `CLIError` before argv is read, and
+  `ParseError` and `ValidationError` instead of exiting, a colliding record, the
+  definition key `__proto__`, and a record whose prototype is replaced (an
+  object-literal `__proto__` key, or `Object.create(base)`, whose inherited
+  definitions are never read) each throw `CLIError` before argv is read, and
   `.deprecated()` notices reach `onDeprecation` rather than a warning stream,
   since there is no output channel on this path.
 
@@ -181,16 +183,34 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to `createFlagSchema()`, which validates its fields against the kind and
   normalizes a nested `elementSchema`.
 
-- **Breaking: `createCommandSchema()` rejects colliding flag spellings.** A
+- **Breaking: `createCommandSchema()` validates what the builder validates** — a
   definition whose flags share a name, an alias, or a negated spelling on one
   command now throws `FLAG_NAME_COLLISION`, and a flag spelled the same way as
   one propagated from an ancestor command throws `PROPAGATED_FLAG_COLLISION`.
   The whole tree is checked, nested subcommands included. Commands built with
   `command()` already refused these at `.flag()` and `.command()`; a definition
-  composed as data used to build without complaint and then lose one of the
-  colliding flags at parse time. `createCLISchema()` normalizes its commands
-  through the same factory and inherits the check, and `readFlags()` reports the
-  same errors it always did.
+  composed as data used to build without complaint and then answer the shared
+  spelling with one flag only. Two flags both aliased `v` still parsed under
+  `--verbose` and `--version`, help listed `-v` on both, and `-v` set the
+  second. The arg invariants moved with them, so a definition declaring one arg
+  both variadic and stdin-backed throws `INVALID_BUILDER_STATE`, and a second
+  stdin-backed arg throws `DUPLICATE_STDIN_ARG`, matching `.arg()`. Those two
+  built without complaint as well. Two stdin-backed args each resolved to the
+  whole of stdin, and a variadic stdin-backed arg read nothing from stdin and
+  failed as missing when argv supplied no positional. Every arg error names the
+  command in `details`, since a definition tree reaches them at any depth and
+  the arg name alone does not say which command declared it. A flag or arg
+  named `__proto__` now throws `INVALID_SCHEMA` from both the factory and the
+  builder, the check `readFlags()` already applied to its definitions record.
+  The factory and `.arg()` used to accept the key, which sets a prototype rather
+  than an entry, so the flag or the value the user typed disappeared; `.flag()`
+  used to report `FLAG_NAME_COLLISION` against a flag the command never
+  declared. A flag record whose prototype is replaced throws `INVALID_SCHEMA`
+  too, since only its own keys are read: an object-literal `__proto__` key lands
+  there, and so does `Object.create(base)`, whose inherited flags the factory
+  silently dropped. `createCLISchema()` normalizes its commands through the same
+  factory and inherits every check, and `readFlags()` reports the same errors it
+  always did.
 
 - **Breaking: `CLISchema` and `ConfigSettings` are sealed** — both carry a
   private brand, so an object literal assembled by hand no longer type-checks
@@ -306,6 +326,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   already defaults to `['package.json']`.
 
 ### Fixed
+
+- **Flags named after `Object.prototype` members were rejected as duplicates** —
+  `.flag('constructor')`, `.flag('toString')`, `.flag('valueOf')`, and every
+  other `Object.prototype` member name failed with a `FLAG_NAME_COLLISION`
+  claiming the command already declared the flag, on commands that declared no
+  flags at all. `collectPropagatedFlags()` read its descendant records the same
+  way, so a propagated flag with one of those names would have stopped at every
+  intermediate subcommand, and `resolveFlags()` read an `.interactive()`
+  resolver's override record the same way, so the inherited method reached the
+  prompt gate as a config and failed the command with `CONSTRAINT_VIOLATED`.
+  `.flag()` refused the name first, so no 3.x CLI ever got that far. Every one of
+  those reads now tests own keys only, so all eleven of those names behave like
+  any other and `createCommandSchema()` accepts the schemas `command()` produces.
+  `__proto__` is the one `Object.prototype` name still rejected, with
+  `INVALID_SCHEMA` on both construction paths, listed under Changed above.
+
+- **An env var named after an `Object.prototype` member always read as set** —
+  `.env('toString')` on a flag, or on an arg, looked the name up on the env
+  record without checking own keys, so an unset variable resolved to the
+  inherited method and failed coercion instead of falling through to config,
+  prompt, or default. Both lookups now test own keys.
 
 - **Quiet mode leaked spinner and progress output** — activity handles now
   resolve to no-ops under quiet verbosity, including interactive TTYs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to `createFlagSchema()`, which validates its fields against the kind and
   normalizes a nested `elementSchema`.
 
+- **Breaking: `createCommandSchema()` rejects colliding flag spellings.** A
+  definition whose flags share a name, an alias, or a negated spelling on one
+  command now throws `FLAG_NAME_COLLISION`, and a flag spelled the same way as
+  one propagated from an ancestor command throws `PROPAGATED_FLAG_COLLISION`.
+  The whole tree is checked, nested subcommands included. Commands built with
+  `command()` already refused these at `.flag()` and `.command()`; a definition
+  composed as data used to build without complaint and then lose one of the
+  colliding flags at parse time. `createCLISchema()` normalizes its commands
+  through the same factory and inherits the check, and `readFlags()` reports the
+  same errors it always did.
+
 - **Breaking: `CLISchema` and `ConfigSettings` are sealed** — both carry a
   private brand, so an object literal assembled by hand no longer type-checks
   where either is expected. Call `cli()` for an executable program or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,6 +348,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   inherited method and failed coercion instead of falling through to config,
   prompt, or default. Both lookups now test own keys.
 
+- **`.run()` never read stdin for an arg named after an `Object.prototype`
+  member** — the precheck that decides whether to read stdin looked the arg name
+  up on the parsed positionals without checking own keys, so an arg such as
+  `.arg('toString', arg.string().stdin())` looked already supplied. `.run()`
+  skipped the read and the command failed with `Missing required argument`
+  however much was piped to it. The lookup now tests own keys. `.execute()` and
+  the testkit take `stdinData` from the caller and were never affected.
+
+- **`out.table()` printed a native method for a column key named after an
+  `Object.prototype` member** — a column keyed `toString`, `constructor`, or any
+  other member name read the row without checking own keys, so a row that
+  carried no such key rendered `[Function: toString]` in place of the empty cell
+  every other missing key produces. Dynamic rows typed as
+  `Record<string, unknown>` are the reachable case, including columns inferred
+  from a first row that does carry the key. Both the text renderer and the JSON
+  projection now test own keys.
+
 - **Quiet mode leaked spinner and progress output** — activity handles now
   resolve to no-ops under quiet verbosity, including interactive TTYs and
   explicit static fallbacks. Consumers can route informational rows through

--- a/docs/.vitepress/data/docs-contract.test.ts
+++ b/docs/.vitepress/data/docs-contract.test.ts
@@ -64,15 +64,25 @@ describe('docs contracts', () => {
 	});
 
 	it('locks high-signal docs claims that previously drifted', async () => {
-		const [migration, runtime, readme, testingGuide, testkitReference, mainReference] =
-			await Promise.all([
-				readUtf8(new URL('../../guide/migration.md', import.meta.url)),
-				readUtf8(new URL('../../guide/runtime.md', import.meta.url)),
-				readUtf8(new URL('../../../README.md', import.meta.url)),
-				readUtf8(new URL('../../guide/testing.md', import.meta.url)),
-				readUtf8(new URL('../../reference/testkit.md', import.meta.url)),
-				readUtf8(new URL('../../reference/main.md', import.meta.url)),
-			]);
+		const [
+			migration,
+			runtime,
+			readme,
+			testingGuide,
+			testkitReference,
+			mainReference,
+			limitations,
+			semantics,
+		] = await Promise.all([
+			readUtf8(new URL('../../guide/migration.md', import.meta.url)),
+			readUtf8(new URL('../../guide/runtime.md', import.meta.url)),
+			readUtf8(new URL('../../../README.md', import.meta.url)),
+			readUtf8(new URL('../../guide/testing.md', import.meta.url)),
+			readUtf8(new URL('../../reference/testkit.md', import.meta.url)),
+			readUtf8(new URL('../../reference/main.md', import.meta.url)),
+			readUtf8(new URL('../../guide/limitations.md', import.meta.url)),
+			readUtf8(new URL('../../guide/semantics.md', import.meta.url)),
+		]);
 
 		expect(migration).toContain('runCommand(deploy, [], {');
 		expect(runtime).not.toContain('test adapter internally');
@@ -85,5 +95,9 @@ describe('docs contracts', () => {
 		expect(mainReference).toContain('.manifest({ from: import.meta })');
 		expect(mainReference).toContain('if (import.meta.main)');
 		expect(mainReference).toContain('if (isMainModule(import.meta))');
+		expect(limitations).toContain('.negatable()');
+		expect(limitations).not.toContain('unless you define that spelling yourself');
+		expect(semantics).toContain('Call `.negatable()` on the boolean');
+		expect(semantics).not.toContain('register that exact spelling as the flag name or as an alias');
 	});
 });

--- a/docs/guide/limitations.md
+++ b/docs/guide/limitations.md
@@ -73,20 +73,21 @@ Workarounds:
 
 References: [Examples](/examples/), [Example Hover](/reference/example-hover-prototype)
 
-## Shortcuts Like Automatic Negated Booleans Are Not Built In
+## Negated Booleans Are Opt-In Per Flag
 
 DreamCLI accepts boolean flags such as `--verbose`, `--verbose=true`, and `--verbose=false`.
-It does not synthesize special negated forms like `--no-verbose` unless you define that spelling yourself.
+`.negatable()` synthesizes the `--no-verbose` form for a flag that asks for it.
+No boolean gets a `--no-` spelling automatically; see [Negatable Booleans](/guide/flags#negatable-booleans).
 
 Why:
 
-- implicit alternate spellings make parsing and docs less explicit;
+- implicit alternate spellings on every boolean make parsing and docs less explicit;
 - the library prefers schema-declared behavior over convention-heavy magic.
 
 Workarounds:
 
-- declare the negative spelling directly if your CLI wants it;
-- document the explicit flag shape in help text.
+- add `.negatable()` to each boolean that wants the pair;
+- pass `.negatable({ alias: 'plain' })` when the negated spelling should be something other than `--no-<name>`.
 
 References: [CLI Semantics](/guide/semantics), [Flags](/guide/flags)
 

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -90,9 +90,11 @@ that set once a version is configured. Because a version can arrive after the
 commands are registered, `.version()` and `.manifest(data)` re-check every
 registered command too. A version that `.manifest()` reads off the filesystem
 lands later still, so `.run()` runs the guard once discovery supplies it and
-fails startup with the same error on stderr and the same exit code. Rename the
-flag, use `out.status()` for status output that root `--quiet` suppresses, or
-release the built-in with `.builtins()`.
+fails startup with the same error and the same exit code, routed the way every
+other startup failure is: message and suggestion on stderr, or the serialized
+error on stdout under `--json`. Rename the flag, use `out.status()` for status
+output that root `--quiet` suppresses, or release the built-in with
+`.builtins()`.
 
 | Method   | Stream                      | Suppressed by quiet |
 | -------- | --------------------------- | ------------------- |

--- a/docs/guide/output.md
+++ b/docs/guide/output.md
@@ -86,9 +86,13 @@ the same way could never be set, so declaring one throws `RESERVED_FLAG`.
 Naming a flag `quiet`, `json`, or `help`, aliasing one to `q` or `h`, or giving
 one a negated spelling like `.negatable({ alias: 'quiet' })` is rejected by
 `.command()`, `.default()`, and `createCLISchema()`, and `version`/`V` join
-that set once a version is configured. Rename the flag, use `out.status()` for
-status output that root `--quiet` suppresses, or release the built-in with
-`.builtins()`.
+that set once a version is configured. Because a version can arrive after the
+commands are registered, `.version()` and `.manifest(data)` re-check every
+registered command too. A version that `.manifest()` reads off the filesystem
+lands later still, so `.run()` runs the guard once discovery supplies it and
+fails startup with the same error on stderr and the same exit code. Rename the
+flag, use `out.status()` for status output that root `--quiet` suppresses, or
+release the built-in with `.builtins()`.
 
 | Method   | Stream                      | Suppressed by quiet |
 | -------- | --------------------------- | ------------------- |

--- a/docs/guide/read-flags.md
+++ b/docs/guide/read-flags.md
@@ -225,11 +225,15 @@ so a call without `onDeprecation` drops them.
 
 ## Errors
 
-Parse failures throw `ParseError`, resolution and constraint failures throw
-`ValidationError`, and a record that collides on a name, an alias, or a negated
-spelling throws `CLIError` before argv is read. Failure never writes output and
-never calls `adapter.exit`; only the built-in help path exits, and it exits
-with 0. The script owns what happens next:
+Parse failures throw `ParseError` and resolution and constraint failures throw
+`ValidationError`. Two kinds of definitions record throw `CLIError` before argv
+is read. A record that collides on a name, an alias, or a negated spelling
+throws `FLAG_NAME_COLLISION`. A record whose keys cannot all be read throws
+`INVALID_SCHEMA`: the definition key `__proto__`, or a replaced prototype, which
+covers an object-literal `__proto__` key and `Object.create(base)`.
+`Object.create(null)` is fine. Failure never writes output and never calls
+`adapter.exit`; only the built-in help path exits, and it exits with 0. The
+script owns what happens next:
 
 ```ts twoslash
 import { flag, isCLIError, readFlags } from '@kjanat/dreamcli';

--- a/docs/guide/semantics.md
+++ b/docs/guide/semantics.md
@@ -69,7 +69,7 @@ Resolves to:
 - Short booleans are presence-based. `-v` means `true`.
 
 dreamcli does **not** implement special negated-boolean syntax automatically.
-If you want `--no-confirm`, register that exact spelling as the flag name or as an alias.
+Call `.negatable()` on the boolean to accept `--no-confirm` alongside `--confirm`; see [Negatable Booleans](/guide/flags#negatable-booleans).
 
 ### Short-flag stacking
 

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -6,12 +6,13 @@ dreamcli from another framework, see
 [Migration And Adoption](/guide/migration).
 
 A CLI built entirely from the fluent builders (`cli()`, `command()`, `flag`,
-`arg`) mostly runs on 4.0 unchanged, with one exception: a command flag spelled
-like a root-owned flag is now rejected when you register the command. The rest
-of the breaking changes land on code that assembles schema objects by hand,
-hand-rolls an `Out`, reaches into `CLISchema.commands`, or passes
-framework-populated fields into execution options. Every category and its
-compatibility rules are listed on the
+`arg`) mostly runs on 4.0 unchanged. Two things changed on that path. A command
+flag spelled like a root-owned flag is now rejected when you register the
+command, and `.flag('__proto__')` or `.arg('__proto__')` now throws
+`INVALID_SCHEMA`. The rest of the breaking changes land on code that assembles
+schema objects by hand, hand-rolls an `Out`, reaches into `CLISchema.commands`,
+or passes framework-populated fields into execution options. Every category and
+its compatibility rules are listed on the
 [Stability Policy](/reference/stability) page.
 
 ## Breaking Changes
@@ -216,6 +217,84 @@ fails to compile and throws `INVALID_SCHEMA` at runtime.
 `Partial<ArgSchema>` to `ArgDefinitionOverrides<K>`, and `enumValues` is
 required on an `enum` arg.
 
+### `createCommandSchema()` validates what the builder validates
+
+A definition whose flags share a name, an alias, or a negated spelling on one
+command throws `FLAG_NAME_COLLISION`, and a flag spelled the same way as one
+propagated from an ancestor command throws `PROPAGATED_FLAG_COLLISION`.
+
+```ts
+// 3.x: built fine; help listed -v on both flags and -v set only --version
+createCommandSchema({
+  name: 'run',
+  flags: {
+    verbose: { kind: 'boolean', aliases: ['v'] },
+    version: { kind: 'boolean', aliases: ['v'] },
+  },
+});
+
+// 4.0: throws FLAG_NAME_COLLISION
+```
+
+In 3.x both flags still parsed under their canonical names, so what the
+collision cost was the shared spelling. Help advertised `-v` on both flags and
+the parser answered it with `--version`.
+
+The arg invariants moved with them. One arg that is both variadic and
+stdin-backed throws `INVALID_BUILDER_STATE`, and a second stdin-backed arg on
+the same command throws `DUPLICATE_STDIN_ARG`, the errors `.arg()` has always
+raised. In 3.x a definition could declare either. Two stdin-backed args each
+resolved to the whole of stdin, and a variadic stdin-backed arg read nothing
+from stdin and failed as missing when argv supplied no positional.
+
+A flag or arg named `__proto__` throws `INVALID_SCHEMA`. Both land in a record
+keyed by name, where that key sets a prototype rather than an entry, so the flag
+or the value the user typed used to disappear.
+
+```ts
+// 3.x: built fine, then the positional value never reached the handler
+createCommandSchema({
+  name: 'run',
+  args: [{ name: '__proto__', schema: { kind: 'string' } }],
+});
+
+// 4.0: throws INVALID_SCHEMA
+```
+
+A `flags` record whose prototype is replaced throws `INVALID_SCHEMA` as well.
+Only its own keys are read, so an object-literal `__proto__` key and a record
+built with `Object.create(base)` both hide a flag the caller meant to declare,
+and 3.x built the command without either one:
+
+```ts
+// 3.x: built fine, then --shared was an unknown flag
+createCommandSchema({
+  name: 'run',
+  flags: Object.create({ shared: { kind: 'boolean' } }),
+});
+
+// 4.0: throws INVALID_SCHEMA
+```
+
+`Object.create(null)` stays legal. Its prototype carries nothing, so a flag put
+on such a record is an own key and is read.
+
+The whole tree is checked, nested subcommands included, and `createCLISchema()`
+inherits the checks through it. `command()` already refused the collisions at
+`.flag()` and `.command()` and the arg invariants at `.arg()`. For those, only
+definitions composed as data change: one that used to build and then misbehave
+at parse time now fails at construction.
+
+`__proto__` changes on the builder too. `.arg('__proto__')` used to build and
+then swallow the positional value; it now throws `INVALID_SCHEMA`.
+`.flag('__proto__')` already threw, with code `FLAG_NAME_COLLISION` naming a flag
+the command never declared, and now throws `INVALID_SCHEMA` like the factory.
+
+Names such as `constructor`, `toString`, and `valueOf` are unaffected and always
+were legal as data. `.flag()` used to reject them as duplicates of a flag the
+command never declared; it now accepts them, so a schema `command()` produces
+and a schema `createCommandSchema()` produces agree on every name.
+
 ### `CommandSchema.middleware` is removed
 
 The executor builds the handler chain from the builder's ordered execution
@@ -361,14 +440,6 @@ need re-recording.
 
 ## Behavioral Changes To Review
 
-- **`createCommandSchema()` validates flag spellings.** A definition whose flags
-  share a name, an alias, or a negated spelling on one command throws
-  `FLAG_NAME_COLLISION`, and a flag spelled the same way as one propagated from
-  an ancestor command throws `PROPAGATED_FLAG_COLLISION`. The whole tree is
-  checked, nested subcommands included, and `createCLISchema()` inherits the
-  check through it. `command()` has always refused these at `.flag()` and
-  `.command()`, so only definitions composed as data change: one that used to
-  build and then lose a flag at parse time now fails at construction.
 - **Root `--json` and `--quiet` take an explicit value.** `--json=true`,
   `--json=1`, `--json=false`, and `--json=0` set the mode where 3.x failed with
   `Unknown flag`, and `--quiet` accepts the same literals. The last occurrence

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -359,6 +359,14 @@ need re-recording.
 
 ## Behavioral Changes To Review
 
+- **`createCommandSchema()` validates flag spellings.** A definition whose flags
+  share a name, an alias, or a negated spelling on one command throws
+  `FLAG_NAME_COLLISION`, and a flag spelled the same way as one propagated from
+  an ancestor command throws `PROPAGATED_FLAG_COLLISION`. The whole tree is
+  checked, nested subcommands included, and `createCLISchema()` inherits the
+  check through it. `command()` has always refused these at `.flag()` and
+  `.command()`, so only definitions composed as data change: one that used to
+  build and then lose a flag at parse time now fails at construction.
 - **Root `--json` and `--quiet` take an explicit value.** `--json=true`,
   `--json=1`, `--json=false`, and `--json=0` set the mode where 3.x failed with
   `Unknown flag`, and `--quiet` accepts the same literals. The last occurrence

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -82,9 +82,11 @@ the whole subcommand tree. `.command()`, `.default()`, `.version()`,
 `.manifest(data)`, and `createCLISchema()` all run it, so a `version` flag
 throws whether the command is registered before or after `.version()`. A
 version that `.manifest()` reads off the filesystem arrives past every one of
-those, so `.run()` runs the same guard again once discovery supplies it, and
-the startup fails with the identical error. `--completions` is reserved on the
-same terms once `.completions({ as: 'flag' })` or
+those, so `.run()` runs the same guard again once discovery supplies it. The
+startup fails with the identical error, reported like any other `.run()`
+startup failure: message and suggestion on stderr, the serialized error on
+stdout under `--json`, and the error's exit code. `--completions` is reserved
+on the same terms once `.completions({ as: 'flag' })` or
 `CLIDefinition.completionsFlag` is set.
 
 Near misses stay legal: `quietMode` and `jsonOutput` as names, `-Q` and `-j` as

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -27,7 +27,7 @@
 | ---------------------- | ----: | --------------------------------------------------------------------- |
 | `index.ts`             |  2282 | CLIBuilder class + cli() factory + JSON error handling                |
 | `planner.ts`           |   695 | `@internal` — execution planner, command resolution strategy          |
-| `runtime-preflight.ts` |   546 | `@internal` — runtime adapter setup, env/config preflight             |
+| `runtime-preflight.ts` |   548 | `@internal` — runtime adapter setup, env/config preflight             |
 | `root-help.ts`         |   383 | `@internal` — root-level help text + text helpers, structural schema  |
 | `dispatch.ts`          |   365 | `@internal` — command dispatch (value-flag-arity aware), levenshtein  |
 | `reserved-flags.ts`    |   238 | `@internal` — build-time `RESERVED_FLAG` guard for root-owned flags   |
@@ -142,6 +142,11 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
 - `collectPropagatedFlags()` in `propagate.ts` tests descendant flag records with `Object.hasOwn()`.
   `in` walks `Object.prototype`, which made every subcommand look like it overrode a propagated flag
   named `toString`, `valueOf`, or any other prototype member.
+- The same rule covers value reads, which grepping for `in` does not find.
+  `commandInvocationNeedsStdin()` in `runtime-preflight.ts` decides whether `.run()` reads stdin by
+  looking each arg name up on the parsed positionals, so a bare `parsed.args[name]` returned the
+  inherited method for an arg named `toString` and the stdin-backed arg looked already supplied.
+  That lookup goes through `Object.hasOwn()`.
 - `root-help.ts` uses structural `CLISchemaLike` instead of importing `CLISchema` — avoids circular
   dep through barrel
 - `levenshtein()` in `dispatch.ts` uses `Uint16Array` rolling buffer — different impl from `parse/`

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -128,8 +128,9 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
   `.version()`/`.manifest(data)` re-check every registered command because either can set the
   version after registration. `createCLISchema()` runs the same check, plus
   `assertNoCompletionsFlagCollision()` when the definition carries `completionsFlag`, so both
-  construction paths agree; `createCommandSchema()` stays permissive, since a bare command is not
-  bound to a root.
+  construction paths agree; `createCommandSchema()` runs no root-owned-token check, since a bare
+  command is not bound to a root. It does run `validateCommandFlagTree()`, so command-local and
+  propagated collisions still throw there.
 - `root-help.ts` uses structural `CLISchemaLike` instead of importing `CLISchema` — avoids circular
   dep through barrel
 - `levenshtein()` in `dispatch.ts` uses `Uint16Array` rolling buffer — different impl from `parse/`

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -25,9 +25,9 @@
 
 | File                   | Lines | Purpose                                                               |
 | ---------------------- | ----: | --------------------------------------------------------------------- |
-| `index.ts`             |  2259 | CLIBuilder class + cli() factory + JSON error handling                |
+| `index.ts`             |  2265 | CLIBuilder class + cli() factory + JSON error handling                |
 | `planner.ts`           |   695 | `@internal` — execution planner, command resolution strategy          |
-| `runtime-preflight.ts` |   526 | `@internal` — runtime adapter setup, env/config preflight             |
+| `runtime-preflight.ts` |   545 | `@internal` — runtime adapter setup, env/config preflight             |
 | `root-help.ts`         |   383 | `@internal` — root-level help text + text helpers, structural schema  |
 | `dispatch.ts`          |   365 | `@internal` — command dispatch (value-flag-arity aware), levenshtein  |
 | `reserved-flags.ts`    |   238 | `@internal` — build-time `RESERVED_FLAG` guard for root-owned flags   |
@@ -122,7 +122,9 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
   the exact `-q`/`-h`/`-V` tokens, so a short cluster like `-vq` still reaches the command. The
   plain spelling is the one users type; `reserved-flags.test.ts` pins both halves.
 - `runtime-preflight.ts` re-runs the guard when `.manifest()` filesystem discovery injects a version
-  (`assertDiscoveredVersionIsFree`), the one path that lands a version past every build-time check.
+  (`discoveredVersionCollision`), the one path that lands a version past every build-time check. It
+  returns the `CLIError` as a `startup-error` preflight result instead of throwing, so `.run()`
+  renders it through the same branch config failures use.
 - The version half of the guard is bidirectional like the `--completions` guard:
   `.command()`/`.default()` check against the current `schema.version`, and
   `.version()`/`.manifest(data)` re-check every registered command because either can set the

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -1,6 +1,6 @@
 # cli — CLIBuilder, multi-command dispatch, plugins
 
-`index.ts` (~2259 lines) — heavily split: 12 `@internal` extraction files.
+`index.ts` (~2282 lines) — heavily split: 12 `@internal` extraction files.
 
 ## KEY TYPES
 
@@ -25,9 +25,9 @@
 
 | File                   | Lines | Purpose                                                               |
 | ---------------------- | ----: | --------------------------------------------------------------------- |
-| `index.ts`             |  2265 | CLIBuilder class + cli() factory + JSON error handling                |
+| `index.ts`             |  2282 | CLIBuilder class + cli() factory + JSON error handling                |
 | `planner.ts`           |   695 | `@internal` — execution planner, command resolution strategy          |
-| `runtime-preflight.ts` |   545 | `@internal` — runtime adapter setup, env/config preflight             |
+| `runtime-preflight.ts` |   546 | `@internal` — runtime adapter setup, env/config preflight             |
 | `root-help.ts`         |   383 | `@internal` — root-level help text + text helpers, structural schema  |
 | `dispatch.ts`          |   365 | `@internal` — command dispatch (value-flag-arity aware), levenshtein  |
 | `reserved-flags.ts`    |   238 | `@internal` — build-time `RESERVED_FLAG` guard for root-owned flags   |
@@ -102,9 +102,10 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
   union forces a `BUILTIN_SPECS` entry through `Record` completeness, and `BUILTIN_NAMES` is a
   literal tuple (`as const satisfies readonly BuiltinName[]`) that `builtins.test.ts` pins with
   `expectTypeOf<Exclude<BuiltinName, (typeof BUILTIN_NAMES)[number]>>().toBeNever()`, so a union
-  member with no array entry fails typecheck. The guard walks that array. `root-help.ts` pushes
-  each built-in by name instead, keeping `--version` between `--help` and `--json` in
-  `Global options:`, so a fourth built-in needs a `pushBuiltin()` call there that nothing enforces.
+  member with no array entry fails typecheck. Both the guard and `root-help.ts` walk that array,
+  and `root-help.ts` splices its `--version` entry in during the `help` iteration to keep
+  `--version` between `--help` and `--json` in `Global options:`, so the pin covers the help block
+  too and a fourth built-in reaches it with no hand-written call.
   `version`/`V` is NOT a built-in — it is opt-in via `.version()`, so it stays a local
   constant in `reserved-flags.ts` and an interception in `planner.ts`.
 - `.builtins({ <name>: 'off' })` releases a built-in to the commands (#86). Normalized state lives on
@@ -135,8 +136,12 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
   version after registration. `createCLISchema()` runs the same check, plus
   `assertNoCompletionsFlagCollision()` when the definition carries `completionsFlag`, so both
   construction paths agree; `createCommandSchema()` runs no root-owned-token check, since a bare
-  command is not bound to a root. It does run `validateCommandFlagTree()`, so command-local and
-  propagated collisions still throw there.
+  command is not bound to a root. It does run `validateCommandFlagTree()` and `validateArgEntry()`,
+  so command-local collisions, propagated collisions, and the arg stdin/variadic invariants still
+  throw there.
+- `collectPropagatedFlags()` in `propagate.ts` tests descendant flag records with `Object.hasOwn()`.
+  `in` walks `Object.prototype`, which made every subcommand look like it overrode a propagated flag
+  named `toString`, `valueOf`, or any other prototype member.
 - `root-help.ts` uses structural `CLISchemaLike` instead of importing `CLISchema` — avoids circular
   dep through barrel
 - `levenshtein()` in `dispatch.ts` uses `Uint16Array` rolling buffer — different impl from `parse/`
@@ -156,7 +161,7 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
 - `planner.ts` orchestrates the execution pipeline — shared with testkit via `execution/`
 - `runtime-preflight.ts` handles adapter creation, env loading, config discovery before dispatch
 
-## TEST FILES (26)
+## TEST FILES (27)
 
 | File                              | Tests                                   |
 | --------------------------------- | --------------------------------------- |

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -28,7 +28,7 @@
 | `index.ts`             |  2282 | CLIBuilder class + cli() factory + JSON error handling                |
 | `planner.ts`           |   695 | `@internal` — execution planner, command resolution strategy          |
 | `runtime-preflight.ts` |   548 | `@internal` — runtime adapter setup, env/config preflight             |
-| `root-help.ts`         |   383 | `@internal` — root-level help text + text helpers, structural schema  |
+| `root-help.ts`         |   385 | `@internal` — root-level help text + text helpers, structural schema  |
 | `dispatch.ts`          |   365 | `@internal` — command dispatch (value-flag-arity aware), levenshtein  |
 | `reserved-flags.ts`    |   238 | `@internal` — build-time `RESERVED_FLAG` guard for root-owned flags   |
 | `root-output-flags.ts` |   214 | `@internal` — `--json`/`--quiet` reader + strip, shared by all layers |

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -97,12 +97,16 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
   built-in-aware layer reads it: `root-output-flags.ts` builds its long/short spelling maps from it,
   `reserved-flags.ts` builds the reserved token set from it, `root-help.ts` renders
   `Global options:` from it, and `completion/shells/shared.ts` gates the synthetic root `--help` on
-  it. Add a spelling to an existing entry and all four follow. Adding a whole built-in needs
-  `BUILTIN_NAMES` updated by hand as well: the `BuiltinName` union forces a `BUILTIN_SPECS` entry
-  through `Record` completeness, but nothing forces the `BUILTIN_NAMES` array, and the guard and the
-  `Global options:` block both walk that array. `version`/`V` is NOT a built-in — it is opt-in via
-  `.version()`, so it stays a local constant in `reserved-flags.ts` and an interception in
-  `planner.ts`.
+  it. Add a spelling to an existing entry and all four follow. Adding a whole built-in still needs
+  `BUILTIN_NAMES` written by hand, but both halves are now compile-time enforced. The `BuiltinName`
+  union forces a `BUILTIN_SPECS` entry through `Record` completeness, and `BUILTIN_NAMES` is a
+  literal tuple (`as const satisfies readonly BuiltinName[]`) that `builtins.test.ts` pins with
+  `expectTypeOf<Exclude<BuiltinName, (typeof BUILTIN_NAMES)[number]>>().toBeNever()`, so a union
+  member with no array entry fails typecheck. The guard walks that array. `root-help.ts` pushes
+  each built-in by name instead, keeping `--version` between `--help` and `--json` in
+  `Global options:`, so a fourth built-in needs a `pushBuiltin()` call there that nothing enforces.
+  `version`/`V` is NOT a built-in — it is opt-in via `.version()`, so it stays a local
+  constant in `reserved-flags.ts` and an interception in `planner.ts`.
 - `.builtins({ <name>: 'off' })` releases a built-in to the commands (#86). Normalized state lives on
   `CLISchema.builtins` (sealed, all three keys present); readers take the partial `BuiltinsConfig`
   and go through `builtinEnabled()`, which defaults an absent key to `'on'`, so an unthreaded reader

--- a/src/core/cli/builtins.test.ts
+++ b/src/core/cli/builtins.test.ts
@@ -36,6 +36,22 @@ function rootCompletionWords(script: string): string {
 	return lines[marker + 1] ?? '';
 }
 
+/** The flag spellings listed in the root-help `Global options:` block, in order. */
+function globalOptionSpellings(output: string): readonly string[] {
+	const lines = output.split('\n');
+	const start = lines.findIndex((line) => line.includes('Global options:'));
+	expect(start).toBeGreaterThan(-1);
+
+	const spellings: string[] = [];
+	for (const line of lines.slice(start + 1)) {
+		const trimmed = line.trim();
+		if (trimmed === '') break;
+		if (!trimmed.startsWith('-')) continue;
+		spellings.push(trimmed.split(/ {2,}/)[0] ?? '');
+	}
+	return spellings;
+}
+
 /** Capture the {@link CLIError} a build-time call throws. */
 function buildError(build: () => unknown): CLIError {
 	let thrown: unknown;
@@ -57,8 +73,40 @@ describe('builtins — BUILTIN_NAMES exhaustiveness', () => {
 		expectTypeOf<Exclude<BuiltinName, (typeof BUILTIN_NAMES)[number]>>().toBeNever();
 	});
 
-	it('walks every BUILTIN_SPECS entry', () => {
-		expect([...BUILTIN_NAMES]).toEqual(Object.keys(BUILTIN_SPECS));
+	it('walks every BUILTIN_SPECS entry exactly once', () => {
+		expect([...BUILTIN_NAMES].sort()).toEqual(Object.keys(BUILTIN_SPECS).sort());
+	});
+});
+
+// === Root-help ordering derived from the array
+
+describe('builtins — Global options order', () => {
+	it('lists the built-ins in BUILTIN_NAMES order with --version after --help', async () => {
+		const app = cli('mycli')
+			.version('1.0.0')
+			.config('mycli')
+			.command(command('show').action(() => {}));
+
+		expect(globalOptionSpellings((await app.execute([])).stdout.join(''))).toEqual([
+			'-h, --help',
+			'-V, --version',
+			'--json',
+			'-q, --quiet',
+			'--config <path>',
+		]);
+	});
+
+	it('keeps --version first once help is released', async () => {
+		const app = cli('mycli')
+			.builtins({ help: 'off' })
+			.version('1.0.0')
+			.command(echoFlag('help', flag.string()));
+
+		expect(globalOptionSpellings((await app.execute([])).stdout.join(''))).toEqual([
+			'-V, --version',
+			'--json',
+			'-q, --quiet',
+		]);
 	});
 });
 

--- a/src/core/cli/builtins.test.ts
+++ b/src/core/cli/builtins.test.ts
@@ -3,13 +3,15 @@
  * `--help`, `--json`, `--quiet` tokens (#86).
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { generateCompletion } from '#internals/core/completion/index.ts';
 import { CLIError } from '#internals/core/errors/index.ts';
 import { command } from '#internals/core/schema/command.ts';
 import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
 import { flag } from '#internals/core/schema/flag.ts';
 import { runCommand } from '#internals/core/testkit/index.ts';
+import type { BuiltinName } from './builtins.ts';
+import { BUILTIN_NAMES, BUILTIN_SPECS } from './builtins.ts';
 import type { BuiltinsConfig, CLIDefinition } from './index.ts';
 import { cli, createCLISchema, resolveRenderContext } from './index.ts';
 
@@ -47,6 +49,18 @@ function buildError(build: () => unknown): CLIError {
 	if (!(thrown instanceof CLIError)) throw new Error('unreachable');
 	return thrown;
 }
+
+// === Spelling-table exhaustiveness
+
+describe('builtins — BUILTIN_NAMES exhaustiveness', () => {
+	it('leaves no BuiltinName outside the array', () => {
+		expectTypeOf<Exclude<BuiltinName, (typeof BUILTIN_NAMES)[number]>>().toBeNever();
+	});
+
+	it('walks every BUILTIN_SPECS entry', () => {
+		expect([...BUILTIN_NAMES]).toEqual(Object.keys(BUILTIN_SPECS));
+	});
+});
 
 // === Normalization
 

--- a/src/core/cli/builtins.ts
+++ b/src/core/cli/builtins.ts
@@ -110,7 +110,7 @@ function builtinSpelling(name: BuiltinName): string {
 }
 
 /** Built-in names in the order root help advertises them. @internal */
-const BUILTIN_NAMES: readonly BuiltinName[] = ['help', 'json', 'quiet'];
+const BUILTIN_NAMES = ['help', 'json', 'quiet'] as const satisfies readonly BuiltinName[];
 
 /** Every built-in on, the state a CLI starts in. @internal */
 const DEFAULT_BUILTINS: BuiltinsDraft = { help: 'on', json: 'on', quiet: 'on' };

--- a/src/core/cli/cli-manifest.test.ts
+++ b/src/core/cli/cli-manifest.test.ts
@@ -229,6 +229,127 @@ describe('CLIBuilder.run() — package.json version', () => {
 	});
 });
 
+// === CLIBuilder.run() — discovered version collides with a command flag
+
+describe('CLIBuilder.run() — discovered version reserved-flag collision', () => {
+	it('renders the collision to stderr and exits instead of rejecting', async () => {
+		const app = cli('myapp')
+			.manifest()
+			.command(
+				command('info')
+					.flag('version', flag.boolean())
+					.action(({ out }) => {
+						out.json({ ok: true });
+					}),
+			);
+
+		const { exitCode, stdout, stderr } = await runWithAdapter(app, ['info'], {
+			'/test/package.json': '{"version":"6.6.6"}',
+		});
+
+		expect(exitCode).toBe(1);
+		expect(stdout).toEqual([]);
+		expect(stderr).toEqual([
+			"Error: Command 'info' defines a '--version' flag, which is reserved by the root '--version' flag. The root intercepts that token before dispatch, so the command can never receive it\n",
+			'Suggestion: Rename the flag\n',
+		]);
+	});
+
+	it('serializes the collision to stdout in json mode', async () => {
+		const app = cli('myapp')
+			.manifest()
+			.command(
+				command('info')
+					.flag('version', flag.boolean())
+					.action(({ out }) => {
+						out.json({ ok: true });
+					}),
+			);
+
+		const { exitCode, stdout, stderr } = await runWithAdapter(app, ['info', '--json'], {
+			'/test/package.json': '{"version":"6.6.6"}',
+		});
+
+		expect(exitCode).toBe(1);
+		expect(stderr).toEqual([]);
+		expect(stdout.length).toBe(1);
+		expect(JSON.parse(stdout[0] ?? '')).toEqual({
+			error: {
+				name: 'CLIError',
+				code: 'RESERVED_FLAG',
+				message:
+					"Command 'info' defines a '--version' flag, which is reserved by the root '--version' flag. The root intercepts that token before dispatch, so the command can never receive it",
+				details: { command: 'info', flag: 'version' },
+				suggest: 'Rename the flag',
+				exitCode: 1,
+			},
+		});
+	});
+
+	it('runs the discovered-version command when nothing collides', async () => {
+		const app = cli('myapp')
+			.manifest()
+			.command(
+				command('info')
+					.flag('versionTag', flag.string())
+					.action(({ out }) => {
+						out.json({ ok: true });
+					}),
+			);
+
+		const { exitCode, stdout, stderr } = await runWithAdapter(app, ['info'], {
+			'/test/package.json': '{"version":"6.6.6"}',
+		});
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toEqual([]);
+		expect(JSON.parse(stdout.join(''))).toEqual({ ok: true });
+	});
+
+	it('renders a collision on the default command', async () => {
+		const app = cli('myapp').default(
+			command('start')
+				.flag('version', flag.boolean())
+				.action(({ out }) => {
+					out.json({ ok: true });
+				}),
+		);
+
+		const { exitCode, stdout, stderr } = await runWithAdapter(app.manifest(), [], {
+			'/test/package.json': '{"version":"6.6.6"}',
+		});
+
+		expect(exitCode).toBe(1);
+		expect(stdout).toEqual([]);
+		expect(stderr[0]).toContain("Command 'start' defines a '--version' flag");
+	});
+
+	it('leaves a released built-in alone when discovery supplies the version', async () => {
+		const app = cli('myapp')
+			.builtins({ json: 'off' })
+			.manifest()
+			.command(
+				command('validate')
+					.flag('json', flag.string())
+					.action(({ flags, out }) => {
+						out.log(flags.json ?? '');
+					}),
+			);
+
+		const { exitCode, stdout, stderr } = await runWithAdapter(
+			app,
+			['validate', '--json', 'doc.txt'],
+			{
+				'/test/package.json': '{"version":"6.6.6"}',
+			},
+		);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toEqual([]);
+		expect(stdout.join('')).toContain('doc.txt');
+	});
+});
+
 // === CLIBuilder.run() — deno-family manifest discovery
 
 describe('CLIBuilder.run() — deno-family manifest discovery', () => {

--- a/src/core/cli/cli-propagate.test.ts
+++ b/src/core/cli/cli-propagate.test.ts
@@ -244,6 +244,29 @@ describe('collectPropagatedFlags', () => {
 			// mid's propagated verbose overwrites root's
 			expect(result['verbose']).toBe(mid.flags['verbose']);
 		});
+
+		it('does not treat an Object.prototype member name as an intermediate override', () => {
+			const root = makeSchema({
+				name: 'cli',
+				flags: { ['valueOf']: propagatedFlag('string') },
+			});
+			const mid = makeSchema({ name: 'db' });
+			const leaf = makeSchema({ name: 'migrate' });
+
+			const result = collectPropagatedFlags([root, mid, leaf]);
+			expect(result['valueOf']).toBe(root.flags['valueOf']);
+		});
+
+		it('still shadows an Object.prototype member name the intermediate declares', () => {
+			const root = makeSchema({
+				name: 'cli',
+				flags: { ['valueOf']: propagatedFlag('string') },
+			});
+			const mid = makeSchema({ name: 'db', flags: { ['valueOf']: localFlag('number') } });
+			const leaf = makeSchema({ name: 'migrate' });
+
+			expect(Object.hasOwn(collectPropagatedFlags([root, mid, leaf]), 'valueOf')).toBe(false);
+		});
 	});
 
 	// --- Return value properties --------------------------------------------

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -633,12 +633,17 @@ function buildCLISchema(definition: CLIDefinition): CLISchema {
  *
  * @param definition - Program name plus optional metadata and commands.
  * @returns A fully populated {@link CLISchema}.
- * @throws {CLIError} With code `'INVALID_SCHEMA'` when the name is empty or a
- *   `builtins` entry is neither `'on'` nor `'off'`.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` when the program name is
+ *   empty, a `builtins` entry is neither `'on'` nor `'off'`, a command name at
+ *   any depth is empty, a flag or arg at any depth is named `__proto__`, or a
+ *   flag record at any depth has a replaced prototype.
  * @throws {CLIError} With code `'FLAG_NAME_COLLISION'` when two flags on one
  *   command share a spelling, at any depth of the command tree.
  * @throws {CLIError} With code `'PROPAGATED_FLAG_COLLISION'` when a command flag
  *   shadows a spelling propagated from an ancestor command.
+ * @throws {CLIError} With code `'INVALID_BUILDER_STATE'` when one arg is both
+ *   variadic and stdin-backed, or `'DUPLICATE_STDIN_ARG'` when two args on one
+ *   command are stdin-backed.
  * @throws {CLIError} With code `'RESERVED_FLAG'` when a command spells a flag
  *   the same way as a root-owned flag (`--json`, `--quiet`/`-q`, `--help`/`-h`,
  *   `--version`/`-V` once `version` is set, and `--completions` once
@@ -1014,8 +1019,8 @@ class CLIBuilder {
 	 *
 	 * @param v - Semantic version string.
 	 * @returns The builder (for chaining).
-	 * @throws {@link CLIError} `RESERVED_FLAG` when a registered command declares
-	 *   a flag named `version` or aliased `V`.
+	 * @throws {@link CLIError} `RESERVED_FLAG` when a registered command spells
+	 *   `--version` or `-V` as a flag name, an alias, or a negated spelling.
 	 */
 	version(v: string): CLIBuilder {
 		assertNoReservedFlagCollisions(
@@ -1280,7 +1285,8 @@ class CLIBuilder {
 	 *
 	 * @param data - Pre-loaded manifest metadata.
 	 * @throws {@link CLIError} `RESERVED_FLAG` when the data carries a version and
-	 *   a registered command declares a flag named `version` or aliased `V`.
+	 *   a registered command spells `--version` or `-V` as a flag name, an alias,
+	 *   or a negated spelling.
 	 *
 	 * @example
 	 * ```ts
@@ -1310,10 +1316,11 @@ class CLIBuilder {
 	 * Has no effect in `.execute()` (filesystem-free) — use the data overload.
 	 *
 	 * A discovered version lands at `.run()` time, past every build-time check, so
-	 * the `RESERVED_FLAG` guard re-runs there. A registered command that declares a
-	 * flag named `version` or aliased `V` then fails startup, writing the error and
-	 * its suggestion to stderr (a JSON error envelope on stdout under `--json`) and
-	 * exiting with the error's exit code instead of throwing.
+	 * the `RESERVED_FLAG` guard re-runs there. A registered command that spells
+	 * `--version` or `-V` as a flag name, an alias, or a negated spelling then fails
+	 * startup, writing the error and its suggestion to stderr (a JSON error envelope
+	 * on stdout under `--json`) and exiting with the error's exit code instead of
+	 * throwing.
 	 *
 	 * @param settings - Optional settings:
 	 *   - `files`: candidate manifest filenames in priority order
@@ -1361,10 +1368,11 @@ class CLIBuilder {
 	 * @param cmd - {@link CommandBuilder} to register.
 	 * @returns The builder (for chaining).
 	 * @throws {@link CLIError} `RESERVED_FLAG` when the command, or one of its
-	 *   nested subcommands, declares a flag named or aliased to a root-owned flag
-	 *   (`--json`, `--quiet`/`-q`, `--help`/`-h`, and `--version`/`-V` once
-	 *   {@link CLIBuilder.version | .version()} is set). A built-in released
-	 *   through {@link CLIBuilder.builtins | .builtins()} is not reserved.
+	 *   nested subcommands, spells a root-owned flag (`--json`, `--quiet`/`-q`,
+	 *   `--help`/`-h`, and `--version`/`-V` once
+	 *   {@link CLIBuilder.version | .version()} is set) as a flag name, an alias,
+	 *   or a negated spelling. A built-in released through
+	 *   {@link CLIBuilder.builtins | .builtins()} is not reserved.
 	 */
 	command<
 		F extends Record<string, FlagBuilder<FlagConfig>>,
@@ -1439,10 +1447,11 @@ class CLIBuilder {
 	 *   the command under its own name (see {@link DefaultCommandOptions}).
 	 * @returns The builder (for chaining).
 	 * @throws {@link CLIError} `RESERVED_FLAG` when the command, or one of its
-	 *   nested subcommands, declares a flag named or aliased to a root-owned flag
-	 *   (`--json`, `--quiet`/`-q`, `--help`/`-h`, and `--version`/`-V` once
-	 *   {@link CLIBuilder.version | .version()} is set). A built-in released
-	 *   through {@link CLIBuilder.builtins | .builtins()} is not reserved.
+	 *   nested subcommands, spells a root-owned flag (`--json`, `--quiet`/`-q`,
+	 *   `--help`/`-h`, and `--version`/`-V` once
+	 *   {@link CLIBuilder.version | .version()} is set) as a flag name, an alias,
+	 *   or a negated spelling. A built-in released through
+	 *   {@link CLIBuilder.builtins | .builtins()} is not reserved.
 	 */
 	default<
 		F extends Record<string, FlagBuilder<FlagConfig>>,

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -1279,6 +1279,8 @@ class CLIBuilder {
 	 * or a settings-shaped object falls through to the settings overload.
 	 *
 	 * @param data - Pre-loaded manifest metadata.
+	 * @throws {@link CLIError} `RESERVED_FLAG` when the data carries a version and
+	 *   a registered command declares a flag named `version` or aliased `V`.
 	 *
 	 * @example
 	 * ```ts
@@ -1306,6 +1308,12 @@ class CLIBuilder {
 	 * (discovery keeps walking).
 	 *
 	 * Has no effect in `.execute()` (filesystem-free) — use the data overload.
+	 *
+	 * A discovered version lands at `.run()` time, past every build-time check, so
+	 * the `RESERVED_FLAG` guard re-runs there. A registered command that declares a
+	 * flag named `version` or aliased `V` then fails startup, writing the error and
+	 * its suggestion to stderr (a JSON error envelope on stdout under `--json`) and
+	 * exiting with the error's exit code instead of throwing.
 	 *
 	 * @param settings - Optional settings:
 	 *   - `files`: candidate manifest filenames in priority order

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -1637,7 +1637,7 @@ class CLIBuilder {
 			inheritedName,
 		});
 
-		if (preflight.kind === 'config-error') {
+		if (preflight.kind === 'startup-error') {
 			if (preflight.jsonMode) {
 				adapter.stdout(`${JSON.stringify({ error: preflight.error.toJSON() })}\n`);
 			} else {

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -635,6 +635,10 @@ function buildCLISchema(definition: CLIDefinition): CLISchema {
  * @returns A fully populated {@link CLISchema}.
  * @throws {CLIError} With code `'INVALID_SCHEMA'` when the name is empty or a
  *   `builtins` entry is neither `'on'` nor `'off'`.
+ * @throws {CLIError} With code `'FLAG_NAME_COLLISION'` when two flags on one
+ *   command share a spelling, at any depth of the command tree.
+ * @throws {CLIError} With code `'PROPAGATED_FLAG_COLLISION'` when a command flag
+ *   shadows a spelling propagated from an ancestor command.
  * @throws {CLIError} With code `'RESERVED_FLAG'` when a command spells a flag
  *   the same way as a root-owned flag (`--json`, `--quiet`/`-q`, `--help`/`-h`,
  *   `--version`/`-V` once `version` is set, and `--completions` once

--- a/src/core/cli/propagate.ts
+++ b/src/core/cli/propagate.ts
@@ -68,7 +68,7 @@ function collectPropagatedFlags(
 				let shadowedByDescendant = false;
 				for (let j = i + 1; j < commandPath.length - 1; j++) {
 					const descendant = commandPath[j];
-					if (descendant !== undefined && name in descendant.flags) {
+					if (descendant !== undefined && Object.hasOwn(descendant.flags, name)) {
 						shadowedByDescendant = true;
 						break;
 					}

--- a/src/core/cli/root-help.ts
+++ b/src/core/cli/root-help.ts
@@ -312,12 +312,14 @@ function formatRootCommandsSection(
 /**
  * Build the `Global options:` section advertising the active built-in flags.
  *
- * `--help, -h`, `--json`, and `-q, --quiet` are listed while the root owns them;
- * `.builtins({ <name>: 'off' })` hands the token to the commands and drops the
- * entry. `--version, -V` is shown only when the program declares a version;
- * `--config <path>` only when `.config()` enabled config discovery. The eager
- * `--completions` flag is intentionally omitted, since it is advertised via the
- * inline surface when active.
+ * `-h, --help`, `--json`, and `-q, --quiet` are listed in {@link BUILTIN_NAMES}
+ * order while the root owns them; `.builtins({ <name>: 'off' })` hands the token
+ * to the commands and drops the entry. `-V, --version` is spliced in after the
+ * `help` entry, so it keeps its place whether or not the root still owns
+ * `--help`, and is shown only when the program declares a version.
+ * `--config <path>` is listed only when `.config()` enabled config discovery.
+ * The eager `--completions` flag is intentionally omitted, since it is
+ * advertised via the inline surface when active.
  *
  * @param schema - The CLI schema (read for `version`, `configSettings`, and `builtins`).
  * @param width - Terminal width for description wrapping.

--- a/src/core/cli/root-help.ts
+++ b/src/core/cli/root-help.ts
@@ -17,7 +17,7 @@ import { command } from '#internals/core/schema/command.ts';
 import type { FlagSchema } from '#internals/core/schema/flag.ts';
 import { createFlagSchema } from '#internals/core/schema/flag.ts';
 import type { BuiltinName, BuiltinsConfig } from './builtins.ts';
-import { BUILTIN_SPECS, builtinEnabled, builtinFlagForms } from './builtins.ts';
+import { BUILTIN_NAMES, BUILTIN_SPECS, builtinEnabled, builtinFlagForms } from './builtins.ts';
 import { resolveRootSurface } from './root-surface.ts';
 
 // Re-use CLISchema inline to avoid circular import through the barrel.
@@ -339,15 +339,15 @@ function formatGlobalOptionsSection(
 		});
 	};
 
-	pushBuiltin('help');
-	if (schema.version !== undefined) {
-		entries.push({
-			left: theme.flag('-V, --version'),
-			description: 'Print the version number and exit',
-		});
+	for (const name of BUILTIN_NAMES) {
+		pushBuiltin(name);
+		if (name === 'help' && schema.version !== undefined) {
+			entries.push({
+				left: theme.flag('-V, --version'),
+				description: 'Print the version number and exit',
+			});
+		}
 	}
-	pushBuiltin('json');
-	pushBuiltin('quiet');
 	if (schema.configSettings !== undefined) {
 		entries.push({
 			left: `${theme.flag('--config')} ${theme.placeholder('<path>')}`,

--- a/src/core/cli/runtime-preflight.test.ts
+++ b/src/core/cli/runtime-preflight.test.ts
@@ -137,7 +137,7 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 		expect(preflight.schema.version).toBe('5.5.5');
 	});
 
-	it('rejects version flag collisions activated by discovered metadata', async () => {
+	it('reports a discovered version that shadows a command flag as a startup error', async () => {
 		const app = cli('myapp')
 			.manifest()
 			.command(
@@ -157,11 +157,12 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 			options: undefined,
 			inheritedName: undefined,
 		});
-
-		expect(preflight.kind).toBe('config-error');
-		if (preflight.kind !== 'config-error') return;
+		expect(preflight.kind).toBe('startup-error');
+		if (preflight.kind !== 'startup-error') return;
 		expect(preflight.error.code).toBe('RESERVED_FLAG');
-		expect(preflight.error.details).toEqual({ command: 'info', flag: 'version' });
+		expect(preflight.error.message).toMatch(/reserved by the root '--version' flag/);
+		expect(preflight.error.suggest).toBe('Rename the flag');
+		expect(preflight.jsonMode).toBe(false);
 	});
 
 	it('leaves a discovered version alone when no command flag collides', async () => {
@@ -299,7 +300,7 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 		expect(piped.inputs.prompter).toBeUndefined();
 	});
 
-	it('returns config-error outcomes for CLI config failures', async () => {
+	it('returns startup-error outcomes for CLI config failures', async () => {
 		const app = cli('myapp')
 			.config('myapp')
 			.command(command('deploy').action(() => {}));
@@ -316,8 +317,8 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 			inheritedName: undefined,
 		});
 
-		expect(preflight.kind).toBe('config-error');
-		if (preflight.kind !== 'config-error') return;
+		expect(preflight.kind).toBe('startup-error');
+		if (preflight.kind !== 'startup-error') return;
 		expect(preflight.jsonMode).toBe(true);
 		expect(preflight.error.code).toBe('CONFIG_PARSE_ERROR');
 	});

--- a/src/core/cli/runtime-preflight.test.ts
+++ b/src/core/cli/runtime-preflight.test.ts
@@ -239,6 +239,54 @@ describe('runtime-preflight — prepareRuntimePreflight', () => {
 		expect(preflight.inputs.stdinData).toBe('piped data');
 	});
 
+	it('reads stdin for a stdin arg named after an Object.prototype member', async () => {
+		const app = cli('myapp').command(
+			command('echo')
+				.arg('toString', arg.string().stdin())
+				.action(() => {}),
+		);
+		const adapter = createTestAdapter({
+			argv: ['node', 'test', 'echo'],
+			stdinData: 'piped data',
+		});
+
+		const preflight = await prepareRuntimePreflight({
+			schema: app.schema,
+			compiled: compiledStateOf(app),
+			adapter,
+			options: undefined,
+			inheritedName: undefined,
+		});
+
+		expect(preflight.kind).toBe('ready');
+		if (preflight.kind !== 'ready') return;
+		expect(preflight.inputs.stdinData).toBe('piped data');
+	});
+
+	it('leaves stdin unread when such an arg already has a positional', async () => {
+		const app = cli('myapp').command(
+			command('echo')
+				.arg('toString', arg.string().stdin())
+				.action(() => {}),
+		);
+		const adapter = createTestAdapter({
+			argv: ['node', 'test', 'echo', 'from-argv'],
+			stdinData: 'piped data',
+		});
+
+		const preflight = await prepareRuntimePreflight({
+			schema: app.schema,
+			compiled: compiledStateOf(app),
+			adapter,
+			options: undefined,
+			inheritedName: undefined,
+		});
+
+		expect(preflight.kind).toBe('ready');
+		if (preflight.kind !== 'ready') return;
+		expect(preflight.inputs.stdinData).toBeUndefined();
+	});
+
 	it('does not read stdin for root help despite stdin-capable commands', async () => {
 		const app = cli('myapp').command(
 			command('echo')

--- a/src/core/cli/runtime-preflight.ts
+++ b/src/core/cli/runtime-preflight.ts
@@ -277,7 +277,9 @@ function commandInvocationNeedsStdin(
 	try {
 		const parsed = parse(schema, argv, flagSettings);
 		return schema.args.some(({ name, schema: argSchema }) => {
-			const parsedValue = parsed.args[name];
+			// An arg named after an Object.prototype member would otherwise read
+			// that inherited method as a supplied positional.
+			const parsedValue = Object.hasOwn(parsed.args, name) ? parsed.args[name] : undefined;
 			return argSchema.stdinMode && (parsedValue === undefined || parsedValue === '-');
 		});
 	} catch (error: unknown) {

--- a/src/core/cli/runtime-preflight.ts
+++ b/src/core/cli/runtime-preflight.ts
@@ -384,10 +384,11 @@ async function applyPackageJsonDiscovery(
  * Re-run the `RESERVED_FLAG` guard when discovery supplied the version.
  *
  * `.manifest()` reads a version off the filesystem at `.run()` time, past every
- * build-time check, so a command flag named `version` or aliased `V` would
- * become unreachable without ever being rejected. Running the same guard here
- * fails the startup with the identical error the build paths raise (#86),
- * rendered like every other startup failure rather than thrown at the caller.
+ * build-time check, so a command flag spelling `--version` or `-V` as a name, an
+ * alias, or a negated spelling would become unreachable without ever being
+ * rejected. Running the same guard here fails the startup with the identical
+ * error the build paths raise (#86), rendered like every other startup failure
+ * rather than thrown at the caller.
  *
  * @param discovered - Schema after manifest discovery merged its metadata in.
  * @param declared - Schema as the builder had it before discovery.

--- a/src/core/cli/runtime-preflight.ts
+++ b/src/core/cli/runtime-preflight.ts
@@ -182,18 +182,18 @@ interface ReadyRuntimePreflight {
 	readonly inputs: RuntimeExecutionInputs;
 }
 
-/** Preflight failed during config file discovery/loading. @internal */
-interface RuntimeConfigErrorPreflight {
-	/** Discriminant — config loading produced a structured error. */
-	readonly kind: 'config-error';
-	/** The config discovery/parse error to render. */
+/** Preflight failed before the CLI could start. @internal */
+interface RuntimeStartupErrorPreflight {
+	/** Discriminant — a startup step produced a structured error. */
+	readonly kind: 'startup-error';
+	/** The startup error to render. */
 	readonly error: CLIError;
 	/** Whether JSON output was requested (needed to choose error rendering). */
 	readonly jsonMode: boolean;
 }
 
-/** Discriminated union of preflight outcomes — either ready or config-error. @internal */
-type RuntimePreflightResult = ReadyRuntimePreflight | RuntimeConfigErrorPreflight;
+/** Discriminated union of preflight outcomes — either ready or startup-error. @internal */
+type RuntimePreflightResult = ReadyRuntimePreflight | RuntimeStartupErrorPreflight;
 
 /** Options bag for {@linkcode prepareRuntimePreflight}. @internal */
 interface PrepareRuntimePreflightOptions {
@@ -386,26 +386,36 @@ async function applyPackageJsonDiscovery(
  * `.manifest()` reads a version off the filesystem at `.run()` time, past every
  * build-time check, so a command flag named `version` or aliased `V` would
  * become unreachable without ever being rejected. Running the same guard here
- * fails the startup with the identical error the build paths raise (#86).
+ * fails the startup with the identical error the build paths raise (#86),
+ * rendered like every other startup failure rather than thrown at the caller.
  *
  * @param discovered - Schema after manifest discovery merged its metadata in.
  * @param declared - Schema as the builder had it before discovery.
  * @param compiled - Compiled graph carrying every registered command schema.
- * @throws {@linkcode CLIError} `RESERVED_FLAG` for the first collision found.
+ * @returns The `RESERVED_FLAG` error for the first collision, or `undefined`.
  *
  * @internal
  */
-function assertDiscoveredVersionIsFree(
+function discoveredVersionCollision(
 	discovered: RuntimePreflightSchemaLike,
 	declared: RuntimePreflightSchemaLike,
 	compiled: CompiledCLI,
-): void {
-	if (discovered.version === declared.version) return;
-	assertNoReservedFlagCollisions(
-		discovered.version,
-		[compiled.defaultCommand?.schema, ...compiled.commands.map((command) => command.schema)],
-		discovered.builtins,
-	);
+): CLIError | undefined {
+	if (discovered.version === declared.version) return undefined;
+
+	try {
+		assertNoReservedFlagCollisions(
+			discovered.version,
+			[compiled.defaultCommand?.schema, ...compiled.commands.map((command) => command.schema)],
+			discovered.builtins,
+		);
+		return undefined;
+	} catch (error: unknown) {
+		if (error instanceof CLIError) {
+			return error;
+		}
+		throw error;
+	}
 }
 
 async function loadRuntimeConfig(
@@ -461,11 +471,14 @@ async function prepareRuntimePreflight(
 		options.inheritedName,
 		isCompletions,
 	);
-	try {
-		assertDiscoveredVersionIsFree(schema, options.schema, options.compiled);
-	} catch (error: unknown) {
-		if (error instanceof CLIError) return { kind: 'config-error', error, jsonMode };
-		throw error;
+	const versionCollision = discoveredVersionCollision(schema, options.schema, options.compiled);
+
+	if (versionCollision !== undefined) {
+		return {
+			kind: 'startup-error',
+			error: versionCollision,
+			jsonMode,
+		};
 	}
 	const loadedConfig = await loadRuntimeConfig(
 		schema,
@@ -477,7 +490,7 @@ async function prepareRuntimePreflight(
 
 	if (loadedConfig instanceof CLIError) {
 		return {
-			kind: 'config-error',
+			kind: 'startup-error',
 			error: loadedConfig,
 			jsonMode,
 		};

--- a/src/core/output/AGENTS.md
+++ b/src/core/output/AGENTS.md
@@ -1,8 +1,8 @@
 # output — OutputChannel, spinner/progress, TTY rendering
 
 Seven source files: `writer.ts` (leaf), `contracts.ts` (type contracts), `display-value.ts` (value
-formatting), `renderers.ts` (table/list rendering), `bind.ts` (method-binding helper), `activity.ts`
-(handle classes, ~575 lines), `index.ts` (OutputChannel + factories, ~830 lines).
+formatting), `renderers.ts` (activity-handle construction), `bind.ts` (method-binding helper),
+`activity.ts` (handle classes, ~575 lines), `index.ts` (OutputChannel + factories, ~830 lines).
 
 Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- `index.ts` ->
 `writer.ts`. `renderers.ts` + `display-value.ts` consumed by `index.ts`.
@@ -19,15 +19,15 @@ Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- 
 
 ## FILES
 
-| File               | Lines | Purpose                                                   |
-| ------------------ | ----: | --------------------------------------------------------- |
-| `index.ts`         |   830 | OutputChannel class + factories + mode dispatch           |
-| `activity.ts`      |   575 | Spinner/progress handle classes (TTY/static/capture/noop) |
-| `contracts.ts`     |   197 | Output type contracts, mode types, option interfaces      |
-| `renderers.ts`     |   125 | Table + list rendering logic                              |
-| `bind.ts`          |    59 | `bindMethods()` — binds instance methods (see GOTCHAS)    |
-| `display-value.ts` |    48 | Value display formatting utilities                        |
-| `writer.ts`        |    46 | `WriteFn` type + `writeLine` helper (leaf)                |
+| File               | Lines | Purpose                                                           |
+| ------------------ | ----: | ----------------------------------------------------------------- |
+| `index.ts`         |   830 | OutputChannel class + factories + mode dispatch + `formatTable()` |
+| `activity.ts`      |   575 | Spinner/progress handle classes (TTY/static/capture/noop)         |
+| `contracts.ts`     |   197 | Output type contracts, mode types, option interfaces              |
+| `renderers.ts`     |   125 | Spinner/progress handle factories + `resolveWriterForStream()`    |
+| `bind.ts`          |    59 | `bindMethods()` — binds instance methods (see GOTCHAS)            |
+| `display-value.ts` |    48 | Value display formatting utilities                                |
+| `writer.ts`        |    46 | `WriteFn` type + `writeLine` helper (leaf)                        |
 
 ## OUTPUT MODES
 

--- a/src/core/output/AGENTS.md
+++ b/src/core/output/AGENTS.md
@@ -2,7 +2,7 @@
 
 Seven source files: `writer.ts` (leaf), `contracts.ts` (type contracts), `display-value.ts` (value
 formatting), `renderers.ts` (table/list rendering), `bind.ts` (method-binding helper), `activity.ts`
-(handle classes, ~568 lines), `index.ts` (OutputChannel + factories, ~698 lines).
+(handle classes, ~575 lines), `index.ts` (OutputChannel + factories, ~814 lines).
 
 Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- `index.ts` ->
 `writer.ts`. `renderers.ts` + `display-value.ts` consumed by `index.ts`.
@@ -21,13 +21,13 @@ Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- 
 
 | File               | Lines | Purpose                                                   |
 | ------------------ | ----: | --------------------------------------------------------- |
-| `index.ts`         |   698 | OutputChannel class + factories + mode dispatch           |
-| `activity.ts`      |   568 | Spinner/progress handle classes (TTY/static/capture/noop) |
-| `contracts.ts`     |   177 | Output type contracts, mode types, option interfaces      |
-| `renderers.ts`     |   101 | Table + list rendering logic                              |
-| `display-value.ts` |    48 | Value display formatting utilities                        |
+| `index.ts`         |   814 | OutputChannel class + factories + mode dispatch           |
+| `activity.ts`      |   575 | Spinner/progress handle classes (TTY/static/capture/noop) |
+| `contracts.ts`     |   197 | Output type contracts, mode types, option interfaces      |
+| `renderers.ts`     |   125 | Table + list rendering logic                              |
 | `bind.ts`          |    59 | `bindMethods()` — binds instance methods (see GOTCHAS)    |
-| `writer.ts`        |    30 | `WriteFn` type + `writeLine` helper (leaf)                |
+| `display-value.ts` |    48 | Value display formatting utilities                        |
+| `writer.ts`        |    46 | `WriteFn` type + `writeLine` helper (leaf)                |
 
 ## OUTPUT MODES
 
@@ -65,6 +65,10 @@ Starting a new one implicitly stops the previous. All activity output routes to 
 - Spinner/progress tests use `vi.useFakeTimers()` inline with `try/finally`
 - `ActivityEvent` has 10 variants (including `progress:increment` distinct from `progress:update`)
 - Ambient `setInterval`/`clearInterval` declared in `activity.ts` (zero-dep, no `@types/node`)
+- `TableColumn.key` is caller data, so `cellValue()` in `index.ts` reads a row through
+  `Object.hasOwn()`. `formatTable()` and `projectTableRows()` both go through it. A bare
+  `row[c.key]` returns the inherited method for a column keyed `toString` or `constructor` on a row
+  that has no such key, and the text table printed `[Function: toString]` where the cell belongs.
 - **Consumer-facing value objects (`OutputChannel` + all spinner/progress handle classes) call
   `bindMethods(this)` as the last constructor statement.** This makes methods safe to destructure
   (`const { log } = out`, `const { succeed } = spinner`) or pass as detached callbacks
@@ -73,14 +77,14 @@ Starting a new one implicitly stops the previous. All activity output routes to 
   methods. The noop handle singletons are plain object literals that use no `this`, so they need no
   binding.
 
-## TEST FILES (6)
+## TEST FILES (7)
 
 | File                               | Tests | Focus                                                 |
 | ---------------------------------- | ----: | ----------------------------------------------------- |
-| `output.test.ts`                   |    56 | Core OutputChannel: log/warn/error, modes, exit codes |
+| `output.test.ts`                   |    81 | Core OutputChannel: log/warn/error, modes, exit codes |
+| `output-spinner.test.ts`           |    50 | Spinner handles: noop/static/TTY/capture, fake timers |
+| `output-progress.test.ts`          |    47 | Progress handles: noop/static/TTY/capture, fake timer |
+| `output-activity-dispatch.test.ts` |    39 | OutputChannel wiring: mode dispatch, overlap, testkit |
+| `output-table.test.ts`             |    25 | Table output in various modes                         |
 | `output-tty.test.ts`               |    20 | TTY-specific rendering, color, formatting             |
-| `output-table.test.ts`             |    16 | Table output in various modes                         |
-| `output-spinner.test.ts`           |    48 | Spinner handles: noop/static/TTY/capture, fake timers |
-| `output-progress.test.ts`          |    43 | Progress handles: noop/static/TTY/capture, fake timer |
-| `output-activity-dispatch.test.ts` |    32 | OutputChannel wiring: mode dispatch, overlap, testkit |
-| `contracts.test.ts`                |     — | Output contract verification                          |
+| `contracts.test.ts`                |    15 | Output contract verification                          |

--- a/src/core/output/AGENTS.md
+++ b/src/core/output/AGENTS.md
@@ -2,7 +2,7 @@
 
 Seven source files: `writer.ts` (leaf), `contracts.ts` (type contracts), `display-value.ts` (value
 formatting), `renderers.ts` (table/list rendering), `bind.ts` (method-binding helper), `activity.ts`
-(handle classes, ~575 lines), `index.ts` (OutputChannel + factories, ~814 lines).
+(handle classes, ~575 lines), `index.ts` (OutputChannel + factories, ~830 lines).
 
 Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- `index.ts` ->
 `writer.ts`. `renderers.ts` + `display-value.ts` consumed by `index.ts`.
@@ -21,7 +21,7 @@ Dependency graph (no cycles): `writer.ts` <- `contracts.ts` <- `activity.ts` <- 
 
 | File               | Lines | Purpose                                                   |
 | ------------------ | ----: | --------------------------------------------------------- |
-| `index.ts`         |   814 | OutputChannel class + factories + mode dispatch           |
+| `index.ts`         |   830 | OutputChannel class + factories + mode dispatch           |
 | `activity.ts`      |   575 | Spinner/progress handle classes (TTY/static/capture/noop) |
 | `contracts.ts`     |   197 | Output type contracts, mode types, option interfaces      |
 | `renderers.ts`     |   125 | Table + list rendering logic                              |
@@ -65,10 +65,13 @@ Starting a new one implicitly stops the previous. All activity output routes to 
 - Spinner/progress tests use `vi.useFakeTimers()` inline with `try/finally`
 - `ActivityEvent` has 10 variants (including `progress:increment` distinct from `progress:update`)
 - Ambient `setInterval`/`clearInterval` declared in `activity.ts` (zero-dep, no `@types/node`)
-- `TableColumn.key` is caller data, so `cellValue()` in `index.ts` reads a row through
-  `Object.hasOwn()`. `formatTable()` and `projectTableRows()` both go through it. A bare
-  `row[c.key]` returns the inherited method for a column keyed `toString` or `constructor` on a row
-  that has no such key, and the text table printed `[Function: toString]` where the cell belongs.
+- `TableColumn.key` is caller data, so `cellValue()` in `index.ts` locates the key's holder along
+  the row's prototype chain and treats `Object.prototype` as absent. `formatTable()` and
+  `projectTableRows()` both go through it. A bare `row[c.key]` returns the inherited method for a
+  column keyed `toString` or `constructor` on a row that has no such key, and the text table printed
+  `[Function: toString]` where the cell belongs. An `Object.hasOwn()` check alone is too strict.
+  Rows are arbitrary caller objects, so a class getter and an `Object.create(defaults)` fallback are
+  ordinary data and must still render.
 - **Consumer-facing value objects (`OutputChannel` + all spinner/progress handle classes) call
   `bindMethods(this)` as the last constructor statement.** This makes methods safe to destructure
   (`const { log } = out`, `const { succeed } = spinner`) or pass as detached callbacks
@@ -85,6 +88,6 @@ Starting a new one implicitly stops the previous. All activity output routes to 
 | `output-spinner.test.ts`           |    50 | Spinner handles: noop/static/TTY/capture, fake timers |
 | `output-progress.test.ts`          |    47 | Progress handles: noop/static/TTY/capture, fake timer |
 | `output-activity-dispatch.test.ts` |    39 | OutputChannel wiring: mode dispatch, overlap, testkit |
-| `output-table.test.ts`             |    25 | Table output in various modes                         |
+| `output-table.test.ts`             |    29 | Table output in various modes                         |
 | `output-tty.test.ts`               |    20 | TTY-specific rendering, color, formatting             |
 | `contracts.test.ts`                |    15 | Output contract verification                          |

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -551,6 +551,21 @@ function resolveTableArgs<T extends Record<string, unknown>>(
 }
 
 /**
+ * Read one cell out of a row.
+ *
+ * A column key such as `toString` names an `Object.prototype` member, and a
+ * bare lookup returns that inherited method from a row that carries no such
+ * key.
+ *
+ * @param row - Source data row.
+ * @param key - Column key to read.
+ * @returns The cell value, or `undefined` when the row does not carry the key.
+ */
+function cellValue<T extends Record<string, unknown>>(row: T, key: keyof T & string): unknown {
+	return Object.hasOwn(row, key) ? row[key] : undefined;
+}
+
+/**
  * Keep only the keys listed in `columns`, preserving column order.
  *
  * @param rows - Source data rows.
@@ -561,7 +576,7 @@ function projectTableRows<T extends Record<string, unknown>>(
 	rows: readonly T[],
 	columns: readonly TableColumn<T>[],
 ): Record<string, unknown>[] {
-	return rows.map((row) => Object.fromEntries(columns.map((c) => [c.key, row[c.key]])));
+	return rows.map((row) => Object.fromEntries(columns.map((c) => [c.key, cellValue(row, c.key)])));
 }
 
 /**
@@ -637,7 +652,9 @@ function formatTable<T extends Record<string, unknown>>(
 	const headers = columns.map((c) => c.header ?? c.key);
 
 	// Convert all cells to strings
-	const cellGrid: string[][] = rows.map((row) => columns.map((c) => cellToString(row[c.key])));
+	const cellGrid: string[][] = rows.map((row) =>
+		columns.map((c) => cellToString(cellValue(row, c.key))),
+	);
 
 	// Compute column widths
 	const widths: number[] = headers.map((h, i) => {

--- a/src/core/output/index.ts
+++ b/src/core/output/index.ts
@@ -551,18 +551,34 @@ function resolveTableArgs<T extends Record<string, unknown>>(
 }
 
 /**
+ * Find the object along a row's prototype chain that carries a key.
+ *
+ * @param row - Source data row.
+ * @param key - Column key to locate.
+ * @returns The owning object, or `null` when nothing in the chain carries it.
+ */
+function cellKeyHolder(row: object, key: string): object | null {
+	for (let holder: object | null = row; holder !== null; holder = Object.getPrototypeOf(holder)) {
+		if (Object.hasOwn(holder, key)) return holder;
+	}
+	return null;
+}
+
+/**
  * Read one cell out of a row.
  *
- * A column key such as `toString` names an `Object.prototype` member, and a
- * bare lookup returns that inherited method from a row that carries no such
- * key.
+ * `Object.prototype` answers a lookup for a column key such as `toString` on
+ * every row, so a key it alone carries reads as absent. A key held anywhere
+ * earlier in the chain is the row's own data, which is where a class getter or
+ * an `Object.create(defaults)` fallback lives.
  *
  * @param row - Source data row.
  * @param key - Column key to read.
- * @returns The cell value, or `undefined` when the row does not carry the key.
+ * @returns The cell value, or `undefined` when only `Object.prototype` carries the key.
  */
 function cellValue<T extends Record<string, unknown>>(row: T, key: keyof T & string): unknown {
-	return Object.hasOwn(row, key) ? row[key] : undefined;
+	const holder = cellKeyHolder(row, key);
+	return holder === null || holder === Object.prototype ? undefined : row[key];
 }
 
 /**

--- a/src/core/output/output-table.test.ts
+++ b/src/core/output/output-table.test.ts
@@ -295,6 +295,7 @@ describe('table', () => {
 
 	describe('column keys the row inherits from its own prototype', () => {
 		class Server {
+			readonly [key: string]: unknown;
 			constructor(
 				readonly host: string,
 				readonly port: number,
@@ -304,25 +305,28 @@ describe('table', () => {
 			}
 		}
 
-		const asRows = (rows: readonly Server[]): readonly Record<string, unknown>[] =>
-			rows.map((row) => row as unknown as Record<string, unknown>);
-
 		it('renders a class getter', () => {
 			const [out, captured] = createCaptureOutput();
-			out.table<Record<string, unknown>>(asRows([new Server('web-1', 80)]), [
-				{ key: 'host', header: 'Host' },
-				{ key: 'address', header: 'Address' },
-			]);
+			out.table(
+				[new Server('web-1', 80)],
+				[
+					{ key: 'host', header: 'Host' },
+					{ key: 'address', header: 'Address' },
+				],
+			);
 			const lines = captured.stdout.join('').split('\n');
 			expect(lines[2]?.trimEnd()).toBe('web-1  web-1:80');
 		});
 
 		it('keeps the class getter in the JSON projection', () => {
 			const [out, captured] = createCaptureOutput({ jsonMode: true });
-			out.table<Record<string, unknown>>(asRows([new Server('web-1', 80)]), [
-				{ key: 'host', header: 'Host' },
-				{ key: 'address', header: 'Address' },
-			]);
+			out.table(
+				[new Server('web-1', 80)],
+				[
+					{ key: 'host', header: 'Host' },
+					{ key: 'address', header: 'Address' },
+				],
+			);
 			expect(captured.stdout).toEqual(['[{"host":"web-1","address":"web-1:80"}]\n']);
 		});
 

--- a/src/core/output/output-table.test.ts
+++ b/src/core/output/output-table.test.ts
@@ -242,7 +242,7 @@ describe('table', () => {
 
 	// --- column keys naming an Object.prototype member
 
-	describe('column keys naming an Object.prototype member', () => {
+	describe('column keys — Object.prototype members', () => {
 		it('leaves the cell empty on a row that does not carry the key', () => {
 			const [out, captured] = createCaptureOutput();
 			out.table<Record<string, unknown>>(
@@ -253,7 +253,9 @@ describe('table', () => {
 					{ key: 'absent', header: 'Absent' },
 				],
 			);
-			const lines = captured.stdout.join('').split('\n');
+			const output = captured.stdout.join('');
+			expect(output.endsWith('\n')).toBe(true);
+			const lines = output.split('\n');
 			expect(lines[2]?.trimEnd()).toBe('1   own');
 			expect(lines[3]?.trimEnd()).toBe('2');
 		});
@@ -273,7 +275,9 @@ describe('table', () => {
 						{ key: name, header: 'H' },
 					],
 				);
-				const lines = captured.stdout.join('').split('\n');
+				const output = captured.stdout.join('');
+				expect(output.endsWith('\n')).toBe(true);
+				const lines = output.split('\n');
 				expect(lines[2]?.trimEnd()).toBe('1');
 			}
 		});
@@ -293,7 +297,7 @@ describe('table', () => {
 
 	// --- column keys held by the row's own prototype chain
 
-	describe('column keys the row inherits from its own prototype', () => {
+	describe('column keys — inherited from the row prototype', () => {
 		class Server {
 			readonly [key: string]: unknown;
 			constructor(
@@ -314,7 +318,9 @@ describe('table', () => {
 					{ key: 'address', header: 'Address' },
 				],
 			);
-			const lines = captured.stdout.join('').split('\n');
+			const output = captured.stdout.join('');
+			expect(output.endsWith('\n')).toBe(true);
+			const lines = output.split('\n');
 			expect(lines[2]?.trimEnd()).toBe('web-1  web-1:80');
 		});
 
@@ -342,7 +348,9 @@ describe('table', () => {
 					{ key: 'status', header: 'Status' },
 				],
 			);
-			const lines = captured.stdout.join('').split('\n');
+			const output = captured.stdout.join('');
+			expect(output.endsWith('\n')).toBe(true);
+			const lines = output.split('\n');
 			expect(lines[2]?.trimEnd()).toBe('1   pending');
 		});
 
@@ -358,7 +366,9 @@ describe('table', () => {
 					{ key: 'toString', header: 'Label' },
 				],
 			);
-			const lines = captured.stdout.join('').split('\n');
+			const output = captured.stdout.join('');
+			expect(output.endsWith('\n')).toBe(true);
+			const lines = output.split('\n');
 			expect(lines[2]?.trimEnd()).toBe('1');
 		});
 	});

--- a/src/core/output/output-table.test.ts
+++ b/src/core/output/output-table.test.ts
@@ -239,4 +239,55 @@ describe('table', () => {
 			expect(captured.stdout).toEqual(['[{"a":1}]\n']);
 		});
 	});
+
+	// --- column keys naming an Object.prototype member
+
+	describe('column keys naming an Object.prototype member', () => {
+		it('leaves the cell empty on a row that does not carry the key', () => {
+			const [out, captured] = createCaptureOutput();
+			out.table<Record<string, unknown>>(
+				[{ id: 1, toString: 'own' }, { id: 2 }],
+				[
+					{ key: 'id', header: 'ID' },
+					{ key: 'toString', header: 'Label' },
+					{ key: 'absent', header: 'Absent' },
+				],
+			);
+			const lines = captured.stdout.join('').split('\n');
+			expect(lines[2]?.trimEnd()).toBe('1   own');
+			expect(lines[3]?.trimEnd()).toBe('2');
+		});
+
+		it('renders every Object.prototype member name as an empty cell', () => {
+			const names = Object.getOwnPropertyNames(Object.prototype).filter(
+				(name) => name !== '__proto__',
+			);
+			expect(names).toHaveLength(11);
+
+			for (const name of names) {
+				const [out, captured] = createCaptureOutput();
+				out.table<Record<string, unknown>>(
+					[{ id: 1 }],
+					[
+						{ key: 'id', header: 'ID' },
+						{ key: name, header: 'H' },
+					],
+				);
+				const lines = captured.stdout.join('').split('\n');
+				expect(lines[2]?.trimEnd()).toBe('1');
+			}
+		});
+
+		it('omits the key from the JSON projection on a row that lacks it', () => {
+			const [out, captured] = createCaptureOutput({ jsonMode: true });
+			out.table<Record<string, unknown>>(
+				[{ id: 1, toString: 'own' }, { id: 2 }],
+				[
+					{ key: 'id', header: 'ID' },
+					{ key: 'toString', header: 'Label' },
+				],
+			);
+			expect(captured.stdout).toEqual(['[{"id":1,"toString":"own"},{"id":2}]\n']);
+		});
+	});
 });

--- a/src/core/output/output-table.test.ts
+++ b/src/core/output/output-table.test.ts
@@ -290,4 +290,72 @@ describe('table', () => {
 			expect(captured.stdout).toEqual(['[{"id":1,"toString":"own"},{"id":2}]\n']);
 		});
 	});
+
+	// --- column keys held by the row's own prototype chain
+
+	describe('column keys the row inherits from its own prototype', () => {
+		class Server {
+			constructor(
+				readonly host: string,
+				readonly port: number,
+			) {}
+			get address(): string {
+				return `${this.host}:${this.port}`;
+			}
+		}
+
+		const asRows = (rows: readonly Server[]): readonly Record<string, unknown>[] =>
+			rows.map((row) => row as unknown as Record<string, unknown>);
+
+		it('renders a class getter', () => {
+			const [out, captured] = createCaptureOutput();
+			out.table<Record<string, unknown>>(asRows([new Server('web-1', 80)]), [
+				{ key: 'host', header: 'Host' },
+				{ key: 'address', header: 'Address' },
+			]);
+			const lines = captured.stdout.join('').split('\n');
+			expect(lines[2]?.trimEnd()).toBe('web-1  web-1:80');
+		});
+
+		it('keeps the class getter in the JSON projection', () => {
+			const [out, captured] = createCaptureOutput({ jsonMode: true });
+			out.table<Record<string, unknown>>(asRows([new Server('web-1', 80)]), [
+				{ key: 'host', header: 'Host' },
+				{ key: 'address', header: 'Address' },
+			]);
+			expect(captured.stdout).toEqual(['[{"host":"web-1","address":"web-1:80"}]\n']);
+		});
+
+		it('renders a value inherited from an Object.create() base', () => {
+			const [out, captured] = createCaptureOutput();
+			const row: Record<string, unknown> = Object.create({ status: 'pending' });
+			row['id'] = 1;
+
+			out.table<Record<string, unknown>>(
+				[row],
+				[
+					{ key: 'id', header: 'ID' },
+					{ key: 'status', header: 'Status' },
+				],
+			);
+			const lines = captured.stdout.join('').split('\n');
+			expect(lines[2]?.trimEnd()).toBe('1   pending');
+		});
+
+		it('still blanks an Object.prototype member on such a row', () => {
+			const [out, captured] = createCaptureOutput();
+			const row: Record<string, unknown> = Object.create({ status: 'pending' });
+			row['id'] = 1;
+
+			out.table<Record<string, unknown>>(
+				[row],
+				[
+					{ key: 'id', header: 'ID' },
+					{ key: 'toString', header: 'Label' },
+				],
+			);
+			const lines = captured.stdout.join('').split('\n');
+			expect(lines[2]?.trimEnd()).toBe('1');
+		});
+	});
 });

--- a/src/core/read-flags/index.ts
+++ b/src/core/read-flags/index.ts
@@ -25,7 +25,7 @@ import {
 } from '#internals/core/parse/index.ts';
 import type { DeprecationWarning, ResolveOptions } from '#internals/core/resolve/index.ts';
 import { resolve } from '#internals/core/resolve/index.ts';
-import { createCommandSchema, validateCommandFlagTree } from '#internals/core/schema/command.ts';
+import { createCommandSchema } from '#internals/core/schema/command.ts';
 import type { FlagBuilder, FlagConfig, InferFlags } from '#internals/core/schema/flag.ts';
 import type { RuntimeAdapter } from '#internals/runtime/adapter.ts';
 import { createAdapter } from '#internals/runtime/auto.ts';
@@ -282,7 +282,6 @@ async function readFlags<const F extends FlagMap>(
 
 	const flags = Object.fromEntries(entries.map(([name, builder]) => [name, builder.schema]));
 	const schema = createCommandSchema({ name: INTERNAL_COMMAND_NAME, flags });
-	validateCommandFlagTree(schema);
 
 	const host = adapterReader(options?.adapter);
 	const argv = options?.argv ?? host().argv.slice(2);

--- a/src/core/read-flags/index.ts
+++ b/src/core/read-flags/index.ts
@@ -220,7 +220,9 @@ function withoutUndeclaredTokens(
  * @throws {CLIError} With code `'FLAG_NAME_COLLISION'` when two definitions share
  *   a name, an alias, or a negated spelling.
  * @throws {CLIError} With code `'INVALID_SCHEMA'` for the definition key
- *   `__proto__`, which JavaScript cannot carry as a plain record key.
+ *   `__proto__`, which JavaScript cannot carry as a plain record key, and for a
+ *   definitions record whose prototype is replaced, which hides the entries a
+ *   key check would read.
  *
  * @example
  * ```ts
@@ -267,6 +269,19 @@ async function readFlags<const F extends FlagMap>(
 				code: 'INVALID_SCHEMA',
 			});
 		}
+	}
+
+	// Only own enumerable keys are read.
+	const prototype: unknown = Object.getPrototypeOf(definitions);
+	if (prototype !== Object.prototype && prototype !== null) {
+		throw new CLIError(
+			"Flag definitions record has a replaced prototype. A '__proto__' key sets the prototype instead of adding a definition, and an inherited definition is never read",
+			{
+				code: 'INVALID_SCHEMA',
+				suggest:
+					"Pass a plain object with no '__proto__' key, or a record built with Object.create(null)",
+			},
+		);
 	}
 
 	const entries = Object.entries(definitions);

--- a/src/core/read-flags/read-flags.test.ts
+++ b/src/core/read-flags/read-flags.test.ts
@@ -392,6 +392,7 @@ describe('readFlags() collisions', () => {
 		expect(isParseError(error)).toBe(false);
 		expect(error).toBeInstanceOf(Error);
 		expect(error instanceof Error && error.message).toContain('collides');
+		expect(error instanceof CLIError && error.code).toBe('FLAG_NAME_COLLISION');
 	});
 
 	it('rejects an alias colliding with another canonical name', async () => {
@@ -403,6 +404,7 @@ describe('readFlags() collisions', () => {
 		);
 
 		expect(error instanceof Error && error.message).toContain('collides');
+		expect(error instanceof CLIError && error.code).toBe('FLAG_NAME_COLLISION');
 	});
 
 	it('rejects a negated spelling colliding with a canonical name', async () => {
@@ -414,6 +416,7 @@ describe('readFlags() collisions', () => {
 		);
 
 		expect(error instanceof Error && error.message).toContain('collides');
+		expect(error instanceof CLIError && error.code).toBe('FLAG_NAME_COLLISION');
 	});
 });
 
@@ -446,6 +449,35 @@ describe('readFlags() prototype keys', () => {
 		expect(nonEnumerableError instanceof CLIError && nonEnumerableError.code).toBe(
 			'INVALID_SCHEMA',
 		);
+	});
+
+	it('rejects a __proto__ definition written as an object-literal property', async () => {
+		const error = await thrownBy(() =>
+			readFlags({ __proto__: flag.string(), keep: flag.string() }, { argv: [], env: {} }),
+		);
+
+		expect(error instanceof CLIError && error.code).toBe('INVALID_SCHEMA');
+	});
+
+	it('resolves a prototype-free definitions record', async () => {
+		const definitions: Record<string, ReturnType<typeof flag.string>> = Object.create(null);
+		definitions['keep'] = flag.string();
+
+		const values = await readFlags(definitions, { argv: ['--keep', 'v'], env: {} });
+
+		expect(values['keep']).toBe('v');
+	});
+
+	it('rejects a definitions record built over another object without naming a key', async () => {
+		const base = { shared: flag.string() };
+		const definitions: Record<string, ReturnType<typeof flag.string>> = Object.create(base);
+		definitions['own'] = flag.string();
+
+		const error = await thrownBy(() => readFlags(definitions, { argv: [], env: {} }));
+
+		expect(error instanceof CLIError && error.code).toBe('INVALID_SCHEMA');
+		expect(error instanceof CLIError && error.message).toContain('replaced prototype');
+		expect(error instanceof CLIError && error.details).toBeUndefined();
 	});
 
 	it('resolves other Object.prototype key names', async () => {

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -1,6 +1,6 @@
 # resolve — Flag/arg value resolution chain
 
-Multi-file module (split from monolithic index). 9 source files, ~1933 source lines.
+Multi-file module (split from monolithic index). 9 source files, ~1948 source lines.
 
 ## RESOLUTION ORDER
 
@@ -23,7 +23,7 @@ Each source tried in order; first non-undefined wins. Missing required values wi
 | `errors.ts`    |   227 | Error aggregation + `throwAggregatedErrors()`                           |
 | `property.ts`  |   106 | Property path resolution utilities                                      |
 | `contracts.ts` |   145 | `ResolveOptions`, `CoerceResult`, `CoerceSource` types                  |
-| `standard.ts`  |   160 | Standard Schema v1 validation pass over resolved values                 |
+| `standard.ts`  |   175 | Standard Schema v1 validation pass over resolved values                 |
 
 ## KEY FUNCTIONS
 
@@ -108,3 +108,8 @@ an actionable `suggest`. This mirrors the compile-time `AllowedPromptConfig<C>` 
   reads as present. `resolveFlags()` guards `parsedFlags`, `env`, and the interactive resolver's
   override record; `resolveArgs()` guards `parsedArgs` and `env`; `resolveConfigPath()` guards every
   path segment.
+- `applyStandardValidators()` in `standard.ts` guards the resolved records for the same reason, even
+  though `index.ts` builds them. They are incomplete whenever a resolver threw: `resolve()` catches
+  the aggregated `ValidationError`, leaves `flags` or `args` at `{}`, and runs the validation pass
+  anyway before rethrowing. A bare read handed a `toString` flag's `flag.custom()` validator the
+  inherited method and added a second, invented `CONSTRAINT_VIOLATED` beside the real error.

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -97,7 +97,7 @@ an actionable `suggest`. This mirrors the compile-time `AllowedPromptConfig<C>` 
 
 ## GOTCHAS
 
-- Split from ~940-line monolithic index — `coerce.ts` (429 lines) is the largest piece
+- Split from ~940-line monolithic index — `coerce.ts` (633 lines) is the largest piece
 - `ResolveOptions` injects everything: env, config, prompter, answers — never touches `process`
 - Imports `schema/prompt.ts` directly (not through barrel) — circular dep avoidance
 - `DeprecationWarning` structs collected during resolution for deprecated flag/arg usage

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -15,7 +15,7 @@ Each source tried in order; first non-undefined wins. Missing required values wi
 
 | File           | Lines | Purpose                                                                 |
 | -------------- | ----: | ----------------------------------------------------------------------- |
-| `index.ts`     |   116 | Barrel — re-exports public API                                          |
+| `index.ts`     |   116 | `resolve()` — orchestrates the chain, then the Standard Schema pass     |
 | `flags.ts`     |   376 | `resolveFlags()` — all flags: CLI -> env -> config -> prompt -> default |
 | `args.ts`      |   144 | `resolveArgs()` — parsed -> default -> required validation              |
 | `coerce.ts`    |   633 | `coerceValue()` — unified raw value -> flag's declared kind             |

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -1,6 +1,6 @@
 # resolve — Flag/arg value resolution chain
 
-Multi-file module (split from monolithic index). 8 source files, ~1333 source lines.
+Multi-file module (split from monolithic index). 9 source files, ~1933 source lines.
 
 ## RESOLUTION ORDER
 
@@ -15,14 +15,15 @@ Each source tried in order; first non-undefined wins. Missing required values wi
 
 | File           | Lines | Purpose                                                                 |
 | -------------- | ----: | ----------------------------------------------------------------------- |
-| `index.ts`     |   108 | Barrel — re-exports public API                                          |
-| `flags.ts`     |   201 | `resolveFlags()` — all flags: CLI -> env -> config -> prompt -> default |
-| `args.ts`      |   141 | `resolveArgs()` — parsed -> default -> required validation              |
-| `coerce.ts`    |   429 | `coerceValue()` — unified raw value -> flag's declared kind             |
-| `config.ts`    |    25 | `resolveConfigPath()` — dotted path lookup in config object             |
-| `errors.ts`    |   228 | Error aggregation + `throwAggregatedErrors()`                           |
-| `property.ts`  |    87 | Property path resolution utilities                                      |
-| `contracts.ts` |   114 | `ResolveOptions`, `CoerceResult`, `CoerceSource` types                  |
+| `index.ts`     |   116 | Barrel — re-exports public API                                          |
+| `flags.ts`     |   376 | `resolveFlags()` — all flags: CLI -> env -> config -> prompt -> default |
+| `args.ts`      |   144 | `resolveArgs()` — parsed -> default -> required validation              |
+| `coerce.ts`    |   633 | `coerceValue()` — unified raw value -> flag's declared kind             |
+| `config.ts`    |    26 | `resolveConfigPath()` — dotted path lookup in config object             |
+| `errors.ts`    |   227 | Error aggregation + `throwAggregatedErrors()`                           |
+| `property.ts`  |   106 | Property path resolution utilities                                      |
+| `contracts.ts` |   145 | `ResolveOptions`, `CoerceResult`, `CoerceSource` types                  |
+| `standard.ts`  |   160 | Standard Schema v1 validation pass over resolved values                 |
 
 ## KEY FUNCTIONS
 
@@ -58,22 +59,24 @@ Returns `CoerceResult` (`{ ok: true; value } | { ok: false; error: ValidationErr
 aggregated `ValidationError` via `throwAggregatedErrors()`. Users see all validation messages at
 once.
 
-## TEST FILES (10, aspect-split)
+## TEST FILES (14, aspect-split)
 
-| File                          | Tests                                      |
-| ----------------------------- | ------------------------------------------ |
-| `resolve.test.ts`             | Core resolution logic, precedence rules    |
-| `resolve-errors.test.ts`      | Validation errors, missing required values |
-| `resolve-env.test.ts`         | Environment variable resolution + coercion |
-| `resolve-config.test.ts`      | Config file resolution + dotted paths      |
-| `resolve-prompt.test.ts`      | Prompt-based resolution                    |
-| `resolve-interactive.test.ts` | Two-pass interactive mode (full flow)      |
-| `resolve-integration.test.ts` | Cross-concern integration                  |
-| `resolve-aggregation.test.ts` | Error aggregation behavior                 |
-| `resolve-arg-env.test.ts`     | Arg environment variable resolution        |
-| `resolve-stdin.test.ts`       | Stdin-based resolution                     |
-| `contracts.test.ts`           | Contract verification                      |
-| `property.test.ts`            | Property path resolution                   |
+| File                              | Tests                                      |
+| --------------------------------- | ------------------------------------------ |
+| `resolve.test.ts`                 | Core resolution logic, precedence rules    |
+| `resolve-errors.test.ts`          | Validation errors, missing required values |
+| `resolve-env.test.ts`             | Environment variable resolution + coercion |
+| `resolve-config.test.ts`          | Config file resolution + dotted paths      |
+| `resolve-prompt.test.ts`          | Prompt-based resolution                    |
+| `resolve-interactive.test.ts`     | Two-pass interactive mode (full flow)      |
+| `resolve-integration.test.ts`     | Cross-concern integration                  |
+| `resolve-aggregation.test.ts`     | Error aggregation behavior                 |
+| `resolve-arg-env.test.ts`         | Arg environment variable resolution        |
+| `resolve-stdin.test.ts`           | Stdin-based resolution                     |
+| `resolve-path-checks.test.ts`     | `flag.path()` filesystem checks            |
+| `resolve-standard-schema.test.ts` | Standard Schema v1 validation pass         |
+| `contracts.test.ts`               | Contract verification                      |
+| `property.test.ts`                | Property path resolution                   |
 
 ## PROMPT — FLAG KIND COMPATIBILITY
 
@@ -99,3 +102,9 @@ an actionable `suggest`. This mirrors the compile-time `AllowedPromptConfig<C>` 
 - Imports `schema/prompt.ts` directly (not through barrel) — circular dep avoidance
 - `DeprecationWarning` structs collected during resolution for deprecated flag/arg usage
 - `contracts.ts` defines shared types used across all resolve files
+- Every read of a caller-supplied record keyed by a flag name, an arg name, or an env var name goes
+  through `Object.hasOwn()` first. A flag may be named `toString` or `constructor`, and an env var
+  may be too, so a bare `record[name]` returns the inherited `Object.prototype` method and the value
+  reads as present. `resolveFlags()` guards `parsedFlags`, `env`, and the interactive resolver's
+  override record; `resolveArgs()` guards `parsedArgs` and `env`; `resolveConfigPath()` guards every
+  path segment.

--- a/src/core/resolve/args.ts
+++ b/src/core/resolve/args.ts
@@ -56,7 +56,7 @@ function resolveArgs(
 		}
 
 		if (schema.envVar !== undefined) {
-			const envValue = env[schema.envVar];
+			const envValue = Object.hasOwn(env, schema.envVar) ? env[schema.envVar] : undefined;
 			if (envValue !== undefined) {
 				const coerced = coerceArgStringValue(
 					name,

--- a/src/core/resolve/flags.ts
+++ b/src/core/resolve/flags.ts
@@ -59,7 +59,7 @@ async function resolveFlags(
 		}
 
 		if (schema.envVar !== undefined) {
-			const envValue = env[schema.envVar];
+			const envValue = Object.hasOwn(env, schema.envVar) ? env[schema.envVar] : undefined;
 			if (envValue !== undefined) {
 				const coerced = coerceValue(name, { kind: 'env', envVar: schema.envVar }, envValue, schema);
 				if (coerced.ok) {
@@ -105,7 +105,12 @@ async function resolveFlags(
 			continue;
 		}
 
-		const interactiveConfig = interactiveConfigs?.[name];
+		// A flag named after an Object.prototype member would otherwise read that
+		// inherited method as an override.
+		const interactiveConfig =
+			interactiveConfigs !== undefined && Object.hasOwn(interactiveConfigs, name)
+				? interactiveConfigs[name]
+				: undefined;
 
 		let effectivePromptConfig: PromptConfig | undefined;
 		// `interactiveConfig === false` explicitly disables prompts for this flag.

--- a/src/core/resolve/resolve-arg-env.test.ts
+++ b/src/core/resolve/resolve-arg-env.test.ts
@@ -476,3 +476,27 @@ describe('resolve — arg env numeric constraints', () => {
 		}
 	});
 });
+
+// === Env lookup reads own keys only
+
+describe('resolve — arg env variable named after an Object.prototype member', () => {
+	it('treats an absent variable as absent', async () => {
+		const schema = makeSchema({
+			args: [{ name: 'target', schema: createArgSchema('string', { envVar: 'valueOf' }) }],
+		});
+
+		await expect(resolve(schema, makeParsed(), { env: {} })).rejects.toThrow(
+			'Missing required argument <target>',
+		);
+	});
+
+	it('still reads the variable when the caller sets it', async () => {
+		const schema = makeSchema({
+			args: [{ name: 'target', schema: createArgSchema('string', { envVar: 'valueOf' }) }],
+		});
+
+		const result = await resolve(schema, makeParsed(), { env: { valueOf: 'set' } });
+
+		expect(result.args).toEqual({ target: 'set' });
+	});
+});

--- a/src/core/resolve/resolve-env.test.ts
+++ b/src/core/resolve/resolve-env.test.ts
@@ -702,3 +702,27 @@ describe('resolve — env numeric constraints', () => {
 		}
 	});
 });
+
+// === Env lookup reads own keys only
+
+describe('resolve — env variable named after an Object.prototype member', () => {
+	it('treats an absent variable as absent', async () => {
+		const schema = makeSchema({
+			flags: { x: createFlagSchema('string', { envVar: 'toString', defaultValue: 'fallback' }) },
+		});
+
+		const result = await resolve(schema, makeParsed(), { env: {} });
+
+		expect(result.flags).toEqual({ x: 'fallback' });
+	});
+
+	it('still reads the variable when the caller sets it', async () => {
+		const schema = makeSchema({
+			flags: { x: createFlagSchema('string', { envVar: 'toString' }) },
+		});
+
+		const result = await resolve(schema, makeParsed(), { env: { toString: 'set' } });
+
+		expect(result.flags).toEqual({ x: 'set' });
+	});
+});

--- a/src/core/resolve/resolve-interactive.test.ts
+++ b/src/core/resolve/resolve-interactive.test.ts
@@ -495,6 +495,30 @@ describe('resolve with interactive resolver', () => {
 		expect(result.flags.e).toBe('per-flag-e');
 		expect(result.flags.f).toBe('default-f');
 	});
+
+	it('reads no override for a flag named after an Object.prototype member', async () => {
+		const schema = makeSchema({
+			flags: { toString: createFlagSchema('string', { defaultValue: 'fallback' }) },
+			interactive: () => ({}),
+		});
+
+		const prompter = createTestPrompter(['prompted']);
+		const result = await resolve(schema, makeParsed(), { prompter });
+
+		expect(result.flags['toString']).toBe('fallback');
+	});
+
+	it('still applies an override the resolver declares under such a name', async () => {
+		const schema = makeSchema({
+			flags: { valueOf: createFlagSchema('string', { defaultValue: 'fallback' }) },
+			interactive: () => ({ valueOf: { kind: 'input' as const, message: 'Value?' } }),
+		});
+
+		const prompter = createTestPrompter(['prompted']);
+		const result = await resolve(schema, makeParsed(), { prompter });
+
+		expect(result.flags['valueOf']).toBe('prompted');
+	});
 });
 
 // === Type inference

--- a/src/core/resolve/resolve-standard-schema.test.ts
+++ b/src/core/resolve/resolve-standard-schema.test.ts
@@ -169,6 +169,49 @@ describe('Standard Schema v1 interop — args', () => {
 	});
 });
 
+// === Names that an Object.prototype member also carries
+
+describe('Standard Schema v1 interop — Object.prototype member names', () => {
+	it('skips a validator on an unresolved flag named after a prototype member', async () => {
+		const cmd = command('run')
+			.flag('toString', flag.custom(asyncName))
+			.flag('needed', flag.string().required())
+			.action(({ out }) => out.log('unreachable'));
+
+		const result = await runCommand(cmd, []);
+
+		expect(result.exitCode).toBe(2);
+		expect(result.error?.code).toBe('REQUIRED_FLAG');
+		expect(result.error?.message).toBe('Missing required flag --needed');
+	});
+
+	it('skips a validator on an unresolved arg named after a prototype member', async () => {
+		const cmd = command('run')
+			.arg('needed', arg.string())
+			.arg('valueOf', arg.custom(asyncName).optional())
+			.action(({ out }) => out.log('unreachable'));
+
+		const result = await runCommand(cmd, []);
+
+		expect(result.exitCode).toBe(2);
+		expect(result.error?.code).toBe('REQUIRED_ARG');
+		expect(result.error?.message).toBe('Missing required argument <needed>');
+	});
+
+	it('still validates such a flag once a value resolves', async () => {
+		const cmd = command('run')
+			.flag('toString', flag.custom(asyncName))
+			.action(({ out }) => out.log('ok'));
+
+		const bad = await runCommand(cmd, ['--toString', 'no']);
+		expect(bad.exitCode).toBe(2);
+		expect(bad.error?.message).toContain('--toString failed validation');
+
+		const ok = await runCommand(cmd, ['--toString', 'yes']);
+		expect(ok.exitCode).toBe(0);
+	});
+});
+
 // === Type inference
 
 describe('Standard Schema v1 interop — types', () => {

--- a/src/core/resolve/standard.ts
+++ b/src/core/resolve/standard.ts
@@ -73,6 +73,21 @@ async function validateValue(
 }
 
 /**
+ * Read one resolved value by name.
+ *
+ * `resolve()` runs this pass even after a resolver threw, so the record may be
+ * missing a declared name, and a name such as `toString` reads back the
+ * inherited `Object.prototype` method from a bare lookup.
+ *
+ * @param values - Resolved flag or arg record.
+ * @param name - Flag or arg name to read.
+ * @returns The resolved value, or `undefined` when the record does not carry it.
+ */
+function resolvedValue(values: Readonly<Record<string, unknown>>, name: string): unknown {
+	return Object.hasOwn(values, name) ? values[name] : undefined;
+}
+
+/**
  * Validate resolved flag and arg values against any attached Standard Schema
  * validators. Values without a validator, or resolved to `undefined`, pass
  * through untouched.
@@ -91,7 +106,7 @@ async function applyStandardValidators(
 	const errors: ValidationError[] = [];
 	const nextFlags: Record<string, unknown> = { ...flags };
 	for (const [name, flagSchema] of Object.entries(schema.flags)) {
-		const value = flags[name];
+		const value = resolvedValue(flags, name);
 		if (value === undefined) {
 			continue;
 		}
@@ -127,7 +142,7 @@ async function applyStandardValidators(
 	const nextArgs: Record<string, unknown> = { ...args };
 	for (const entry of schema.args) {
 		const validator = entry.schema.standard;
-		const value = args[entry.name];
+		const value = resolvedValue(args, entry.name);
 		if (validator === undefined || value === undefined) {
 			continue;
 		}

--- a/src/core/schema/AGENTS.md
+++ b/src/core/schema/AGENTS.md
@@ -6,8 +6,8 @@ Multi-file module in `core/`. All others (except resolve, output, completion) us
 
 | File                    | Lines | Purpose                                                                                                       |
 | ----------------------- | ----: | ------------------------------------------------------------------------------------------------------------- |
-| `command.ts`            |  1702 | `CommandBuilder<F, A, C>` — fluent builder + `Out` interface + schema + `createCommandSchema()`               |
-| `flag.ts`               |  2101 | `FlagBuilder` — `flag.string/number/boolean/enum/array/custom/url/path/date/duration/bytes/count/keyValue()`  |
+| `command.ts`            |  1828 | `CommandBuilder<F, A, C>` — fluent builder + `Out` interface + schema + `createCommandSchema()`               |
+| `flag.ts`               |  2073 | `FlagBuilder` — `flag.string/number/boolean/enum/array/custom/url/path/date/duration/bytes/count/keyValue()`  |
 | `arg.ts`                |  1102 | `ArgBuilder` — `arg.string()`, `.number()`, `.enum()`                                                         |
 | `brand.ts`              |    19 | `schemaBrand` — type-only `unique symbol` sealing flag, arg, command, CLI, and config-settings schemas        |
 | `activity.ts`           |   240 | Activity types — `SpinnerHandle`, `ProgressHandle`, `ActivityEvent`, etc.                                     |
@@ -15,9 +15,10 @@ Multi-file module in `core/`. All others (except resolve, output, completion) us
 | `prompt.ts`             |   171 | Prompt config types — `PromptConfig` discriminated union (4 kinds)                                            |
 | `number-constraints.ts` |   153 | `NumberConstraints` + shared `validateNumberConstraints()` (parse & resolve both import it)                   |
 | `string-constraints.ts` |   147 | `StringConstraints` + shared `validateStringConstraints()` (parse & resolve both import it)                   |
-| `value-parsers.ts`      |   237 | Parse fns behind sugar factories — `parseUrlValue`, `parseDateValue`, `parseDurationValue`, `parseBytesValue` |
-| `run.ts`                |   208 | `RunOptions` / `RunResult` — execution options + structured result (re-exported by testkit)                   |
-| `index.ts`              |   152 | Barrel — re-exports all public symbols                                                                        |
+| `standard.ts`           |   143 | Vendored Standard Schema v1 types (no runtime dep) + `isStandardSchemaV1()` guard                             |
+| `value-parsers.ts`      |   243 | Parse fns behind sugar factories — `parseUrlValue`, `parseDateValue`, `parseDurationValue`, `parseBytesValue` |
+| `run.ts`                |   240 | `RunOptions` / `RunResult` — execution options + structured result (re-exported by testkit)                   |
+| `index.ts`              |   148 | Barrel — re-exports all public symbols                                                                        |
 
 ## TYPE SYSTEM PATTERNS
 
@@ -100,24 +101,53 @@ Runtime enforcement lives in `resolve/flags.ts` (`COMPATIBLE_PROMPT_KINDS` + `va
 - `Out.setExitCode(code)` is part of the public action-handler output surface. It requests a
   success-path process exit code without error output; thrown errors still own failure exits.
 - `command.ts` imports activity types from `./activity.ts` directly
-- `validateCommandFlagTree()` has exactly two call sites: `createCommandSchema()`, once over the
-  finished tree, and the builder's `.flag()` / `.command()`, incrementally. `buildCommandSchema()`
+- `validateCommandFlagTree()` has exactly three call sites: `createCommandSchema()`, once over the
+  finished tree, and the builder's `.flag()` and `.command()`, incrementally. `buildCommandSchema()`
   recurses into itself, not into `createCommandSchema()`, so a nested definition is normalized once
   and validated once. Callers downstream of a factory (`readFlags()`, `createCLISchema()`) must not
-  re-run it.
+  re-run it. It catches collisions between distinct record entries only; `.flag()` owns the
+  same-name duplicate check, since a second write to one key overwrites rather than colliding.
+- `assertUsableFlagKey()` / `assertUsableArgKey()` throw `INVALID_SCHEMA` on the name `__proto__`.
+  Assigning that key on a plain object sets the prototype instead of an entry, so the flag would
+  vanish from `CommandSchema.flags` and an arg's value would vanish from `mapPositionals()` in
+  `parse/` and `resolveArgs()` in `resolve/`. Both run on the factory path and the builder path
+  (`.flag()` directly, `.arg()` through `validateArgEntry()`), so the two agree.
+- A name check alone does not cover flags. An object literal routes a bare `__proto__` key to the
+  prototype setter, so `Object.entries()` never yields it and the flag is already gone.
+  `assertUsableFlagRecord()` reads the flag record's own prototype instead; `Object.prototype` and
+  `null` (an `Object.create(null)` record) pass, anything else throws. It raises its own error
+  rather than reusing the name error, because a replaced prototype also covers
+  `Object.create(base)`, where nothing is named `__proto__` and the inherited entries are the ones
+  that would be lost. `readFlags()` carries its own copy of both checks, worded for a definitions
+  record.
+- `buildCommandSchema()` runs `validateArgEntry()` over the accumulating arg list, so the
+  stdin/variadic invariants `.arg()` enforces also apply to a definition composed as data. It takes
+  the command name and puts it in `details` on all three errors, since a definition tree reaches
+  those throws at any depth and the arg name alone does not say which command declared it.
+- Membership tests against a flag record use `Object.hasOwn()`, never `in`. `in` walks
+  `Object.prototype`, so `.flag('constructor')` reported a collision with a flag that did not exist
+  and `collectPropagatedFlags()` in `cli/propagate.ts` treated every subcommand as overriding a
+  propagated flag named after a prototype member.
+- Reads carry the same rule, and grepping for `in` does not find them. A bare `record[flagName]` on
+  a caller-supplied record returns the inherited `Object.prototype` method for a flag named
+  `toString`, which then reads as a supplied value. `resolveFlags()` in `resolve/` guards its `env`
+  lookup and the interactive resolver's override record with `Object.hasOwn()` for that reason.
 
-## TEST FILES (11)
+## TEST FILES (14)
 
-| File                           | Tests                                                 |
-| ------------------------------ | ----------------------------------------------------- |
-| `command.test.ts`              | CommandBuilder API, schema, type inference            |
-| `schema-sealing.test.ts`       | Brand seal, spread propagation, factory normalization |
-| `flag.test.ts`                 | FlagBuilder API, kinds, validation                    |
-| `flag-array-separator.test.ts` | `.separator()` / `.unique()` parse + resolve          |
-| `flag-count-keyvalue.test.ts`  | `flag.count()` / `flag.keyValue()` end to end         |
-| `string-constraints.test.ts`   | String constraint validation + builder chaining       |
-| `value-parsers.test.ts`        | URL/date/duration/bytes parsers + sugar factories     |
-| `arg.test.ts`                  | ArgBuilder API, kinds, validation                     |
-| `middleware.test.ts`           | Middleware factory, context typing                    |
-| `prompt.test.ts`               | Prompt config types                                   |
-| `derive.test.ts`               | Type derivation tests                                 |
+| File                                | Tests                                                 |
+| ----------------------------------- | ----------------------------------------------------- |
+| `command.test.ts`                   | CommandBuilder API, schema, type inference            |
+| `schema-sealing.test.ts`            | Brand seal, spread propagation, factory normalization |
+| `flag.test.ts`                      | FlagBuilder API, kinds, validation                    |
+| `flag-array-separator.test.ts`      | `.separator()` / `.unique()` parse + resolve          |
+| `flag-count-keyvalue.test.ts`       | `flag.count()` / `flag.keyValue()` end to end         |
+| `flag-negatable-duplicates.test.ts` | `.negatable()` spellings + `.duplicates()` policy     |
+| `flag-element-eligibility.test.ts`  | `flag.array()` element eligibility, type level        |
+| `standard.test.ts`                  | Standard Schema v1 types + `isStandardSchemaV1()`     |
+| `string-constraints.test.ts`        | String constraint validation + builder chaining       |
+| `value-parsers.test.ts`             | URL/date/duration/bytes parsers + sugar factories     |
+| `arg.test.ts`                       | ArgBuilder API, kinds, validation                     |
+| `middleware.test.ts`                | Middleware factory, context typing                    |
+| `prompt.test.ts`                    | Prompt config types                                   |
+| `derive.test.ts`                    | Type derivation tests                                 |

--- a/src/core/schema/AGENTS.md
+++ b/src/core/schema/AGENTS.md
@@ -6,7 +6,7 @@ Multi-file module in `core/`. All others (except resolve, output, completion) us
 
 | File                    | Lines | Purpose                                                                                                       |
 | ----------------------- | ----: | ------------------------------------------------------------------------------------------------------------- |
-| `command.ts`            |  1751 | `CommandBuilder<F, A, C>` — fluent builder + `Out` interface + schema + `createCommandSchema()`               |
+| `command.ts`            |  1702 | `CommandBuilder<F, A, C>` — fluent builder + `Out` interface + schema + `createCommandSchema()`               |
 | `flag.ts`               |  2101 | `FlagBuilder` — `flag.string/number/boolean/enum/array/custom/url/path/date/duration/bytes/count/keyValue()`  |
 | `arg.ts`                |  1102 | `ArgBuilder` — `arg.string()`, `.number()`, `.enum()`                                                         |
 | `brand.ts`              |    19 | `schemaBrand` — type-only `unique symbol` sealing flag, arg, command, CLI, and config-settings schemas        |
@@ -100,6 +100,11 @@ Runtime enforcement lives in `resolve/flags.ts` (`COMPATIBLE_PROMPT_KINDS` + `va
 - `Out.setExitCode(code)` is part of the public action-handler output surface. It requests a
   success-path process exit code without error output; thrown errors still own failure exits.
 - `command.ts` imports activity types from `./activity.ts` directly
+- `validateCommandFlagTree()` has exactly two call sites: `createCommandSchema()`, once over the
+  finished tree, and the builder's `.flag()` / `.command()`, incrementally. `buildCommandSchema()`
+  recurses into itself, not into `createCommandSchema()`, so a nested definition is normalized once
+  and validated once. Callers downstream of a factory (`readFlags()`, `createCLISchema()`) must not
+  re-run it.
 
 ## TEST FILES (11)
 

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -9,7 +9,13 @@ import type {
 	CommandSchema,
 	ExampleMeta,
 } from './command.ts';
-import { CommandBuilder, command, group, resolveExampleCommand } from './command.ts';
+import {
+	CommandBuilder,
+	command,
+	createCommandSchema,
+	group,
+	resolveExampleCommand,
+} from './command.ts';
 import { flag } from './flag.ts';
 import { middleware } from './middleware.ts';
 
@@ -903,5 +909,124 @@ describe('command() — commands field', () => {
 	it('CommandSchema.commands is typed as readonly CommandSchema[]', () => {
 		const cmd = command('test');
 		expectTypeOf(cmd.schema.commands).toEqualTypeOf<readonly CommandSchema[]>();
+	});
+});
+
+// === createCommandSchema() flag collision validation
+
+function collisionCode(build: () => unknown): string {
+	try {
+		build();
+	} catch (error) {
+		if (error instanceof CLIError) return error.code;
+		throw error;
+	}
+
+	throw new Error('Expected createCommandSchema to throw a CLIError');
+}
+
+describe('createCommandSchema() flag collisions', () => {
+	it('rejects two flags sharing one alias on the same command', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'run',
+				flags: {
+					verbose: { kind: 'boolean', aliases: ['v'] },
+					version: { kind: 'boolean', aliases: ['v'] },
+				},
+			});
+		expect(collisionCode(build)).toBe('FLAG_NAME_COLLISION');
+	});
+
+	it('rejects an alias that spells another flag canonical name', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'run',
+				flags: {
+					force: { kind: 'boolean' },
+					frobnicate: { kind: 'boolean', aliases: ['force'] },
+				},
+			});
+		expect(collisionCode(build)).toBe('FLAG_NAME_COLLISION');
+	});
+
+	it('rejects a negated spelling that collides with another canonical name', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'build',
+				flags: {
+					sandbox: { kind: 'boolean', negation: { alias: undefined, hidden: false } },
+					'no-sandbox': { kind: 'boolean' },
+				},
+			});
+		expect(collisionCode(build)).toBe('FLAG_NAME_COLLISION');
+	});
+
+	it('rejects a collision declared inside a nested subcommand', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'db',
+				commands: [
+					{
+						name: 'migrate',
+						flags: {
+							verbose: { kind: 'boolean', aliases: ['v'] },
+							version: { kind: 'boolean', aliases: ['v'] },
+						},
+					},
+				],
+			});
+		expect(collisionCode(build)).toBe('FLAG_NAME_COLLISION');
+	});
+
+	it('rejects a child alias that collides with a propagated ancestor alias', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'db',
+				flags: { verbose: { kind: 'boolean', aliases: ['v'], propagate: true } },
+				commands: [{ name: 'migrate', flags: { version: { kind: 'boolean', aliases: ['v'] } } }],
+			});
+		expect(collisionCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
+	});
+
+	it('rejects a grandchild alias that collides with a propagated root alias', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'db',
+				flags: { verbose: { kind: 'boolean', aliases: ['v'], propagate: true } },
+				commands: [
+					{
+						name: 'migrate',
+						commands: [{ name: 'up', flags: { version: { kind: 'boolean', aliases: ['v'] } } }],
+					},
+				],
+			});
+		expect(collisionCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
+	});
+
+	it('allows a child to shadow a propagated flag by canonical name', () => {
+		expect(() =>
+			createCommandSchema({
+				name: 'db',
+				flags: { verbose: { kind: 'boolean', aliases: ['v'], propagate: true } },
+				commands: [{ name: 'migrate', flags: { verbose: { kind: 'boolean', aliases: ['v'] } } }],
+			}),
+		).not.toThrow();
+	});
+
+	it('accepts a valid tree and stays deep-equal when fed back in', () => {
+		const built = createCommandSchema({
+			name: 'db',
+			flags: { verbose: { kind: 'boolean', aliases: ['v'], propagate: true } },
+			commands: [{ name: 'migrate', flags: { force: { kind: 'boolean', aliases: ['f'] } } }],
+		});
+		expect(createCommandSchema(built)).toEqual(built);
+	});
+
+	it('accepts a builder-composed schema fed back through the factory', () => {
+		const built = command('db')
+			.flag('verbose', flag.boolean().alias('v').propagate())
+			.command(command('migrate').flag('force', flag.boolean().alias('f'))).schema;
+		expect(createCommandSchema(built)).toEqual(built);
 	});
 });

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -912,17 +912,21 @@ describe('command() — commands field', () => {
 	});
 });
 
-// === createCommandSchema() flag collision validation
+// === createCommandSchema() tree-wide validation
 
-function collisionCode(build: () => unknown): string {
+function schemaError(build: () => unknown): CLIError {
 	try {
 		build();
 	} catch (error) {
-		if (error instanceof CLIError) return error.code;
+		if (error instanceof CLIError) return error;
 		throw error;
 	}
 
 	throw new Error('Expected createCommandSchema to throw a CLIError');
+}
+
+function schemaErrorCode(build: () => unknown): string {
+	return schemaError(build).code;
 }
 
 describe('createCommandSchema() flag collisions', () => {
@@ -935,7 +939,7 @@ describe('createCommandSchema() flag collisions', () => {
 					version: { kind: 'boolean', aliases: ['v'] },
 				},
 			});
-		expect(collisionCode(build)).toBe('FLAG_NAME_COLLISION');
+		expect(schemaErrorCode(build)).toBe('FLAG_NAME_COLLISION');
 	});
 
 	it('rejects an alias that spells another flag canonical name', () => {
@@ -947,7 +951,7 @@ describe('createCommandSchema() flag collisions', () => {
 					frobnicate: { kind: 'boolean', aliases: ['force'] },
 				},
 			});
-		expect(collisionCode(build)).toBe('FLAG_NAME_COLLISION');
+		expect(schemaErrorCode(build)).toBe('FLAG_NAME_COLLISION');
 	});
 
 	it('rejects a negated spelling that collides with another canonical name', () => {
@@ -959,7 +963,7 @@ describe('createCommandSchema() flag collisions', () => {
 					'no-sandbox': { kind: 'boolean' },
 				},
 			});
-		expect(collisionCode(build)).toBe('FLAG_NAME_COLLISION');
+		expect(schemaErrorCode(build)).toBe('FLAG_NAME_COLLISION');
 	});
 
 	it('rejects a collision declared inside a nested subcommand', () => {
@@ -976,7 +980,7 @@ describe('createCommandSchema() flag collisions', () => {
 					},
 				],
 			});
-		expect(collisionCode(build)).toBe('FLAG_NAME_COLLISION');
+		expect(schemaErrorCode(build)).toBe('FLAG_NAME_COLLISION');
 	});
 
 	it('rejects a child alias that collides with a propagated ancestor alias', () => {
@@ -986,7 +990,7 @@ describe('createCommandSchema() flag collisions', () => {
 				flags: { verbose: { kind: 'boolean', aliases: ['v'], propagate: true } },
 				commands: [{ name: 'migrate', flags: { version: { kind: 'boolean', aliases: ['v'] } } }],
 			});
-		expect(collisionCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
+		expect(schemaErrorCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
 	});
 
 	it('rejects a grandchild alias that collides with a propagated root alias', () => {
@@ -1001,7 +1005,7 @@ describe('createCommandSchema() flag collisions', () => {
 					},
 				],
 			});
-		expect(collisionCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
+		expect(schemaErrorCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
 	});
 
 	it('allows a child to shadow a propagated flag by canonical name', () => {
@@ -1028,5 +1032,329 @@ describe('createCommandSchema() flag collisions', () => {
 			.flag('verbose', flag.boolean().alias('v').propagate())
 			.command(command('migrate').flag('force', flag.boolean().alias('f'))).schema;
 		expect(createCommandSchema(built)).toEqual(built);
+	});
+});
+
+describe('createCommandSchema() nested names', () => {
+	it('rejects an empty name on a direct child', () => {
+		const build = () => createCommandSchema({ name: 'db', commands: [{ name: '' }] });
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+
+	it('rejects an empty name on a grandchild', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'db',
+				commands: [{ name: 'migrate', commands: [{ name: '' }] }],
+			});
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+});
+
+describe('createCommandSchema() prototype keys', () => {
+	it('rejects a __proto__ flag key instead of dropping it', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'run',
+				flags: { ['__proto__']: { kind: 'boolean' }, keep: { kind: 'string' } },
+			});
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+
+	it('rejects a __proto__ flag key on a nested subcommand', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'db',
+				commands: [{ name: 'migrate', flags: { ['__proto__']: { kind: 'boolean' } } }],
+			});
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+
+	it('rejects a __proto__ flag key written as an object-literal property', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'run',
+				flags: { __proto__: { kind: 'boolean' }, keep: { kind: 'string' } },
+			});
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+
+	it('rejects an object-literal __proto__ flag key on a nested subcommand', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'db',
+				commands: [{ name: 'migrate', flags: { __proto__: { kind: 'boolean' } } }],
+			});
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+
+	it('accepts a prototype-free flag record', () => {
+		const flags: Record<string, { kind: 'string' }> = Object.create(null);
+		flags['keep'] = { kind: 'string' };
+		expect(Object.keys(createCommandSchema({ name: 'run', flags }).flags)).toEqual(['keep']);
+	});
+
+	it('rejects a flag record built over another object without naming a flag', () => {
+		const base = { shared: { kind: 'boolean' as const } };
+		const flags: Record<string, { kind: 'string' }> = Object.create(base);
+		flags['own'] = { kind: 'string' };
+
+		let thrown: unknown;
+		try {
+			createCommandSchema({ name: 'run', flags });
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(CLIError);
+		if (!(thrown instanceof CLIError)) return;
+		expect(thrown.code).toBe('INVALID_SCHEMA');
+		expect(thrown.message).toContain('replaced prototype');
+		expect(thrown.details).toEqual({ command: 'run' });
+	});
+
+	it('rejects a __proto__ arg name instead of swallowing the value', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'run',
+				args: [{ name: '__proto__', schema: { kind: 'string' } }],
+			});
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+
+	it('rejects a __proto__ arg name on a nested subcommand', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'db',
+				commands: [{ name: 'migrate', args: [{ name: '__proto__', schema: { kind: 'string' } }] }],
+			});
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+
+	it('keeps other Object.prototype key names as ordinary flags', () => {
+		const schema = createCommandSchema({
+			name: 'run',
+			flags: { constructor: flag.string().schema },
+		});
+		expect(Object.keys(schema.flags)).toEqual(['constructor']);
+	});
+});
+
+// === Builder / factory parity on record-hostile names
+
+describe('CommandBuilder.flag() prototype keys', () => {
+	it('accepts an Object.prototype member name as a flag', () => {
+		const built = command('run').flag('constructor', flag.string());
+		expect(Object.keys(built.schema.flags)).toEqual(['constructor']);
+	});
+
+	it('accepts every Object.prototype member name without a false collision', () => {
+		const names = Object.getOwnPropertyNames(Object.prototype).filter(
+			(name) => name !== '__proto__',
+		);
+		expect(names).toHaveLength(11);
+
+		for (const name of names) {
+			expect(Object.keys(command('run').flag(name, flag.string()).schema.flags)).toEqual([name]);
+			expect(
+				Object.keys(
+					createCommandSchema({ name: 'run', flags: { [name]: { kind: 'string' } } }).flags,
+				),
+			).toEqual([name]);
+			expect(
+				command('run')
+					.arg(name, arg.string())
+					.schema.args.map((entry) => entry.name),
+			).toEqual([name]);
+		}
+	});
+
+	it('still rejects a genuine duplicate flag name', () => {
+		const duplicate: string = 'force';
+		const build = () => command('run').flag('force', flag.boolean()).flag(duplicate, flag.string());
+		expect(schemaErrorCode(build)).toBe('FLAG_NAME_COLLISION');
+	});
+
+	it('rejects __proto__ the way the factory does', () => {
+		const build = () => command('run').flag('__proto__', flag.boolean());
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+
+	it('stays deep-equal when a prototype-named flag round-trips through the factory', () => {
+		const built = command('run')
+			.flag('constructor', flag.string())
+			.flag('toString', flag.boolean()).schema;
+		expect(createCommandSchema(built)).toEqual(built);
+	});
+});
+
+describe('CommandBuilder propagated flag collisions', () => {
+	it('rejects a subcommand whose flag collides with a propagated spelling', () => {
+		const build = () =>
+			group('db')
+				.flag('verbose', flag.boolean().alias('v').propagate())
+				.command(command('migrate').flag('version', flag.boolean().alias('v')));
+		expect(schemaErrorCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
+	});
+
+	it('rejects the same collision when the propagated flag is added last', () => {
+		const build = () =>
+			group('db')
+				.command(command('migrate').flag('version', flag.boolean().alias('v')))
+				.flag('verbose', flag.boolean().alias('v').propagate());
+		expect(schemaErrorCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
+	});
+
+	it('rejects a collision declared on a grandchild', () => {
+		const build = () =>
+			group('db')
+				.flag('verbose', flag.boolean().alias('v').propagate())
+				.command(
+					group('migrate').command(command('up').flag('version', flag.boolean().alias('v'))),
+				);
+		expect(schemaErrorCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
+	});
+
+	it('accepts a subcommand flag that shadows the propagated canonical name', () => {
+		expect(() =>
+			group('db')
+				.flag('verbose', flag.boolean().alias('v').propagate())
+				.command(command('migrate').flag('verbose', flag.boolean().alias('v'))),
+		).not.toThrow();
+	});
+});
+
+describe('CommandBuilder.arg() prototype keys', () => {
+	it('rejects __proto__ the way the factory does', () => {
+		const build = () => command('run').arg('__proto__', arg.string());
+		expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+	});
+
+	it('accepts an Object.prototype member name as an arg', () => {
+		const built = command('run').arg('constructor', arg.string());
+		expect(built.schema.args.map((entry) => entry.name)).toEqual(['constructor']);
+	});
+});
+
+// === Arg invariants shared by both construction paths
+
+describe('createCommandSchema() arg invariants', () => {
+	it('rejects one arg that is both variadic and stdin-backed', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'run',
+				args: [{ name: 'input', schema: { kind: 'string', variadic: true, stdinMode: true } }],
+			});
+		expect(schemaErrorCode(build)).toBe('INVALID_BUILDER_STATE');
+	});
+
+	it('rejects two stdin-backed args on one command', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'run',
+				args: [
+					{ name: 'first', schema: { kind: 'string', stdinMode: true } },
+					{ name: 'second', schema: { kind: 'string', stdinMode: true } },
+				],
+			});
+		expect(schemaErrorCode(build)).toBe('DUPLICATE_STDIN_ARG');
+	});
+
+	it('rejects the same pair declared on a nested subcommand', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'db',
+				commands: [
+					{
+						name: 'migrate',
+						args: [
+							{ name: 'first', schema: { kind: 'string', stdinMode: true } },
+							{ name: 'second', schema: { kind: 'string', stdinMode: true } },
+						],
+					},
+				],
+			});
+		expect(schemaErrorCode(build)).toBe('DUPLICATE_STDIN_ARG');
+	});
+
+	it('accepts a single stdin-backed arg beside ordinary ones', () => {
+		const schema = createCommandSchema({
+			name: 'run',
+			args: [
+				{ name: 'target', schema: { kind: 'string' } },
+				{ name: 'input', schema: { kind: 'string', stdinMode: true } },
+			],
+		});
+		expect(schema.args.map((entry) => entry.name)).toEqual(['target', 'input']);
+	});
+});
+
+describe('createCommandSchema() arg error details', () => {
+	it('names the command a nested duplicate stdin arg was declared on', () => {
+		const thrown = schemaError(() =>
+			createCommandSchema({
+				name: 'db',
+				commands: [
+					{
+						name: 'migrate',
+						commands: [
+							{
+								name: 'up',
+								args: [
+									{ name: 'first', schema: { kind: 'string', stdinMode: true } },
+									{ name: 'second', schema: { kind: 'string', stdinMode: true } },
+								],
+							},
+						],
+					},
+				],
+			}),
+		);
+
+		expect(thrown.code).toBe('DUPLICATE_STDIN_ARG');
+		expect(thrown.details).toEqual({ command: 'up', arg: 'second', existingArg: 'first' });
+	});
+
+	it('names the command a nested variadic stdin arg was declared on', () => {
+		const thrown = schemaError(() =>
+			createCommandSchema({
+				name: 'db',
+				commands: [
+					{
+						name: 'migrate',
+						args: [{ name: 'input', schema: { kind: 'string', stdinMode: true, variadic: true } }],
+					},
+				],
+			}),
+		);
+
+		expect(thrown.code).toBe('INVALID_BUILDER_STATE');
+		expect(thrown.details).toEqual({
+			command: 'migrate',
+			arg: 'input',
+			stdinMode: true,
+			variadic: true,
+		});
+	});
+
+	it('names the command a nested __proto__ arg was declared on', () => {
+		const thrown = schemaError(() =>
+			createCommandSchema({
+				name: 'db',
+				commands: [{ name: 'migrate', args: [{ name: '__proto__', schema: { kind: 'string' } }] }],
+			}),
+		);
+
+		expect(thrown.code).toBe('INVALID_SCHEMA');
+		expect(thrown.details).toEqual({ command: 'migrate', arg: '__proto__' });
+	});
+
+	it('names the command the builder declared the arg on', () => {
+		const thrown = schemaError(() =>
+			command('copy').arg('source', arg.string().stdin()).arg('dest', arg.string().stdin()),
+		);
+
+		expect(thrown.code).toBe('DUPLICATE_STDIN_ARG');
+		expect(thrown.details).toEqual({ command: 'copy', arg: 'dest', existingArg: 'source' });
 	});
 });

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -626,14 +626,94 @@ interface CommandDefinition {
 }
 
 /**
+ * Reject a flag name a plain record cannot carry.
+ *
+ * Assigning `__proto__` on an object literal sets the prototype instead of an
+ * entry, so both construction paths refuse the key rather than let the flag
+ * vanish.
+ *
+ * @param commandName - Command the flag was declared on, for the error details.
+ * @param name - Proposed flag name.
+ * @throws {@link CLIError} `INVALID_SCHEMA` when the name is `__proto__`.
+ *
+ * @internal
+ */
+function assertUsableFlagKey(commandName: string, name: string): void {
+	if (name !== '__proto__') return;
+
+	throw new CLIError("Flag name '__proto__' is not usable as a flag", {
+		code: 'INVALID_SCHEMA',
+		details: { command: commandName, flag: '__proto__' },
+		suggest: 'Rename the flag, for example to "proto"',
+	});
+}
+
+/**
+ * Reject a flag record whose entries a name check cannot reach.
+ *
+ * Only own enumerable keys are read. An object literal routes a bare
+ * `__proto__` key to the prototype setter, and a record built over another
+ * object hides its inherited entries, so in both cases a declared flag is
+ * already gone by the time {@link assertUsableFlagKey} sees a name. The
+ * replaced prototype is the evidence common to both. `Object.prototype` and
+ * `null` (an `Object.create(null)` record) carry no entries of their own and
+ * pass.
+ *
+ * @param commandName - Command the flags were declared on, for the error details.
+ * @param flags - Flag record as the caller supplied it.
+ * @throws {@link CLIError} `INVALID_SCHEMA` when the record's prototype is
+ *   replaced.
+ *
+ * @internal
+ */
+function assertUsableFlagRecord(commandName: string, flags: object): void {
+	const prototype: unknown = Object.getPrototypeOf(flags);
+	if (prototype === Object.prototype || prototype === null) return;
+
+	throw new CLIError(
+		`Command '${commandName}' flag record has a replaced prototype. A '__proto__' key sets the prototype instead of adding a flag, and an inherited flag is never read`,
+		{
+			code: 'INVALID_SCHEMA',
+			details: { command: commandName },
+			suggest:
+				"Pass a plain object with no '__proto__' key, or a record built with Object.create(null)",
+		},
+	);
+}
+
+/**
+ * Reject an arg name a plain record cannot carry.
+ *
+ * Resolved args reach the handler as a record keyed by arg name, and the parser
+ * accumulates positionals into one, so `__proto__` would swallow the value the
+ * user typed and hand the handler the prototype instead.
+ *
+ * @param commandName - Command the arg was declared on, for the error details.
+ * @param name - Proposed arg name.
+ * @throws {@link CLIError} `INVALID_SCHEMA` when the name is `__proto__`.
+ *
+ * @internal
+ */
+function assertUsableArgKey(commandName: string, name: string): void {
+	if (name !== '__proto__') return;
+
+	throw new CLIError(`Argument name '${name}' is not usable as an argument`, {
+		code: 'INVALID_SCHEMA',
+		details: { command: commandName, arg: name },
+		suggest: 'Rename the argument, for example to "proto"',
+	});
+}
+
+/**
  * Merge definition fields onto the {@link CommandSchema} defaults, recursively.
  *
  * @param definition - Command definition to normalize.
  * @returns A fully populated {@link CommandSchema}.
  * @throws {@link CLIError} `INVALID_SCHEMA` when a name at any depth is empty
- *   or contains whitespace.
+ *   or contains whitespace, a flag or arg is named `__proto__` at any depth,
+ *   or a flag record at any depth has a replaced prototype.
  * @throws {@link CLIError} `INVALID_BUILDER_STATE` or `DUPLICATE_STDIN_ARG` when
- *   an arg breaks the stdin invariants.
+ *   an arg breaks the stdin/variadic invariants.
  *
  * @internal
  */
@@ -646,15 +726,19 @@ function buildCommandSchema(definition: CommandDefinition): CommandSchema {
 		});
 	}
 
+	const flagDefinitions = definition.flags ?? {};
+	assertUsableFlagRecord(definition.name, flagDefinitions);
+
 	const flags: Record<string, FlagSchema> = {};
-	for (const [name, value] of Object.entries(definition.flags ?? {})) {
+	for (const [name, value] of Object.entries(flagDefinitions)) {
+		assertUsableFlagKey(definition.name, name);
 		flags[name] = createFlagSchema(value);
 	}
 
 	const args: CommandArgEntry[] = [];
 	for (const entry of definition.args ?? []) {
 		const schema = createArgSchema(entry.schema);
-		validateArgEntry(entry.name, schema, args);
+		validateArgEntry(definition.name, entry.name, schema, args);
 		args.push({ name: entry.name, schema });
 	}
 
@@ -686,14 +770,20 @@ function buildCommandSchema(definition: CommandDefinition): CommandSchema {
  *
  * Flag spellings are checked across the whole tree, so a definition whose names,
  * aliases, or negated spellings collide with each other or with a propagated
- * ancestor flag is rejected here rather than silently losing a flag at parse
- * time. This is the same check the {@link CommandBuilder} applies as flags and
+ * ancestor flag is rejected here. Both flags still parse under their canonical
+ * names, so what a collision costs is the shared spelling. Help advertises it on
+ * both flags and the parser answers it with one of them.
+ * Args go through the same invariants {@link CommandBuilder.arg} enforces.
+ * These are the checks the {@link CommandBuilder} applies as flags, args, and
  * subcommands are registered.
  *
  * @param definition - Command name plus optional flags, args, and subcommands.
  * @returns A fully populated {@link CommandSchema}.
  * @throws {CLIError} With code `'INVALID_SCHEMA'` when a name at any depth is
- *   empty or contains whitespace.
+ *   empty or contains whitespace, a flag or arg at any depth is named
+ *   `__proto__`, which JavaScript cannot carry as a plain record key, or a flag
+ *   record at any depth has a
+ *   replaced prototype, which hides the entries a name check would read.
  * @throws {CLIError} With code `'FLAG_NAME_COLLISION'` when two flags on one
  *   command share a spelling.
  * @throws {CLIError} With code `'PROPAGATED_FLAG_COLLISION'` when a flag shadows
@@ -721,20 +811,29 @@ function createCommandSchema(definition: CommandDefinition): CommandSchema {
 /**
  * Validate a new arg entry against invariants before adding it to the command.
  *
+ * @param commandName - Command the arg was declared on. A definition tree reaches
+ *   here at any depth, so every error carries it in `details`.
  * @param name - Arg name being registered.
  * @param schema - Runtime descriptor of the arg.
  * @param args - Already-registered arg entries on this command.
  *
+ * @throws {@link CLIError} `INVALID_SCHEMA` if the name is `__proto__`.
  * @throws {@link CLIError} `INVALID_BUILDER_STATE` if both `.stdin()` and `.variadic()` are set.
  * @throws {@link CLIError} `DUPLICATE_STDIN_ARG` if another arg already uses `.stdin()`.
  *
  * @internal
  */
-function validateArgEntry(name: string, schema: ArgSchema, args: readonly CommandArgEntry[]): void {
+function validateArgEntry(
+	commandName: string,
+	name: string,
+	schema: ArgSchema,
+	args: readonly CommandArgEntry[],
+): void {
+	assertUsableArgKey(commandName, name);
 	if (schema.stdinMode && schema.variadic) {
 		throw new CLIError(`Argument <${name}> cannot be both variadic and stdin-backed`, {
 			code: 'INVALID_BUILDER_STATE',
-			details: { arg: name, stdinMode: true, variadic: true },
+			details: { command: commandName, arg: name, stdinMode: true, variadic: true },
 			suggest: 'Remove .stdin() or .variadic() from this argument',
 		});
 	}
@@ -752,7 +851,7 @@ function validateArgEntry(name: string, schema: ArgSchema, args: readonly Comman
 		`Only one stdin argument is allowed; <${existing.name}> is already stdin-backed`,
 		{
 			code: 'DUPLICATE_STDIN_ARG',
-			details: { arg: name, existingArg: existing.name },
+			details: { command: commandName, arg: name, existingArg: existing.name },
 			suggest: 'Keep .stdin() on a single argument per command',
 		},
 	);
@@ -1434,12 +1533,21 @@ class CommandBuilder<
 	 * ```
 	 *
 	 * @returns The builder (for chaining).
+	 * @throws {@link CLIError} `INVALID_SCHEMA` when the name is `__proto__`,
+	 *   which a plain record cannot carry.
+	 * @throws {@link CLIError} `FLAG_NAME_COLLISION` when the command already
+	 *   declares this name, or the new flag's spellings collide with another
+	 *   flag's.
+	 * @throws {@link CLIError} `PROPAGATED_FLAG_COLLISION` when a spelling
+	 *   collides with one propagated to a registered subcommand.
 	 */
 	flag<N extends string, B extends FlagBuilder<FlagConfig>>(
 		name: N & Exclude<N, keyof F>,
 		builder: B,
 	): CommandBuilder<F & Record<N, B>, A, C> {
-		if (name in this.schema.flags) {
+		assertUsableFlagKey(this.schema.name, name);
+
+		if (Object.hasOwn(this.schema.flags, name)) {
 			throw new CLIError(`Command '${this.schema.name}' already defines flag --${name}`, {
 				code: 'FLAG_NAME_COLLISION',
 				details: { command: this.schema.name, flag: name, surface: name, surfaceKind: 'canonical' },
@@ -1499,12 +1607,18 @@ class CommandBuilder<
 	 * ```
 	 *
 	 * @returns The builder (for chaining).
+	 * @throws {@link CLIError} `INVALID_SCHEMA` when the name is `__proto__`,
+	 *   which a plain record cannot carry.
+	 * @throws {@link CLIError} `INVALID_BUILDER_STATE` when the arg is both
+	 *   variadic and stdin-backed.
+	 * @throws {@link CLIError} `DUPLICATE_STDIN_ARG` when another arg on this
+	 *   command is already stdin-backed.
 	 */
 	arg<N extends string, B extends ArgBuilder<ArgConfig>>(
 		name: N & Exclude<N, keyof A>,
 		builder: B,
 	): CommandBuilder<F, A & Record<N, B>, C> {
-		validateArgEntry(name, builder.schema, this.schema.args);
+		validateArgEntry(this.schema.name, name, builder.schema, this.schema.args);
 		const entry: CommandArgEntry = { name, schema: builder.schema };
 		const nextArgs = [...this.schema.args, entry];
 		return new CommandBuilder(
@@ -1541,6 +1655,9 @@ class CommandBuilder<
 	 *
 	 * @param sub - Child {@link CommandBuilder} to nest under this command.
 	 * @returns The builder (for chaining).
+	 * @throws {@link CLIError} `PROPAGATED_FLAG_COLLISION` when a spelling this
+	 *   command propagates collides with one the subcommand, or any of its own
+	 *   descendants, declares.
 	 */
 	command<
 		F2 extends Record<string, FlagBuilder<FlagConfig>>,

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -634,6 +634,8 @@ interface CommandDefinition {
  *   or contains whitespace.
  * @throws {@link CLIError} `INVALID_BUILDER_STATE` or `DUPLICATE_STDIN_ARG` when
  *   an arg breaks the stdin invariants.
+ *
+ * @internal
  */
 function buildCommandSchema(definition: CommandDefinition): CommandSchema {
 	if (definition.name === '' || /\s/u.test(definition.name)) {
@@ -681,6 +683,12 @@ function buildCommandSchema(definition: CommandDefinition): CommandSchema {
  *
  * Flags, args, and subcommands are normalized recursively, so an already-built
  * schema fed back in produces a deep-equal schema.
+ *
+ * Flag spellings are checked across the whole tree, so a definition whose names,
+ * aliases, or negated spellings collide with each other or with a propagated
+ * ancestor flag is rejected here rather than silently losing a flag at parse
+ * time. This is the same check the {@link CommandBuilder} applies as flags and
+ * subcommands are registered.
  *
  * @param definition - Command name plus optional flags, args, and subcommands.
  * @returns A fully populated {@link CommandSchema}.
@@ -1690,12 +1698,4 @@ export type {
 	WidenContext,
 	WidenDerivedContext,
 };
-export {
-	CommandBuilder,
-	command,
-	createCommandSchema,
-	group,
-	outBrand,
-	resolveExampleCommand,
-	validateCommandFlagTree,
-};
+export { CommandBuilder, command, createCommandSchema, group, outBrand, resolveExampleCommand };

--- a/src/core/schema/schema-sealing.test.ts
+++ b/src/core/schema/schema-sealing.test.ts
@@ -420,6 +420,43 @@ describe('schema sealing', () => {
 			expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
 		});
 
+		it('rejects a colliding flag spelling on a nested command definition', () => {
+			const build = () =>
+				createCLISchema({
+					name: 'mycli',
+					commands: [
+						{
+							name: 'db',
+							commands: [
+								{
+									name: 'migrate',
+									flags: {
+										verbose: { kind: 'boolean', aliases: ['v'] },
+										version: { kind: 'boolean', aliases: ['v'] },
+									},
+								},
+							],
+						},
+					],
+				});
+			expect(schemaErrorCode(build)).toBe('FLAG_NAME_COLLISION');
+		});
+
+		it('rejects a default command flag shadowing a propagated ancestor spelling', () => {
+			const build = () =>
+				createCLISchema({
+					name: 'mycli',
+					defaultCommand: {
+						name: 'db',
+						flags: { verbose: { kind: 'boolean', aliases: ['v'], propagate: true } },
+						commands: [
+							{ name: 'migrate', flags: { version: { kind: 'boolean', aliases: ['v'] } } },
+						],
+					},
+				});
+			expect(schemaErrorCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
+		});
+
 		it('builds identical flag schemas from the positional and object forms', () => {
 			expect(createFlagSchema('enum', { enumValues: ['us', 'eu'], description: 'Region' })).toEqual(
 				createFlagSchema({ kind: 'enum', enumValues: ['us', 'eu'], description: 'Region' }),

--- a/src/core/schema/schema-sealing.test.ts
+++ b/src/core/schema/schema-sealing.test.ts
@@ -457,6 +457,50 @@ describe('schema sealing', () => {
 			expect(schemaErrorCode(build)).toBe('PROPAGATED_FLAG_COLLISION');
 		});
 
+		it('rejects a __proto__ flag key on a command definition', () => {
+			const build = () =>
+				createCLISchema({
+					name: 'mycli',
+					commands: [{ name: 'run', flags: { ['__proto__']: { kind: 'boolean' } } }],
+				});
+			expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+		});
+
+		it('rejects an object-literal __proto__ flag key on a command definition', () => {
+			const build = () =>
+				createCLISchema({
+					name: 'mycli',
+					commands: [{ name: 'run', flags: { __proto__: { kind: 'boolean' } } }],
+				});
+			expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+		});
+
+		it('rejects a __proto__ arg name on a command definition', () => {
+			const build = () =>
+				createCLISchema({
+					name: 'mycli',
+					commands: [{ name: 'run', args: [{ name: '__proto__', schema: { kind: 'string' } }] }],
+				});
+			expect(schemaErrorCode(build)).toBe('INVALID_SCHEMA');
+		});
+
+		it('rejects two stdin-backed args on a command definition', () => {
+			const build = () =>
+				createCLISchema({
+					name: 'mycli',
+					commands: [
+						{
+							name: 'run',
+							args: [
+								{ name: 'first', schema: { kind: 'string', stdinMode: true } },
+								{ name: 'second', schema: { kind: 'string', stdinMode: true } },
+							],
+						},
+					],
+				});
+			expect(schemaErrorCode(build)).toBe('DUPLICATE_STDIN_ARG');
+		});
+
 		it('builds identical flag schemas from the positional and object forms', () => {
 			expect(createFlagSchema('enum', { enumValues: ['us', 'eu'], description: 'Region' })).toEqual(
 				createFlagSchema({ kind: 'enum', enumValues: ['us', 'eu'], description: 'Region' }),


### PR DESCRIPTION
Targets v4. Stacked on #110. Top of the stack. This layer is the review-to-fixpoint pass over the reviewer findings from #108-#110: fourteen fresh-eyes adversarial rounds, each with fix authority, run until functional findings dried up.

**Hardening (breaking where marked)**
- **Breaking:** `createCommandSchema()` now validates what the builder validates: flag-form collisions (names, aliases, negated spellings, propagated shadows) and the arg invariants (variadic+stdin, duplicate stdin, `__proto__` names) throw at the factory boundary at any depth, with the owning command in every error's `details`. `readFlags()` drops its compensating call.
- **Breaking:** flag records with a replaced prototype (an object-literal `__proto__` key, or a record built over another object) throw `INVALID_SCHEMA` with a dedicated message; `Object.create(null)` stays legal.
- The `.run()`-time discovered-version `RESERVED_FLAG` renders through the standard startup-error path (stderr + suggestion + exit code, JSON envelope under `--json`) instead of escaping as an unhandled rejection.
- Root help's `Global options:` block derives from `BUILTIN_NAMES`, which is exhaustiveness-pinned against the `BuiltinName` union at compile time, so a future built-in cannot skip the guard or the help block.

**The prototype-chain bug family, found and fixed across the rounds**
- `.flag('constructor')` and every other `Object.prototype` member name was falsely rejected as a duplicate (`in` on the flag record); propagated flags with such names were silently dropped (`in` in propagate); `.interactive()` handed such flags the inherited method as a prompt config; unset env vars with such names resolved to inherited methods instead of falling through; stdin-backed args with such names never triggered a stdin read in `.run()` (reachable on 3.x); the Standard Schema pass ran validators against inherited methods after a failed resolution; `out.table()` rendered `[Function: toString]` for absent cells, and the first fix for that over-blanked class getters until narrowed to reject only keys held by `Object.prototype` itself.
- Each fix carries a regression test proven to fail against the pre-fix code by mutation; every remaining caller-keyable bracket read in `src` was read and triaged.

**Docs made true**
- The upgrade guide and changelog now state the real 3.x failure modes (a shared spelling answered by the later flag, not a lost flag), the builder-path breaks, and both render routes for the startup failure; limitations.md and semantics.md negated-boolean claims corrected (semantics.md's advice was inverted: `--no-confirm` as an alias set `confirm=true`) and locked by docs-contract tests; AGENTS module maps reconciled with `wc -l` and `ls` throughout.

Rounds 16-17 found zero functional defects (one banned cast in a round-15 test, two AGENTS map rows), which is the convergence signal this layer ran to. Gates green per commit: typecheck, lint, fmt, full suite (3196 → 3273 tests), build with attw+publint, docs build.
