### PR TITLE
v4 parser occurrences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ src/
 │   ├── output/             # stdout/stderr/json/table/activity dispatch
 │   ├── completion/         # shell completion generators
 │   ├── json-schema/        # definition schema + input schema generation
-│   ├── parse/              # tokenizer + schema-aware raw parse
+│   ├── parse/              # tokenizer, schema-aware raw parse, occurrence model
 │   ├── prompt/             # terminal/test prompt engines
 │   ├── config/             # config discovery + package.json walk-up
 │   ├── help/               # schema-driven help formatter
@@ -44,23 +44,23 @@ specs/                      # planning/design docs
 
 ## WHERE TO LOOK
 
-| Task                                          | Location                        | Notes                                      |
-| --------------------------------------------- | ------------------------------- | ------------------------------------------ |
-| Add command, flag, arg, or middleware API     | `src/core/schema/`              | most public API work starts here           |
-| Fix argv parsing                              | `src/core/parse/`               | tokenizer + parser live in one file        |
-| Fix resolution precedence                     | `src/core/resolve/`             | argv -> env -> config -> prompt -> default |
-| Change help text formatting                   | `src/core/help/`                | width-aware text formatter                 |
-| Change config discovery or `manifest()`       | `src/core/config/`              | config loaders + package metadata walk-up  |
-| Change prompt UX or test prompts              | `src/core/prompt/`              | prompt engines and sentinels               |
-| Change JSON Schema output                     | `src/core/json-schema/`         | definition schema + input schema           |
-| Change output, spinner, or progress           | `src/core/output/`              | stdout/stderr and activity handles         |
-| Change shell completions                      | `src/core/completion/`          | per-shell generators                       |
-| Change CLI dispatch or plugins                | `src/core/cli/`                 | root help, dispatch, runtime preflight     |
-| Change runtime adapters                       | `src/runtime/`                  | Node, Bun, Deno, detect, support           |
-| Change docs data, routes, or site build       | `docs/.vitepress/`              | docs app internals                         |
-| Edit guide/concept prose                      | `docs/guide/`, `docs/concepts/` | hand-authored Markdown                     |
-| Change build, release, or project automation  | `scripts/`                      | operational scripts                        |
-| Change example-backed docs or consumer canary | `examples/`                     | docs source + `examples/gh` workspace      |
+| Task                                          | Location                        | Notes                                        |
+| --------------------------------------------- | ------------------------------- | -------------------------------------------- |
+| Add command, flag, arg, or middleware API     | `src/core/schema/`              | most public API work starts here             |
+| Fix argv parsing                              | `src/core/parse/`               | tokenizer + parser, and the occurrence model |
+| Fix resolution precedence                     | `src/core/resolve/`             | argv -> env -> config -> prompt -> default   |
+| Change help text formatting                   | `src/core/help/`                | width-aware text formatter                   |
+| Change config discovery or `manifest()`       | `src/core/config/`              | config loaders + package metadata walk-up    |
+| Change prompt UX or test prompts              | `src/core/prompt/`              | prompt engines and sentinels                 |
+| Change JSON Schema output                     | `src/core/json-schema/`         | definition schema + input schema             |
+| Change output, spinner, or progress           | `src/core/output/`              | stdout/stderr and activity handles           |
+| Change shell completions                      | `src/core/completion/`          | per-shell generators                         |
+| Change CLI dispatch or plugins                | `src/core/cli/`                 | root help, dispatch, runtime preflight       |
+| Change runtime adapters                       | `src/runtime/`                  | Node, Bun, Deno, detect, support             |
+| Change docs data, routes, or site build       | `docs/.vitepress/`              | docs app internals                           |
+| Edit guide/concept prose                      | `docs/guide/`, `docs/concepts/` | hand-authored Markdown                       |
+| Change build, release, or project automation  | `scripts/`                      | operational scripts                          |
+| Change example-backed docs or consumer canary | `examples/`                     | docs source + `examples/gh` workspace        |
 
 ## CONVENTIONS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   counts an empty tail as an absent input, which is what makes
   `printf 'x\ny\n' | mycli build` reach the fallback stage under `.run()`.
 
-- **`.stdin({ trim: true })` drops the terminator a pipe appends.** A `string`
-  input keeps the buffer byte for byte by default, which is the right answer for
-  message bodies and the wrong one for paths. `trim` drops one trailing `\n`,
-  `\r\n`, or `\r` from a single value before anything decodes or checks it, so
+- **`.stdin({ trim: true })` drops the terminator a pipe appends.** Codecs that
+  preserve text terminators, including `string` and `path`, keep the buffer byte
+  for byte by default. `trim` drops one trailing `\n`, `\r\n`, or `\r` from a
+  single value before anything decodes or checks it, so
   `echo ./dist | mycli clean` satisfies `arg.path({ mustExist: true })`. It
   applies to both surfaces, to an explicit `-` and to the implicit fallback, and
-  to `readFlags()` and `runCommand()`. A `string` is the one kind that still
-  carries the terminator at that point; every other kind already drops it while
-  decoding and is unaffected, so no value ever loses two. A collection's
+  to `readFlags()` and `runCommand()`. Other decoding codecs already remove one
+  framing terminator and are unaffected, so no value ever loses two. A collection's
   terminators separate its elements, so `.split({ stdin })` still decides those.
   The binding serializes as `stdin.trim` in definition documents, alongside
   `when` and `consume`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **A variadic argument reads stdin from its tail.** `.stdin()` and
+  `.variadic()` now compose. A `-` among the tail tokens stands for the whole
+  stdin source at that position, so
+  `printf 'x\ny\n' | mycli build a - b` collects `['a', 'x', 'y', 'b']`, and an
+  empty tail under a binding that covers a missing input takes the whole buffer.
+  `arg.keyValue().variadic().stdin()` aggregates entries across the typed tokens
+  and the pipe under its `.duplicateKeys()` policy. Each `-` stands for all of
+  the buffer, so two of them splice it twice, and the stream is still read at
+  most once per invocation. The preflight that decides whether to read stdin
+  counts an empty tail as an absent input, which is what makes
+  `printf 'x\ny\n' | mycli build` reach the fallback stage under `.run()`.
+
+- **`.stdin({ trim: true })` drops the terminator a pipe appends.** A `string`
+  input keeps the buffer byte for byte by default, which is the right answer for
+  message bodies and the wrong one for paths. `trim` drops one trailing `\n`,
+  `\r\n`, or `\r` from a single value before anything decodes or checks it, so
+  `echo ./dist | mycli clean` satisfies `arg.path({ mustExist: true })`. It
+  applies to both surfaces, to an explicit `-` and to the implicit fallback, and
+  to `readFlags()` and `runCommand()`. A `string` is the one kind that still
+  carries the terminator at that point; every other kind already drops it while
+  decoding and is unaffected, so no value ever loses two. A collection's
+  terminators separate its elements, so `.split({ stdin })` still decides those.
+  The binding serializes as `stdin.trim` in definition documents, alongside
+  `when` and `consume`.
+
 - **Stability policy and a 4.0 upgrade guide** — the
   [stability page](https://dreamcli.kjanat.dev/reference/stability) now places
   every export of the root, `/testkit`, `/runtime`, and `/version` entrypoints
@@ -301,6 +326,46 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Breaking: a positional declared after a variadic one is a build error.** A
+  variadic argument consumes every remaining positional, so anything registered
+  behind it could never be filled and a second variadic one had nothing left to
+  collect. Both silently produced an argument that stayed empty. `.arg()` and
+  `createCommandSchema()` now throw `INVALID_BUILDER_STATE`
+  (`Argument <target> comes after variadic argument <files>, which consumes
+  every remaining positional`), with the command under `command`, the offending
+  argument under `arg`, and the greedy one under `variadicArg`, so a definition
+  tree names the nested command that declared the pair. Move the variadic
+  argument last.
+
+- **Breaking: an explicit `-` with nothing piped is an error inside a
+  collection.** `--tag a --tag - --tag b` with an empty pipe used to resolve to
+  `['a', 'b']`, dropping the occurrence the user typed. It now fails with
+  `REQUIRED_FLAG` / `REQUIRED_ARG` and the message
+  `No piped stdin for the '-' occurrence of flag --tag`. Occurrences of nothing
+  but `-` are unchanged: they are the whole value, so they still fall through to
+  env, config, prompt, and the default, exactly as an absent input does, and the
+  implicit `when: 'missing'` fallback that simply does not fire stays silent. A
+  scalar `-` falls through for the same reason. Only a collection could be
+  silently shortened, so only a collection errors.
+
+- **Breaking: the arg collection modifiers require a collection.**
+  `createArgSchema('string', { unique: true })` and its siblings used to build,
+  storing a field nothing would read. They now state their requirement to the
+  compiler and throw `INVALID_SCHEMA` from `createArgSchema()`: `separator` and
+  `split` want a variadic argument or `arg.keyValue()`, `unique` a variadic
+  argument of a list kind, and `duplicateKeys` `arg.keyValue()`. The values a
+  schema already stores as its own default, `unique: false` and
+  `duplicateKeys: 'last'`, stay accepted on any kind, so a built `ArgSchema` fed
+  back through the factory round-trips. This mirrors the `array | keyValue`
+  restriction the flag surface already had. Drop the field, or add
+  `variadic: true` alongside it. The matching builder methods are new in 4.0, so
+  only definitions composed as data change.
+
+- **Breaking: `.stdin()` and `.variadic()` on one argument is now legal.** The
+  pairing threw `INVALID_BUILDER_STATE`; the tail-splicing entry under Added
+  describes what it does instead. Code that relied on the throw has nothing to
+  catch.
+
 - **Breaking: declared defaults are validated.** A `.default()` value is
   already the typed value, so it is validated rather than decoded: the codec's
   own domain, string and number constraints, element and aggregate Standard
@@ -413,12 +478,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   composed as data used to build without complaint and then answer the shared
   spelling with one flag only. Two flags both aliased `v` still parsed under
   `--verbose` and `--version`, help listed `-v` on both, and `-v` set the
-  second. The arg invariants moved with them, so a definition declaring one arg
-  both variadic and stdin-backed throws `INVALID_BUILDER_STATE`, and a second
+  second. The arg invariants moved with them, so a definition declaring a
+  positional after a variadic one throws `INVALID_BUILDER_STATE`, and a second
   stdin-backed input throws `DUPLICATE_STDIN_INPUT`, matching `.arg()`. Those two
   built without complaint as well. Two stdin-backed args each resolved to the
-  whole of stdin, and a variadic stdin-backed arg read nothing from stdin and
-  failed as missing when argv supplied no positional. Every arg error names the
+  whole of stdin, and a positional behind a variadic one silently never filled. Every arg error names the
   command in `details`, since a definition tree reaches them at any depth and
   the arg name alone does not say which command declared it. A flag or arg
   named `__proto__` now throws `INVALID_SCHEMA` from both the factory and the
@@ -547,6 +611,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   already defaults to `['package.json']`.
 
 ### Fixed
+
+- **A duplicate key the user typed said it came from stdin.** Under
+  `.duplicateKeys('error')`, a repeat among CLI occurrences was worded
+  `Duplicate key 'A' from stdin for flag --v`, naming a source the value never
+  had, on a command with no pipe at all. CLI occurrences now name no source
+  (`Duplicate key 'A' for flag --v`), and a key a `-` occurrence spliced in
+  still reads `from stdin`. Each occurrence carries its own source through
+  aggregation, so a collection filled from both names whichever one carried the
+  repeat. `details` no longer claims `source: 'stdin'` for a typed token, and
+  the arg surface follows the same rule with `for argument <vars>`.
+
+- **`flag.count().stdin()` threw only on the definition path.** The builder
+  method is blocked by its `this` constraint at compile time and
+  `createFlagSchema('count', { stdin: {} })` throws `INVALID_SCHEMA`, but a
+  JavaScript caller reaching the builder got a count flag carrying a stdin
+  binding no stage would ever read. The builder now throws the same error, with
+  the same message and code. In 3.x neither path complained: `createSchema()`
+  stored `stdinMode: true` on a count flag and `.stdin()` did not exist on the
+  count builder at all.
 
 - **Flags named after `Object.prototype` members were rejected as duplicates** —
   `.flag('constructor')`, `.flag('toString')`, `.flag('valueOf')`, and every

--- a/docs/.vitepress/data/meta-schema-descriptions.ts
+++ b/docs/.vitepress/data/meta-schema-descriptions.ts
@@ -97,6 +97,7 @@ const DEF_PROPERTY_TARGETS: Readonly<Record<string, Readonly<Record<string, Node
 	stdin: {
 		when: { exportId: 'dreamcli:StdinBinding', property: 'when' },
 		consume: { exportId: 'dreamcli:StdinBinding', property: 'consume' },
+		trim: { exportId: 'dreamcli:StdinBinding', property: 'trim' },
 	},
 	negation: {
 		alias: { exportId: 'dreamcli:FlagNegation', property: 'alias' },

--- a/docs/concepts/input.md
+++ b/docs/concepts/input.md
@@ -103,6 +103,28 @@ curl -s https://api.example.com/data | jq '.items[]' | sort | head -5
 
 Four programs, connected by pipes, each doing one thing well.
 
+A pipe carries bytes, not slots, so a program that accepts several values needs
+a way to say *which* one the pipe fills. The convention is a bare `-`, and it
+holds the position the piped data takes:
+
+```bash
+mycli send --tag before --tag - --tag after
+```
+
+The `-` sits between two ordinary values, and what the pipe carried lands
+exactly there. The same token works in a positional slot. A program that reads
+one value can skip the `-` entirely and let an omitted slot mean the pipe.
+
+The cost of the convention is that a program reading the stream can no longer
+take a literal `-` as data, since the token is read as the source first.
+
+One more thing a pipe does that a command line does not: it appends a line
+terminator. `echo ./docs` sends `./docs\n`, not `./docs`. For a number or a
+date that terminator is framing and gets dropped, but for a string the text
+*is* the value, so the newline is part of it unless the program asks for it to
+be trimmed. This is the single most common surprise when a piped path fails a
+check that the same path typed by hand passes.
+
 ## Interactive Prompts
 
 Sometimes a CLI asks you questions:

--- a/docs/concepts/input.md
+++ b/docs/concepts/input.md
@@ -115,8 +115,10 @@ The `-` sits between two ordinary values, and what the pipe carried lands
 exactly there. The same token works in a positional slot. A program that reads
 one value can skip the `-` entirely and let an omitted slot mean the pipe.
 
-The cost of the convention is that a program reading the stream can no longer
-take a literal `-` as data, since the token is read as the source first.
+The cost of a dash-consuming stdin binding is that it can no longer take a
+literal `-` as data, since the token is read as the source first. A binding with
+`{ when: 'missing' }` is the exception: it reads only an omitted input and leaves
+a typed `-` literal.
 
 One more thing a pipe does that a command line does not: it appends a line
 terminator. `echo ./docs` sends `./docs\n`, not `./docs`. For a number or a

--- a/docs/guide/arguments.md
+++ b/docs/guide/arguments.md
@@ -602,11 +602,11 @@ too, but keeps CLI precedence: the bytes come from the pipe and every later
 stage stays out of the way. When nothing was piped, both forms fall through to
 env, config, prompt, and the default.
 
-The whole buffer becomes the value. A string argument keeps it byte for byte, so
-`echo hi | mycli` gives `'hi\n'`; every other scalar kind drops the single line
-terminator a pipe appends before decoding, so `echo 30s` reaches
-`arg.duration()` as `30s`. `arg.keyValue()` decodes the buffer into entries, one
-`KEY=VALUE` per line by default.
+The whole buffer becomes the value. Codecs that preserve text terminators keep
+it byte for byte, so `echo hi | mycli` gives a string argument `'hi\n'` and a
+path keeps the terminator too. Other codecs remove one framing terminator before
+decoding, so `echo 30s` reaches `arg.duration()` as `30s`. `arg.keyValue()`
+decodes the buffer into entries, one `KEY=VALUE` per line by default.
 
 `{ trim: true }` drops that terminator for a string argument too, which is what
 a piped path wants:
@@ -638,8 +638,8 @@ arg.string().stdin({ trim: true }); // drops one trailing terminator
 ```
 
 Stdin is read at most once per invocation, and only when one of these bindings
-would actually fire. A `when: 'dash'` argument the user never dashes never
-touches the stream.
+would actually fire. If the user does not provide `-`, a `when: 'dash'`
+argument does not read the stream.
 
 ### The positional tail {#stdin-tail}
 

--- a/docs/guide/arguments.md
+++ b/docs/guide/arguments.md
@@ -123,8 +123,8 @@ Reach for one of these before `arg.custom()` with a hand-written parser.
 
 All five compose with `.optional()`, `.default()`, `.variadic()`, `.stdin()`,
 `.env()`, `.config()`, `.prompt()`, `.describe()`, and `.deprecated()`, under
-the same rules as any other argument, so `.variadic()` and `.stdin()` still
-cannot be combined. A variadic one validates each collected value separately.
+the same rules as any other argument. A variadic one validates each collected
+value separately.
 
 ### URL
 
@@ -175,8 +175,8 @@ Path './docs
 ' for argument <p> does not exist
 ```
 
-Use `printf './docs'` when piping a path, or strip the terminator before the
-pipe.
+`.stdin({ trim: true })` drops that terminator, so `echo ./docs | mycli` reaches
+the check as `'./docs'`. `printf './docs'` works too.
 
 Failures carry `CONSTRAINT_VIOLATED` and name the argument:
 
@@ -282,15 +282,19 @@ is read as a native object.
 Entry values are strings on the arg surface. `flag.keyValue()` takes an element
 builder for per-value codecs and checks; its positional counterpart does not.
 
-A non-variadic key-value argument can read stdin, where the whole buffer decodes
-into entries:
+A key-value argument can read stdin, where the whole buffer decodes into
+entries, and its variadic form splices the buffer into the tail it collects:
 
 ```ts
 arg.keyValue().stdin();
+arg.keyValue().variadic().stdin();
 ```
 
 ```bash
 $ printf 'A=1\nB=2\n' | mycli run -
+# args.vars === { A: '1', B: '2' }
+
+$ printf 'B=2\n' | mycli run A=1 -
 # args.vars === { A: '1', B: '2' }
 ```
 
@@ -338,13 +342,32 @@ arg.string().variadic().split({ cli: ',', env: 'json' });
 // FILES='["a","b"]'   →  ['a', 'b']
 ```
 
-`.separator()`, `.split()`, and `.unique()` are collection modifiers. On an
-argument that aggregates nothing, such as `arg.string()` without `.variadic()`,
-they are accepted and stored but change nothing. `.duplicateKeys()` is available
-only on `arg.keyValue()`.
+These four modifiers are collection modifiers, so they are available on an
+argument that aggregates. Each states the shape it needs. `.separator()` and
+`.split()` want a variadic argument or `arg.keyValue()`. `.unique()`
+deduplicates a list, so it wants a variadic argument of a list kind, and a
+key-value argument folds repeated keys through `.duplicateKeys()` instead, which
+in turn wants `arg.keyValue()`. The compiler refuses each one elsewhere, and the
+definition path throws `INVALID_SCHEMA` at build time:
 
-A variadic argument cannot also read stdin. `arg.keyValue()` can, in its
-non-variadic form.
+```ts
+arg.string().separator(','); // INVALID_SCHEMA
+createArgSchema('string', { unique: true }); // INVALID_SCHEMA
+createArgSchema('keyValue', { variadic: true, unique: true }); // INVALID_SCHEMA
+```
+
+```
+Arg schema field 'separator' requires a collection, received a non-variadic 'string' arg
+Suggestion: Add 'variadic: true', declare the arg as kind 'keyValue', or drop 'separator'
+```
+
+The values a schema already stores as its own default, `unique: false` and
+`duplicateKeys: 'last'`, are exempt on the definition path, so feeding a built
+`ArgSchema` back through `createArgSchema()` round-trips. Only the compiler
+rejects `.duplicateKeys('last')` on a string argument.
+
+A variadic argument reads stdin like any other, and
+[the positional tail](#stdin-tail) describes what a `-` among its tokens does.
 
 ### Standard Schema on a collection argument
 
@@ -421,7 +444,9 @@ requiredVsOptional.optional;
 
 ## Variadic Arguments
 
-The last argument can be variadic, collecting all remaining positional values:
+The last argument can be variadic, collecting all remaining positional values.
+It takes every remaining token, so it has to be the last one a command declares:
+another positional after it, variadic or not, throws `INVALID_BUILDER_STATE`.
 
 ```ts twoslash
 import { arg, command } from '@kjanat/dreamcli';
@@ -441,6 +466,25 @@ command('copy')
 $ mycli copy a.txt b.txt c.txt
 # args.files = ['a.txt', 'b.txt', 'c.txt']
 ```
+
+Anything registered behind a variadic argument could never be filled, so both
+construction paths refuse it:
+
+```ts
+command('copy').arg('files', arg.string().variadic()).arg('target', arg.string());
+```
+
+```
+Argument <target> comes after variadic argument <files>, which consumes every remaining positional
+Suggestion: Declare <target> before <files>, or drop .variadic() from <files>
+```
+
+A second variadic argument is the same error, since the first one leaves it
+nothing to collect. `details` carries the command in `command`, the argument
+that could never fill in `arg`, and the greedy one in `variadicArg`, so a
+definition tree names the nested command that declared the pair. Every earlier
+ordering still builds: required then optional then variadic, a lone variadic, a
+scalar followed by a `arg.keyValue().variadic()` tail.
 
 ## Environment-Backed Arguments
 
@@ -564,9 +608,24 @@ terminator a pipe appends before decoding, so `echo 30s` reaches
 `arg.duration()` as `30s`. `arg.keyValue()` decodes the buffer into entries, one
 `KEY=VALUE` per line by default.
 
+`{ trim: true }` drops that terminator for a string argument too, which is what
+a piped path wants:
+
+```ts
+arg.path({ mustExist: true }).stdin({ trim: true });
+```
+
+```bash
+$ echo ./dist | mycli clean
+# args.path === './dist', and the check runs against './dist'
+```
+
+Trimming applies to a single value. A collection's terminators separate its
+elements, so `.split({ stdin })` decides them and `trim` has nothing to do.
+
 ### Choosing when stdin is read
 
-`.stdin()` takes `{ when, consume }`:
+`.stdin()` takes `{ when, consume, trim }`:
 
 ```ts twoslash
 import { arg } from '@kjanat/dreamcli';
@@ -575,11 +634,74 @@ arg.string().stdin(); // '-' or an omitted slot reads stdin
 arg.string().stdin({ when: 'dash' }); // only an explicit '-'
 arg.string().stdin({ when: 'missing' }); // only an omitted slot; '-' stays literal
 arg.string().stdin({ consume: 'broadcast' }); // shares the buffer with other inputs
+arg.string().stdin({ trim: true }); // drops one trailing terminator
 ```
 
 Stdin is read at most once per invocation, and only when one of these bindings
 would actually fire. A `when: 'dash'` argument the user never dashes never
 touches the stream.
+
+### The positional tail {#stdin-tail}
+
+A variadic argument reads stdin too. A `-` among its tokens splices what the
+buffer decodes to into that position, and an empty tail under a binding that
+covers a missing input takes the whole buffer:
+
+```ts
+command('build').arg('files', arg.string().variadic().stdin());
+```
+
+```bash
+$ printf 'x\ny\n' | mycli build a - b
+# args.files === ['a', 'x', 'y', 'b']
+
+$ printf 'x\ny\n' | mycli build
+# args.files === ['x', 'y']
+```
+
+Each `-` stands for the whole source, so two of them splice the buffer twice and
+`mycli build - -` over `'x\n'` collects `['x', 'x']`. That is the same rule the
+flag surface follows for `--tag - --tag -`.
+
+`.split({ stdin })` decodes the tail, so a piped JSON array works the same way a
+piped list of lines does:
+
+```ts
+command('build').arg('files', arg.string().variadic().stdin().split({ stdin: 'json' }));
+```
+
+```bash
+$ echo '["p","q"]' | mycli build a - b
+# args.files === ['a', 'p', 'q', 'b']
+```
+
+A key-value tail aggregates the typed tokens and the pipe together, then folds
+repeated keys under `.duplicateKeys()`:
+
+```bash
+$ printf 'M=5\n' | mycli run A=1 - Z=9
+# args.vars === { A: '1', M: '5', Z: '9' }
+```
+
+Only a binding that covers a missing input reads an empty tail. Under
+`{ when: 'dash' }` an empty tail never selects stdin, so the stream stays
+untouched and a required argument reports itself missing.
+
+A `-` typed beside other tokens with nothing piped fails, because dropping it
+would silently shorten the tail:
+
+```
+No piped stdin for the '-' occurrence of argument <files>
+Suggestion: Pipe a value to stdin, or drop the '-' from <files>
+```
+
+A tail of nothing but `-` is the whole value, so with nothing piped it falls
+through to env, config, prompt, and the default, exactly as an omitted slot
+does.
+
+A stdin-enabled input cannot receive a literal `-` as its value: the token names
+the source before anything reads it as text. Pass the value another way, or use
+`{ when: 'missing' }`, which leaves `-` as the literal string.
 
 ### Worked Transcripts
 
@@ -659,16 +781,21 @@ command('convert')
 // echo shared | mycli convert → flags.body === 'shared\n', args.input === 'shared\n'
 ```
 
-Stdin-backed arguments cannot also be variadic. Declaring both throws
-`INVALID_BUILDER_STATE` when the argument is registered on a command:
+A variadic argument consumes every remaining positional, so it is the last one a
+command can declare. Registering another positional after it, variadic or not,
+throws `INVALID_BUILDER_STATE` on both construction paths:
+
+```ts
+command('copy').arg('files', arg.string().variadic()).arg('target', arg.string());
+```
 
 ```
-Argument <files> cannot be both variadic and stdin-backed
-Suggestion: Remove .stdin() or .variadic() from this argument
+Argument <target> comes after variadic argument <files>, which consumes every remaining positional
+Suggestion: Declare <target> before <files>, or drop .variadic() from <files>
 ```
 
-`arg.keyValue()` aggregates without `.variadic()`, so its non-variadic form
-reads a whole record from the stream.
+`details` carries the offending argument under `arg` and the greedy one under
+`variadicArg`.
 
 If stdin is absent, resolution falls through to the later stages and then to
 required versus optional behavior, so use `.optional()` when missing piped input

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -339,7 +339,8 @@ Under `'error'`, the message names the key and the source that carried it:
 `Duplicate key 'A' from env VARS for flag --env` for the environment, and
 `Duplicate key 'A' for flag --v` for occurrences the user typed, which name no
 source. A key spliced in from a pipe reads `from stdin`. A JSON object cannot
-repeat a key, so the policy has nothing to decide for `.split({ env: 'json' })`.
+preserve repeated member names through decoding, so `.duplicateKeys()` cannot
+reliably detect them for `.split({ env: 'json' })`.
 
 ### Custom
 
@@ -767,10 +768,10 @@ the default. A scalar `-` is the whole value, so dropping it loses nothing. That
 is where a scalar and a collection part: `--tag a --tag -` with nothing piped
 fails, because dropping the occurrence would shorten the list.
 
-The whole buffer becomes the value. A string flag keeps it byte for byte, so
-`echo hi | mycli` gives `'hi\n'`; every other kind drops the single line
-terminator a pipe appends before decoding, so `echo true` reaches
-`flag.boolean()` as `true`.
+The whole buffer becomes the value. Codecs that preserve text terminators keep
+it byte for byte, so `echo hi | mycli` gives a string flag `'hi\n'` and a path
+keeps the terminator too. Decoding codecs remove one framing terminator first,
+so `echo true` reaches `flag.boolean()` as `true`.
 
 `{ trim: true }` drops that terminator for a string flag too, so
 `echo ./dist | mycli clean --path -` reaches a `mustExist` check as `'./dist'`.
@@ -792,8 +793,8 @@ flag.string().stdin({ trim: true }); // drops one trailing terminator
 ```
 
 Stdin is read at most once per invocation, and only when one of these bindings
-would actually fire. A `when: 'dash'` flag the user never dashes never touches
-the stream.
+would actually fire. If the user does not provide `-`, a `when: 'dash'` flag
+does not read the stream.
 
 ### Worked Transcripts
 

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -267,7 +267,16 @@ $ printf 'a\nb\n' | mycli send --tag - --tag z
 $ mycli send --tag -
 # nothing piped: the flag produces no CLI value and env, config, prompt,
 # and the default stay reachable, so an undeclared source leaves []
+
+$ mycli send --tag a --tag -
+# nothing piped beside a typed occurrence:
+# No piped stdin for the '-' occurrence of flag --tag
 ```
+
+A `-` the user typed beside other occurrences fails when nothing was piped,
+rather than shortening the collection behind their back. Occurrences of nothing
+but `-` are the whole value, so they fall through to the later sources the way
+an absent flag does.
 
 A flag that declares no stdin binding treats `-` as an ordinary element, and the
 stream is never read:
@@ -280,7 +289,12 @@ $ printf 'piped' | mycli send --tag - --tag x   # flag.array(flag.string())
 An explicit `-` and the implicit fallback decode identically. A spliced read is
 CLI-sourced, so it still outranks env, config, prompt, and the default. Two `-`
 occurrences splice the buffer twice, since the whole buffer is what each one
-stands for.
+stands for: `--tag - --tag -` over `'a\n'` resolves to `['a', 'a']`.
+
+A stdin-enabled input never receives a literal `-` as a value, on either
+surface. The token names the source before anything reads it as text, so a
+program that must accept `-` as data either drops the binding or declares
+`{ when: 'missing' }`, which leaves `-` literal.
 
 Broadcast consumers each decode the one shared buffer under their own binding,
 so a line-split array flag and a JSON key-value flag can read the same pipe:
@@ -321,9 +335,11 @@ flag.keyValue().duplicateKeys('first').alias('e').env('VARS');
 // VARS='A=1,A=2'     →  { A: '1' }
 ```
 
-Under `'error'`, the message names the key and the source that carried it, as in
-`Duplicate key 'A' from env VARS for flag --env`. A JSON object cannot repeat a
-key, so the policy has nothing to decide for `.split({ env: 'json' })`.
+Under `'error'`, the message names the key and the source that carried it:
+`Duplicate key 'A' from env VARS for flag --env` for the environment, and
+`Duplicate key 'A' for flag --v` for occurrences the user typed, which name no
+source. A key spliced in from a pipe reads `from stdin`. A JSON object cannot
+repeat a key, so the policy has nothing to decide for `.split({ env: 'json' })`.
 
 ### Custom
 
@@ -379,9 +395,10 @@ In process-free execution (`.execute()` / `runCommand()`), pass a `stat`
 function via run options to enable the checks (plus `mkdir` for `create`);
 without them the checks are skipped and nothing is created.
 
-`flag.path()` trims one trailing line terminator from a value read from stdin,
-so `echo ./docs | mycli` reaches a `mustExist` check as `'./docs'`. A free-form
-`flag.string()` still preserves the stdin buffer byte for byte.
+`flag.path()` resolves as a `string`, so a value read from stdin keeps the
+buffer byte for byte, trailing line terminator included. `echo ./docs | mycli`
+reaches a `mustExist` check as `'./docs\n'` and fails. `.stdin({ trim: true })`
+drops that terminator, and `printf './docs'` works too.
 
 ### Date
 
@@ -720,10 +737,10 @@ Resolution order:
 
 `.stdin()` lets a flag read its value from piped stdin. It is available on every
 kind but `count`, which counts occurrences rather than reading a value:
-`flag.count().stdin()` does not compile, and the equivalent definition object
-throws `INVALID_SCHEMA`. A scalar takes the whole buffer; a collection decodes
-it into elements, one per line by default, and splices them where a `-`
-occurrence sits, which [Collections](#collections) covers in full.
+`flag.count().stdin()` does not compile, and both the builder and the equivalent
+definition object throw `INVALID_SCHEMA`. A scalar takes the whole buffer; a
+collection decodes it into elements, one per line by default, and splices them
+where a `-` occurrence sits, which [Collections](#collections) covers in full.
 
 ```ts twoslash
 import { command, flag } from '@kjanat/dreamcli';
@@ -746,16 +763,23 @@ The stdin stage sits ahead of env, so a flag set in the environment still reads 
 pipe and the pipe wins. Passing the sentinel `-` selects stdin too, but keeps CLI
 precedence: the bytes come from the pipe and every later stage stays out of the
 way. When nothing was piped, both forms fall through to env, config, prompt, and
-the default.
+the default. A scalar `-` is the whole value, so dropping it loses nothing. That
+is where a scalar and a collection part: `--tag a --tag -` with nothing piped
+fails, because dropping the occurrence would shorten the list.
 
 The whole buffer becomes the value. A string flag keeps it byte for byte, so
 `echo hi | mycli` gives `'hi\n'`; every other kind drops the single line
 terminator a pipe appends before decoding, so `echo true` reaches
 `flag.boolean()` as `true`.
 
+`{ trim: true }` drops that terminator for a string flag too, so
+`echo ./dist | mycli clean --path -` reaches a `mustExist` check as `'./dist'`.
+It applies to a single value; a collection's terminators separate its elements
+and `.split({ stdin })` decides them.
+
 ### Choosing when stdin is read
 
-`.stdin()` takes `{ when, consume }`:
+`.stdin()` takes `{ when, consume, trim }`:
 
 ```ts twoslash
 import { flag } from '@kjanat/dreamcli';
@@ -764,6 +788,7 @@ flag.string().stdin(); // '-' or an absent flag reads stdin
 flag.string().stdin({ when: 'dash' }); // only an explicit '-'
 flag.string().stdin({ when: 'missing' }); // only an absent flag; '-' stays literal
 flag.string().stdin({ consume: 'broadcast' }); // shares the buffer with other inputs
+flag.string().stdin({ trim: true }); // drops one trailing terminator
 ```
 
 Stdin is read at most once per invocation, and only when one of these bindings
@@ -865,6 +890,19 @@ command('convert')
   .flag('body', flag.string().stdin({ consume: 'broadcast' }))
   .arg('input', arg.string().stdin({ consume: 'broadcast' }));
 // echo shared | mycli convert → flags.body === 'shared\n', args.input === 'shared\n'
+```
+
+`flag.count()` is the one kind that cannot read stdin, since it counts
+occurrences rather than reading a value. The builder method is refused by the
+compiler, and both it and the definition object throw the same error:
+
+```ts
+createFlagSchema('count', { stdin: {} });
+```
+
+```
+Flag schema field 'stdin' is not available on kind 'count'
+Suggestion: Drop 'stdin' or declare the flag as one of: string, number, boolean, enum, custom, array, keyValue
 ```
 
 ## Required vs Optional

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -291,10 +291,10 @@ CLI-sourced, so it still outranks env, config, prompt, and the default. Two `-`
 occurrences splice the buffer twice, since the whole buffer is what each one
 stands for: `--tag - --tag -` over `'a\n'` resolves to `['a', 'a']`.
 
-A stdin-enabled input never receives a literal `-` as a value, on either
-surface. The token names the source before anything reads it as text, so a
-program that must accept `-` as data either drops the binding or declares
-`{ when: 'missing' }`, which leaves `-` literal.
+A binding where `-` selects stdin never receives that token as a literal value,
+on either surface. The token names the source before anything reads it as text.
+A binding with `{ when: 'missing' }` remains stdin-enabled but leaves `-`
+literal.
 
 Broadcast consumers each decode the one shared buffer under their own binding,
 so a line-split array flag and a JSON key-value flag can read the same pipe:

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -766,7 +766,7 @@ precedence: the bytes come from the pipe and every later stage stays out of the
 way. When nothing was piped, both forms fall through to env, config, prompt, and
 the default. A scalar `-` is the whole value, so dropping it loses nothing. That
 is where a scalar and a collection part: `--tag a --tag -` with nothing piped
-fails, because dropping the occurrence would shorten the list.
+fails because dropping the occurrence would shorten the list.
 
 The whole buffer becomes the value. Codecs that preserve text terminators keep
 it byte for byte, so `echo hi | mycli` gives a string flag `'hi\n'` and a path

--- a/docs/guide/read-flags.md
+++ b/docs/guide/read-flags.md
@@ -109,6 +109,34 @@ only through the adapter, and only when a declared binding would fire, so a
 record whose `when: 'dash'` flag was never dashed never touches it. Pass
 `stdinData` to supply the bytes yourself, including `null` for nothing piped.
 
+`{ trim: true }` drops one trailing `\n`, `\r\n`, or `\r` from a single value
+here too:
+
+```ts twoslash
+import { flag, readFlags } from '@kjanat/dreamcli';
+// ---cut---
+const values = await readFlags(
+  { p: flag.string().stdin({ trim: true }) },
+  { argv: [], stdinData: 'hello\n' },
+);
+
+values.p; // 'hello'
+```
+
+A `-` occurrence the caller passed beside other occurrences rejects when
+`stdinData` is `null`, with the same `REQUIRED_FLAG` a command raises:
+
+```ts
+await readFlags(
+  { tag: flag.array(flag.string()).stdin() },
+  { argv: ['--tag', 'a', '--tag', '-'], stdinData: null },
+);
+// throws: No piped stdin for the '-' occurrence of flag --tag
+```
+
+Occurrences of nothing but `-` fall through instead, so `stdinData: null` with
+`argv: ['--tag', '-']` leaves the flag to env, config, prompt, and the default.
+
 Two stages need something from the caller. `config` is a plain object passed in;
 nothing is read from disk. `prompter` is a prompt engine passed in; none is
 built. A `.prompt()` flag with no prompter falls through to its default, on a

--- a/docs/guide/semantics.md
+++ b/docs/guide/semantics.md
@@ -133,10 +133,29 @@ and accepts `\n`, `\r\n`, and `\r`: `'a\nb\n'` gives `['a', 'b']` and
   `{ A: 'b=c' }`. A segment with no `=`, or an empty key, fails: `INVALID_VALUE`
   on a CLI token, `TYPE_MISMATCH` from every other source.
 - Entries fold under `.duplicateKeys()`: `'last'` (the default), `'first'`, or
-  `'error'`, which reports `CONSTRAINT_VIOLATED` naming the key. The policy
-  applies to every source, not only to repeated CLI occurrences.
+  `'error'`, which reports `CONSTRAINT_VIOLATED` naming the key and the source
+  that carried it. The policy applies to every source, not only to repeated CLI
+  occurrences.
 - A count reads an explicit value (`--verbose=2`, env, config) as the count
   itself, and must be a non-negative integer.
+
+Under `'error'`, each occurrence keeps its own source through aggregation, so a
+collection filled from both the command line and a pipe names whichever one
+carried the repeat. Tokens the user typed name no source:
+
+```bash
+$ mycli set --v A=1 --v A=2
+Duplicate key 'A' for flag --v
+
+$ printf 'A=2\n' | mycli set --v A=1 --v -
+Duplicate key 'A' from stdin for flag --v
+
+$ VARS='A=1,A=2' mycli set
+Duplicate key 'A' from env VARS for flag --env
+```
+
+The argument surface words it the same way, with `for argument <vars>` in place
+of `for flag --v`.
 
 ## Resolution Precedence
 
@@ -213,8 +232,9 @@ Outcomes:
 
 ### Stdin
 
-An input reads stdin only when it declares `.stdin()`. The binding has two
-axes, `when` and `consume`, defaulting to `dash-or-missing` and `exclusive`.
+An input reads stdin only when it declares `.stdin()`. The binding has three
+axes, `when`, `consume`, and `trim`, defaulting to `dash-or-missing`,
+`exclusive`, and `false`.
 
 | `when`              | `-` typed            | Input omitted        |
 | ------------------- | -------------------- | -------------------- |
@@ -226,7 +246,8 @@ A `-` that selects stdin resolves on the `cli` stage, so it outranks every later
 source. An omitted input reads stdin only for `when: 'missing'` or
 `when: 'dash-or-missing'`. With `when: 'dash'`, omission falls through to env,
 config, prompt, and default. When nothing is piped, every stdin form produces no
-value and the walk continues.
+value and the walk continues, except for a `-` typed beside other occurrences of
+a collection, which fails instead.
 
 The stream is read at most once per invocation, and only when a declared binding
 would fire. Declaring a second exclusive stdin input on one command, flag or
@@ -235,17 +256,22 @@ command that passes `{ consume: 'broadcast' }` receives the same buffer.
 
 For a scalar input, the whole buffer becomes the value. A `string` input keeps
 it byte for byte; every other scalar kind drops one trailing `\n`, `\r\n`, or
-`\r` before decoding, and then accepts exactly what an env value accepts. There
-is no option for this: the rule follows the codec, because a `string` is the one
-kind whose value is the text itself.
+`\r` before decoding, and then accepts exactly what an env value accepts. The
+rule follows the codec, because a `string` is the one kind whose value is the
+text itself. `{ trim: true }` drops that one terminator for a `string` too, and
+is what a piped path wants before a `mustExist` check runs.
 
 For a collection, the buffer decodes into elements under the input's stdin
 policy, `'lines'` by default. A `-` occurrence stands for the whole stdin source
-at the position it holds, and the decoded elements are spliced in there:
+at the position it holds, and the decoded elements are spliced in there. A
+variadic argument reads its tail the same way:
 
 ```bash
 $ printf 'a\nb\n' | mycli send --tag before --tag - --tag after
 # flags.tag === ['before', 'a', 'b', 'after']
+
+$ printf 'a\nb\n' | mycli build x - y
+# args.files === ['x', 'a', 'b', 'y']
 ```
 
 Splicing rules:
@@ -255,11 +281,21 @@ Splicing rules:
 - Entries splice into the same occurrence order and then fold under
   `.duplicateKeys()`, so a piped key can be overridden by a later CLI one.
 - Two `-` occurrences splice the buffer twice. The buffer is read once and each
-  occurrence stands for all of it.
+  occurrence stands for all of it, so `--tag - --tag -` over `'a\n'` resolves to
+  `['a', 'a']` and `mycli build - -` over `'x\n'` to `['x', 'x']`.
 - When every occurrence is `-` and nothing was piped, the input produces no CLI
   value, so env, config, prompt, and the default stay reachable.
+- A `-` typed beside other occurrences with nothing piped fails with
+  `REQUIRED_FLAG` or `REQUIRED_ARG`, rather than dropping the occurrence and
+  silently shortening the collection.
+- A scalar `-` with nothing piped falls through instead. It is the whole value,
+  so dropping it loses nothing, and env, config, prompt, and the default stay
+  reachable. Only a collection can be shortened, so only a collection errors.
 - An input that declares no stdin binding treats `-` as an ordinary element and
-  never reads the stream.
+  never reads the stream. An input that does declare one can never receive a
+  literal `-` as a value, on either surface: the token names the source before
+  anything reads it as text. `{ when: 'missing' }` is the one binding that
+  leaves a typed `-` literal.
 
 ## Non-Interactive Behavior
 

--- a/docs/guide/semantics.md
+++ b/docs/guide/semantics.md
@@ -254,12 +254,12 @@ would fire. Declaring a second exclusive stdin input on one command, flag or
 argument, throws `DUPLICATE_STDIN_INPUT` at build time; every stdin input on a
 command that passes `{ consume: 'broadcast' }` receives the same buffer.
 
-For a scalar input, the whole buffer becomes the value. A `string` input keeps
-it byte for byte; every other scalar kind drops one trailing `\n`, `\r\n`, or
-`\r` before decoding, and then accepts exactly what an env value accepts. The
-rule follows the codec, because a `string` is the one kind whose value is the
-text itself. `{ trim: true }` drops that one terminator for a `string` too, and
-is what a piped path wants before a `mustExist` check runs.
+For a scalar input, the whole buffer becomes the value. Codecs that preserve
+text terminators keep it byte for byte; this includes strings and paths. Other
+codecs drop one trailing `\n`, `\r\n`, or `\r` before decoding, then accept
+exactly what an env value accepts. `{ trim: true }` drops that one terminator
+for a preserving codec and is what a piped path wants before a `mustExist`
+check runs.
 
 For a collection, the buffer decodes into elements under the input's stdin
 policy, `'lines'` by default. A `-` occurrence stands for the whole stdin source
@@ -290,7 +290,7 @@ Splicing rules:
   silently shortening the collection.
 - A scalar `-` with nothing piped falls through instead. It is the whole value,
   so dropping it loses nothing, and env, config, prompt, and the default stay
-  reachable. Only a collection can be shortened, so only a collection errors.
+  reachable. Only a collection can be shortened, so only a collection can error.
 - An input that declares no stdin binding treats `-` as an ordinary element and
   never reads the stream. An input that does declare one can never receive a
   literal `-` as a value, on either surface: the token names the source before

--- a/docs/guide/semantics.md
+++ b/docs/guide/semantics.md
@@ -245,9 +245,10 @@ axes, `when`, `consume`, and `trim`, defaulting to `dash-or-missing`,
 A `-` that selects stdin resolves on the `cli` stage, so it outranks every later
 source. An omitted input reads stdin only for `when: 'missing'` or
 `when: 'dash-or-missing'`. With `when: 'dash'`, omission falls through to env,
-config, prompt, and default. When nothing is piped, every stdin form produces no
-value and the walk continues, except for a `-` typed beside other occurrences of
-a collection, which fails instead.
+config, prompt, and default. When a selected stdin route has no piped data, it
+produces no value and the walk continues, except for a `-` typed beside other
+occurrences of a collection, which fails instead. With `when: 'missing'`, a
+typed `-` is literal and does not select stdin.
 
 The stream is read at most once per invocation, and only when a declared binding
 would fire. Declaring a second exclusive stdin input on one command, flag or

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -224,18 +224,19 @@ Fix:
 References: [Collections](/guide/flags#collections),
 [CLI Semantics](/guide/semantics#stdin)
 
-## A Stdin Input Will Not Accept `-` As A Value
+## A `-` Stdin Selector Is Not A Literal Value
 
 Symptom:
 
-- an input that reads stdin can never hold the one-character string `-`; the
-  token reads the stream, or fails because nothing was piped.
+- an input whose binding treats `-` as a stdin selector cannot hold the
+  one-character string `-`; the token reads the stream, or fails because nothing
+  was piped.
 
 Cause:
 
-- the token names the source before anything reads it as text, so on a
-  stdin-enabled input `-` is never data. This holds on both surfaces and for
-  both the scalar and the collection shapes.
+- with `when: 'dash'` or `when: 'dash-or-missing'`, the token names the source
+  before anything reads it as text, so `-` is not data. With `when: 'missing'`,
+  a typed `-` remains a literal value.
 
 Check:
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -106,24 +106,41 @@ Symptom:
 
 Cause:
 
-- there is no trim option. A `string` input keeps the stdin buffer byte for byte
-  because the text *is* the value, and truncating it would discard data the
-  caller may have meant.
-- every other scalar kind, including `path`, interprets the text and drops one
-  trailing `\n`, `\r\n`, or `\r` before decoding. `echo ./docs` reaches
-  `flag.path()` as `./docs`, and `echo 42` reaches `flag.number()` as `42`.
+- a `string` input keeps the stdin buffer byte for byte by default, because for
+  a string the text *is* the value, and truncating it would discard data the
+  caller may have meant. `flag.path()` and `arg.path()` resolve as strings, so
+  they keep it too.
+- every other scalar kind interprets the text rather than keeping it, so it
+  drops one trailing `\n`, `\r\n`, or `\r` before decoding. `echo 42` reaches
+  `flag.number()` as `42`, and `echo 30s` reaches `flag.duration()` as `30s`.
 
 Check:
 
-- the input's kind. Only `string` keeps the terminator.
+- whether the binding passed `{ trim: true }`;
+- the input's kind. Only `string` and the path kinds carry the terminator this
+  far, so `trim` changes nothing on the others.
 - whether the producer appends a newline. `echo` does; `printf` without `\n`
   does not.
 
 Fix:
 
-- emit the string without a terminator, for example `printf '%s' 'value' | mycli`;
+- declare `.stdin({ trim: true })`, which drops one trailing `\n`, `\r\n`, or
+  `\r` from a single value before any check runs;
+- or emit the value without a terminator, for example `printf '%s' './docs' | mycli`;
 - or declare the input as a collection, where line splitting treats a final
   terminator as framing and drops it.
+
+```ts
+arg.path({ mustExist: true }).stdin({ trim: true });
+```
+
+```bash
+$ echo ./docs | mycli check
+# the mustExist check runs against './docs'
+```
+
+`trim` applies to a single value. A collection's terminators separate its
+elements, so `.split({ stdin })` decides those and `trim` has nothing to do.
 
 References: [CLI Semantics](/guide/semantics), [Flags](/guide/flags#path),
 [Arguments](/guide/arguments#path)
@@ -132,8 +149,8 @@ References: [CLI Semantics](/guide/semantics), [Flags](/guide/flags#path),
 
 Symptom:
 
-- a `-` occurrence on an array or key-value input produces nothing, or produces
-  more elements than the pipe carried;
+- a `-` occurrence on an array, key-value, or variadic input produces nothing,
+  or produces more elements than the pipe carried;
 - the pipe's elements land in the wrong position in the resolved list.
 
 Cause:
@@ -164,6 +181,156 @@ Fix:
 
 References: [Collections](/guide/flags#collections),
 [CLI Semantics](/guide/semantics)
+
+## A `-` Occurrence Fails With Nothing Piped
+
+Symptom:
+
+- a command that mixes typed values with a `-` exits 2 before the action runs:
+
+```
+No piped stdin for the '-' occurrence of flag --tag
+Suggestion: Pipe a value to stdin, or drop the '-' occurrence of --tag
+```
+
+```
+No piped stdin for the '-' occurrence of argument <files>
+Suggestion: Pipe a value to stdin, or drop the '-' from <files>
+```
+
+Cause:
+
+- a `-` among other occurrences is one element of the collection, and nothing
+  was piped for it to stand for. Resolution fails with `REQUIRED_FLAG` or
+  `REQUIRED_ARG` rather than shortening the collection behind the caller's back.
+- occurrences of nothing but `-` behave differently: they are the whole value,
+  so with nothing piped they fall through to env, config, prompt, and the
+  default, the way an absent input does.
+- a scalar `-` behaves that way too. It is the whole value, so dropping it
+  loses nothing and resolution falls through.
+
+Check:
+
+- whether the producer feeding the pipe actually wrote anything;
+- whether the invocation is a shell that opened no pipe at all;
+- whether the typed occurrences beside the `-` were meant to be there.
+
+Fix:
+
+- pipe a value to stdin;
+- or drop the `-` and let the remaining occurrences stand alone;
+- or declare `{ when: 'missing' }`, which leaves a typed `-` as the literal
+  string and reads the stream only when the input is absent.
+
+References: [Collections](/guide/flags#collections),
+[CLI Semantics](/guide/semantics#stdin)
+
+## A Stdin Input Will Not Accept `-` As A Value
+
+Symptom:
+
+- an input that reads stdin can never hold the one-character string `-`; the
+  token reads the stream, or fails because nothing was piped.
+
+Cause:
+
+- the token names the source before anything reads it as text, so on a
+  stdin-enabled input `-` is never data. This holds on both surfaces and for
+  both the scalar and the collection shapes.
+
+Check:
+
+- whether the value the caller wants really is a bare `-`, rather than a path
+  or a name that begins with one;
+- which `when` the binding declares.
+
+Fix:
+
+- declare `{ when: 'missing' }`, which reads the stream only for an absent
+  input and leaves a typed `-` literal;
+- or drop `.stdin()` from that input and read the stream on a different one;
+- or pass the value through `.env()`, `.config()`, or a config file.
+
+There is no escape syntax for a stdin-enabled input. `--` ends flag parsing, so
+it does not make a following `-` literal either.
+
+References: [Flags](/guide/flags#stdin-backed-flags),
+[Arguments](/guide/arguments#stdin-backed-arguments),
+[CLI Semantics](/guide/semantics#stdin)
+
+## An Argument Declared After A Variadic One Throws
+
+Symptom:
+
+- building the command throws before any argv is read:
+
+```
+Argument <target> comes after variadic argument <files>, which consumes every remaining positional
+Suggestion: Declare <target> before <files>, or drop .variadic() from <files>
+```
+
+Cause:
+
+- a variadic argument takes every remaining positional token, so anything
+  registered behind it could never be filled, and a second variadic one would
+  have nothing left to collect.
+
+Check:
+
+- the order of the `.arg()` calls, or of the `args` entries in a definition;
+- `details`, which carries the command in `command`, the argument that could
+  never fill in `arg`, and the greedy one in `variadicArg`.
+
+Fix:
+
+- move the variadic argument last;
+- or drop `.variadic()` from the earlier one.
+
+The code is `INVALID_BUILDER_STATE` on both construction paths, and a definition
+tree reports the nested command that declared the pair.
+
+References: [Variadic Arguments](/guide/arguments#variadic-arguments),
+[Upgrading to 4.0](/guide/upgrading-v4)
+
+## A Collection Modifier Throws On An Argument
+
+Symptom:
+
+- `.separator()`, `.split()`, `.unique()`, or `.duplicateKeys()` is refused by
+  the compiler, or a definition throws `INVALID_SCHEMA`:
+
+```
+Arg schema field 'separator' requires a collection, received a non-variadic 'string' arg
+Suggestion: Add 'variadic: true', declare the arg as kind 'keyValue', or drop 'separator'
+```
+
+```
+Arg schema field 'unique' requires a variadic arg of a list kind
+Suggestion: Add 'variadic: true' on a list kind, or drop 'unique'
+```
+
+Cause:
+
+- these four are collection modifiers, and an argument that aggregates nothing
+  has no elements to split, dedupe, or fold. Each states the shape it needs:
+  `.separator()` and `.split()` want a variadic argument or `arg.keyValue()`,
+  `.unique()` a variadic argument of a list kind, and `.duplicateKeys()`
+  `arg.keyValue()`.
+
+Check:
+
+- whether `.variadic()` sits ahead of the modifier in the chain;
+- for `.unique()`, that the kind is a list rather than `arg.keyValue()`, which
+  folds repeated keys through `.duplicateKeys()` instead.
+
+Fix:
+
+- add `.variadic()` before the modifier;
+- or declare the argument as `arg.keyValue()`;
+- or drop the call, which changed nothing on a single-value argument anyway.
+
+References: [Collections](/guide/arguments#collections),
+[Upgrading to 4.0](/guide/upgrading-v4)
 
 ## Two Inputs Both Want Stdin
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -106,19 +106,18 @@ Symptom:
 
 Cause:
 
-- a `string` input keeps the stdin buffer byte for byte by default, because for
-  a string the text *is* the value, and truncating it would discard data the
-  caller may have meant. `flag.path()` and `arg.path()` resolve as strings, so
-  they keep it too.
-- every other scalar kind interprets the text rather than keeping it, so it
-  drops one trailing `\n`, `\r\n`, or `\r` before decoding. `echo 42` reaches
-  `flag.number()` as `42`, and `echo 30s` reaches `flag.duration()` as `30s`.
+- codecs that preserve text terminators keep the stdin buffer byte for byte by
+  default. This includes strings and paths, so `flag.path()` and `arg.path()`
+  keep the terminator unless `{ trim: true }` is set.
+- other codecs interpret the text and drop one trailing `\n`, `\r\n`, or `\r`
+  before decoding. `echo 42` reaches `flag.number()` as `42`, and `echo 30s`
+  reaches `flag.duration()` as `30s`.
 
 Check:
 
 - whether the binding passed `{ trim: true }`;
-- the input's kind. Only `string` and the path kinds carry the terminator this
-  far, so `trim` changes nothing on the others.
+- the input's codec. String and path codecs carry the terminator this far, so
+  `trim` changes nothing on decoding codecs.
 - whether the producer appends a newline. `echo` does; `printf` without `\n`
   does not.
 

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -240,12 +240,15 @@ In 3.x both flags still parsed under their canonical names, so what the
 collision cost was the shared spelling. Help advertised `-v` on both flags and
 the parser answered it with `--version`.
 
-The arg invariants moved with them. One arg that is both variadic and
-stdin-backed throws `INVALID_BUILDER_STATE`, and a second stdin-backed input on
-the same command throws `DUPLICATE_STDIN_INPUT` (renamed from v3's
-`DUPLICATE_STDIN_ARG`). In 3.x a definition could declare either. Two stdin-backed args each
-resolved to the whole of stdin, and a variadic stdin-backed arg read nothing
-from stdin and failed as missing when argv supplied no positional.
+The arg invariants moved with them. A second stdin-backed input on the same
+command throws `DUPLICATE_STDIN_INPUT` (renamed from v3's
+`DUPLICATE_STDIN_ARG`), and a positional declared after a variadic one throws
+`INVALID_BUILDER_STATE`, on both construction paths. In 3.x
+a hand-assembled `CommandSchema` could declare either, and two stdin-backed args
+each resolved to the whole of stdin while a positional behind a variadic one
+silently never filled. The placement rule is new to `.arg()` as well, and
+[its own section](#a-positional-after-a-variadic-one-is-a-build-error) covers
+what to change.
 
 A flag or arg named `__proto__` throws `INVALID_SCHEMA`. Both land in a record
 keyed by name, where that key sets a prototype rather than an entry, so the flag
@@ -281,9 +284,11 @@ on such a record is an own key and is read.
 
 The whole tree is checked, nested subcommands included, and `createCLISchema()`
 inherits the checks through it. `command()` already refused the collisions at
-`.flag()` and `.command()` and the arg invariants at `.arg()`. For those, only
-definitions composed as data change: one that used to build and then misbehave
-at parse time now fails at construction.
+`.flag()` and `.command()`, and refused a second stdin-backed arg at `.arg()`
+under the old code `DUPLICATE_STDIN_ARG`. For those, only definitions composed
+as data change: one that used to build and then misbehave at parse time now
+fails at construction. Argument placement is the exception, since `.arg()`
+accepted a positional after a variadic one in 3.x.
 
 `__proto__` changes on the builder too. `.arg('__proto__')` used to build and
 then swallow the positional value; it now throws `INVALID_SCHEMA`.
@@ -463,10 +468,11 @@ createArgSchema('string', { stdin: { when: 'dash', consume: 'broadcast' } });
 ```
 
 The definition document changes to match. An arg fragment emits
-`stdin: { when, consume }` where `stdinMode: true` used to appear, at
-`schemaVersion: 1`, which has not shipped. Tooling reading the fragment reads
-the object; tooling that only asked whether stdin was enabled checks for the
-key's presence.
+`stdin: { when, consume, trim }` where `stdinMode: true` used to appear, at
+`schemaVersion: 1`, which has not shipped. All three fields are always written,
+so a reader never has to know the builder's defaults. Tooling reading the
+fragment reads the object; tooling that only asked whether stdin was enabled
+checks for the key's presence.
 
 ### `DUPLICATE_STDIN_ARG` is now `DUPLICATE_STDIN_INPUT`
 
@@ -476,6 +482,52 @@ matches the new one; the message reads `Only one input may consume stdin
 exclusively; <name> already consumes stdin`, naming the input that was declared
 first. `details` names the offending input under `flag` or `arg` and the
 existing one under `existingFlag` or `existingArg`.
+
+### An explicit `-` with nothing piped fails inside a collection
+
+A `-` the user typed beside other occurrences used to be dropped when nothing
+was piped, so `--tag a --tag - --tag b` with an empty pipe resolved to
+`['a', 'b']` and the caller never learned the pipe had been empty. It now fails:
+
+```
+No piped stdin for the '-' occurrence of flag --tag
+Suggestion: Pipe a value to stdin, or drop the '-' occurrence of --tag
+```
+
+The code is `REQUIRED_FLAG` on a flag and `REQUIRED_ARG` on an argument, and
+the positional tail words it `for the '-' occurrence of argument <files>`.
+
+Two shapes are unchanged. Occurrences of nothing but `-` are the whole value, so
+with nothing piped they still fall through to env, config, prompt, and the
+default. So does a scalar `-`, since dropping it loses nothing. Only a
+collection could be silently shortened, so only a collection errors.
+
+A script that relied on the old drop has two ways forward: pipe a value, or stop
+passing `-` when there is nothing to read. A `{ when: 'missing' }` binding never
+enters this path, since it leaves a typed `-` literal.
+
+### `.stdin()` and `.variadic()` compose
+
+The pairing threw `INVALID_BUILDER_STATE` with the message `Argument <files>
+cannot be both variadic and stdin-backed`. It is now legal, and a `-` among the
+tail tokens splices what the buffer decodes to into that position:
+
+```ts
+command('build').arg('files', arg.string().variadic().stdin());
+```
+
+```bash
+$ printf 'x\ny\n' | mycli build a - b
+# args.files === ['a', 'x', 'y', 'b']
+
+$ printf 'x\ny\n' | mycli build
+# args.files === ['x', 'y']
+```
+
+An empty tail counts as an absent input, so a binding that covers a missing one
+takes the whole buffer. Code that caught the throw has nothing left to catch;
+delete the `try`. Nothing that built in 3.x resolves differently, since the
+pairing could not be built.
 
 ### Stdin values reach non-string codecs without their trailing terminator
 
@@ -534,6 +586,65 @@ arg.string().variadic().default('a');
 // 4.0: the array the arg produces
 arg.string().variadic().default(['a', 'b']);
 ```
+
+### A positional after a variadic one is a build error
+
+A variadic argument takes every remaining positional token, so anything
+registered behind it could never be filled and a second variadic one had nothing
+left to collect. Both used to build and then produce an argument that stayed
+empty. `.arg()` and `createCommandSchema()` now share one check:
+
+```ts
+// 3.x: built fine, then <target> never filled
+command('copy').arg('files', arg.string().variadic()).arg('target', arg.string());
+
+// 4.0: throws INVALID_BUILDER_STATE
+```
+
+```
+Argument <target> comes after variadic argument <files>, which consumes every remaining positional
+Suggestion: Declare <target> before <files>, or drop .variadic() from <files>
+```
+
+`details` carries the command in `command`, the argument that could never fill
+in `arg`, and the greedy one in `variadicArg`, so a definition tree names the
+nested command that declared the pair.
+
+Move the variadic argument last. Required, optional, and variadic in that order
+still builds, as does a scalar followed by an `arg.keyValue().variadic()` tail.
+A command that genuinely needs a trailing value after a list has to take it as a
+flag instead, since positional order alone cannot express it.
+
+### The arg collection modifiers require a collection
+
+`.unique()`, `.separator()`, `.split()`, and `.duplicateKeys()` state the shape
+they need. `.separator()` and `.split()` want a variadic argument or
+`arg.keyValue()`, `.unique()` a variadic argument of a list kind, and
+`.duplicateKeys()` `arg.keyValue()`. The compiler refuses each one elsewhere,
+and `createArgSchema()` throws `INVALID_SCHEMA`:
+
+```ts
+// 3.x: built fine, and the field was stored and never read
+createArgSchema('string', { unique: true });
+createArgSchema('string', { separator: ',' });
+
+// 4.0: throws INVALID_SCHEMA
+```
+
+```
+Arg schema field 'unique' requires a variadic arg of a list kind
+Suggestion: Add 'variadic: true' on a list kind, or drop 'unique'
+```
+
+Add `variadic: true`, declare the argument as `keyValue`, or drop the field,
+which changed nothing on a single-value argument anyway. The values a schema
+already stores as its own default, `unique: false` and `duplicateKeys: 'last'`,
+stay accepted on any kind, so feeding a built `ArgSchema` back through
+`createArgSchema()` round-trips.
+
+The four builder methods are new in 4.0, so only definitions composed as data
+change. This mirrors the `array | keyValue` restriction the flag surface already
+had.
 
 ### `.separator()` sets the CLI delimiter alone
 
@@ -600,6 +711,12 @@ Adopt at your own pace; none of these are required:
   collections read stdin with `-` splicing into occurrence order, and
   `arg.boolean()` and `arg.keyValue()` join the arg factories. See
   [Flags](/guide/flags) and [Arguments](/guide/arguments).
+- **Trimming a piped value**: `.stdin({ trim: true })` drops one trailing `\n`,
+  `\r\n`, or `\r` from a single value, so `echo ./dist | mycli clean` satisfies
+  `arg.path({ mustExist: true })`. It defaults to `false`, which is what 3.x
+  did, so an existing binding is unaffected. See
+  [Flags](/guide/flags#stdin-backed-flags) and
+  [Arguments](/guide/arguments#stdin-backed-arguments).
 - **Consumer-owned built-in flags**: `.builtins({ help: 'off' })`,
   `.builtins({ json: 'off' })`, or `.builtins({ quiet: 'off' })` hands a
   root-owned token to the commands, for a CLI whose `--json`, `-q`, or

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -500,7 +500,7 @@ the positional tail words it `for the '-' occurrence of argument <files>`.
 Two shapes are unchanged. Occurrences of nothing but `-` are the whole value, so
 with nothing piped they still fall through to env, config, prompt, and the
 default. So does a scalar `-`, since dropping it loses nothing. Only a
-collection could be silently shortened, so only a collection errors.
+collection could be silently shortened, so only a collection can error.
 
 A script that relied on the old drop has two ways forward: pipe a value, or stop
 passing `-` when there is nothing to read. A `{ when: 'missing' }` binding never

--- a/docs/reference/stability.md
+++ b/docs/reference/stability.md
@@ -229,6 +229,10 @@ built schema, so the same type serves as consumer input and as a member of a
 sealed value. The input contract is the one that governs them. `StdinOptions`
 splits the two roles instead: a caller writes the partial form and the schema
 stores the fully populated `StdinBinding`, which takes the same input contract.
+The binding has three axes, `when`, `consume`, and `trim`. Every
+`StdinOptions` member is optional, so a fourth axis may arrive in a minor
+release. Every `StdinBinding` member is required, so the stored form gains one
+only in a major.
 `SplitOptions` splits them the same way: a caller writes the per-source settings
 and the schema stores the CLI delimiter on `separator` and the rest on
 `SourceSplitBinding`, which `SplitBinding` resolves with the defaults filled in.
@@ -477,6 +481,11 @@ fragments of both `FlagDefinitionFragmentV1` and `ArgDefinitionFragmentV1`. Thei
 names are frozen with the version 1 format and carry no claim about which of the
 two embeds them; the meta-schema hoists one definition per fragment and both
 parents `$ref` it.
+
+`StdinBindingFragmentV1` carries `when`, `consume`, and `trim`, all three
+required and all three always written, so a reader never has to know the
+builder's defaults. The meta-schema lists them under `$defs.stdin` with
+`additionalProperties: false` and the same three in `required`.
 
 These values leave the process. The package version does not govern their shape.
 `schemaVersion` does.

--- a/dreamcli.schema.json
+++ b/dreamcli.schema.json
@@ -315,11 +315,16 @@
             "broadcast"
           ],
           "description": "Whether this input consumes the stream alone."
+        },
+        "trim": {
+          "type": "boolean",
+          "description": "Whether one trailing line terminator is dropped from a single value."
         }
       },
       "required": [
         "when",
-        "consume"
+        "consume",
+        "trim"
       ],
       "description": "The normalized stdin axis of a flag or an arg."
     },

--- a/dreamcli.schema.json
+++ b/dreamcli.schema.json
@@ -323,8 +323,7 @@
       },
       "required": [
         "when",
-        "consume",
-        "trim"
+        "consume"
       ],
       "description": "The normalized stdin axis of a flag or an arg."
     },

--- a/skills/cli-creation/SKILL.md
+++ b/skills/cli-creation/SKILL.md
@@ -121,19 +121,30 @@ tokens by default, comma-delimited env values, line-delimited stdin, and native
 arrays and objects from config. `.separator()` sets the CLI policy alone and is
 no longer inherited by env or config. `.unique()` dedupes a list, and
 `.duplicateKeys('last' | 'first' | 'error')` decides a repeated key on every
-source. A validator on the element builder checks each element; one on the
-collection builder checks the finished value.
+source, naming the source that carried it. A validator on the element builder
+checks each element; one on the collection builder checks the finished value.
+On the arg surface all four are collection modifiers: call them after
+`.variadic()` or on `arg.keyValue()`, or the compiler refuses them and
+`createArgSchema()` throws `INVALID_SCHEMA`.
+
+**Argument order.** A variadic argument takes every remaining positional, so it
+is the last one a command can declare. Anything registered behind it throws
+`INVALID_BUILDER_STATE`.
 
 **Sources.** Both factories declare the same sources. Chain `.stdin()`,
 `.env()`, `.config()`, `.prompt()`, `.default()` on a flag or an argument and
 let one resolution order (argv, stdin, env, config, prompt, default) do the
 work. Count and key-value flags and key-value arguments are not promptable.
-`.stdin()` takes `{ when, consume }`; one command has one exclusive stdin
-consumer unless every stdin input passes `{ consume: 'broadcast' }`. A `-`
+`.stdin()` takes `{ when, consume, trim }`; one command has one exclusive
+stdin consumer unless every stdin input passes `{ consume: 'broadcast' }`. A `-`
 occurrence on a collection splices the decoded buffer in at that position, so
 `--tag before --tag - --tag after` over `a\nb\n` gives
-`['before', 'a', 'b', 'after']`. Stdin is available to scalar, array, and
-key-value inputs; count flags and variadic arguments cannot read it.
+`['before', 'a', 'b', 'after']`, and a variadic argument reads its tail the same
+way. A `-` typed beside other occurrences with nothing piped fails; a lone `-`
+falls through. `{ trim: true }` drops one trailing line terminator from a single
+value, which is what `arg.path({ mustExist: true }).stdin({ trim: true })`
+wants. Stdin is available to scalar, array, key-value, and variadic inputs;
+count flags cannot read it, and key-value arguments cannot prompt.
 
 **Cross-flag rules.** Put them in `.derive()`, which runs after resolution and
 before the action, and return derived state to widen `ctx`.

--- a/skills/cli-creation/SKILL.md
+++ b/skills/cli-creation/SKILL.md
@@ -123,8 +123,9 @@ no longer inherited by env or config. `.unique()` dedupes a list, and
 `.duplicateKeys('last' | 'first' | 'error')` decides a repeated key on every
 source, naming the source that carried it. A validator on the element builder
 checks each element; one on the collection builder checks the finished value.
-On the arg surface all four are collection modifiers: call them after
-`.variadic()` or on `arg.keyValue()`, or the compiler refuses them and
+On the arg surface, `.separator()` and `.split()` require `.variadic()` or
+`arg.keyValue()`, `.unique()` requires a variadic list, and `.duplicateKeys()`
+requires `arg.keyValue()`. The compiler refuses every other shape and
 `createArgSchema()` throws `INVALID_SCHEMA`.
 
 **Argument order.** A variadic argument takes every remaining positional, so it

--- a/skills/cli-creation/references/pattern-cookbook.md
+++ b/skills/cli-creation/references/pattern-cookbook.md
@@ -37,17 +37,35 @@ arg.string().stdin(); // `-` or an omitted slot reads the pipe
 flag.string().stdin({ when: 'dash' }); // only an explicit `-`
 arg.string().stdin({ when: 'missing' }); // only an omitted slot; `-` stays literal
 flag.string().stdin({ consume: 'broadcast' }); // shares the buffer with other inputs
+flag.string().stdin({ trim: true }); // drops one trailing line terminator
 ```
 
-Available on `string`, `number`, `boolean`, `enum`, and `custom` flags and on
-every arg kind; the collection kinds (`array`, `keyValue`, `count`) reject it
-with `INVALID_SCHEMA`. A `-` stays CLI-sourced and outranks every later stage;
-an absent input takes the stdin stage, which sits ahead of env. One command has
-one exclusive stdin consumer, and a second `.stdin()` input of either surface
-throws `DUPLICATE_STDIN_INPUT` unless every one of them passes
-`{ consume: 'broadcast' }`. A `string` input keeps the buffer byte for byte, so
-`echo hi | mycli` gives `'hi\n'`; every other kind drops one trailing line
-terminator before decoding.
+Available on every flag kind but `count`, which counts occurrences rather than
+reading a value and throws `INVALID_SCHEMA`, and on every arg kind. A `-` stays
+CLI-sourced and outranks every later stage; an absent input takes the stdin
+stage, which sits ahead of env. One command has one exclusive stdin consumer,
+and a second `.stdin()` input of either surface throws `DUPLICATE_STDIN_INPUT`
+unless every one of them passes `{ consume: 'broadcast' }`.
+
+A `string` input keeps the buffer byte for byte, so `echo hi | mycli` gives
+`'hi\n'`; every other kind drops one trailing line terminator before decoding.
+`{ trim: true }` drops it for a `string` too, which is what a piped path wants:
+
+```ts
+arg.path({ mustExist: true }).stdin({ trim: true });
+// echo ./dist | mycli clean → the check runs against './dist'
+```
+
+It applies to a single value. A collection's terminators separate its elements,
+so `.split({ stdin })` decides those.
+
+A collection reads the buffer as elements and splices them where a `-`
+occurrence sits. A `-` typed beside other occurrences with nothing piped fails
+with `REQUIRED_FLAG` or `REQUIRED_ARG`, rather than shortening the collection;
+occurrences of nothing but `-`, and a scalar `-`, fall through to the later
+sources instead. A stdin-enabled input can never receive a literal `-` as its
+value, since the token names the source; `{ when: 'missing' }` is the one
+binding that leaves it literal.
 
 ### Rich flag types
 
@@ -88,9 +106,16 @@ There is no `arg.array()` (use `.variadic()`) and no `arg.count()`, which counts
 flag occurrences. `arg.boolean()` and `arg.keyValue()` do exist:
 `arg.boolean()` consumes an explicit `true`/`false` token, and
 `arg.keyValue()` consumes `KEY=VALUE` tokens into a record. `.stdin()`,
-`.env()`, and `.config()` are available on scalar and key-value arguments;
-prompts are unavailable on key-value arguments, and a variadic argument cannot
-also read stdin. Array and key-value flags can read stdin; count flags cannot.
+`.env()`, `.config()`, and `.prompt()` are all available on an argument,
+`.variadic()` included: a `-` among the tail tokens splices the decoded buffer
+in at that position, so `printf 'x\ny\n' | mycli build a - b` collects
+`['a', 'x', 'y', 'b']`, and an empty tail takes the whole buffer.
+Prompts are unavailable on key-value arguments, and count flags cannot read
+stdin.
+
+A variadic argument is the last positional a command can declare. Registering
+another one behind it throws `INVALID_BUILDER_STATE` on both construction
+paths, since it could never be filled.
 
 ### Constraints instead of hand-written validation
 
@@ -156,6 +181,12 @@ arg.keyValue().variadic(); // mycli render a=1 b=2 → { a: '1', b: '2' }
 `--region us,eu --region ap` and repetition both work. Put flag-level modifiers
 (`.env()`, `.default()`) on the array, never on the element, which is a compile
 error.
+
+On the arg surface these four are collection modifiers, so each states the shape
+it needs and the compiler refuses it elsewhere. `.separator()` and `.split()`
+want a variadic argument or `arg.keyValue()`, `.unique()` a variadic argument of
+a list kind, and `.duplicateKeys()` `arg.keyValue()`. `createArgSchema()` throws
+`INVALID_SCHEMA` on the same combinations.
 
 Each source decodes under its own policy, and a CLI separator is not inherited:
 

--- a/src/core/cli/AGENTS.md
+++ b/src/core/cli/AGENTS.md
@@ -137,8 +137,8 @@ building and the no-commands error; `executeCLI()` renders the six plan kinds: `
   `assertNoCompletionsFlagCollision()` when the definition carries `completionsFlag`, so both
   construction paths agree; `createCommandSchema()` runs no root-owned-token check, since a bare
   command is not bound to a root. It does run `validateCommandFlagTree()` and `validateArgEntry()`,
-  so command-local collisions, propagated collisions, and the arg stdin/variadic invariants still
-  throw there.
+  so command-local collisions, propagated collisions, and the arg positional-order and stdin
+  invariants still throw there.
 - `collectPropagatedFlags()` in `propagate.ts` tests descendant flag records with `Object.hasOwn()`.
   `in` walks `Object.prototype`, which made every subcommand look like it overrode a propagated flag
   named `toString`, `valueOf`, or any other prototype member.

--- a/src/core/cli/index.ts
+++ b/src/core/cli/index.ts
@@ -641,9 +641,9 @@ function buildCLISchema(definition: CLIDefinition): CLISchema {
  *   command share a spelling, at any depth of the command tree.
  * @throws {CLIError} With code `'PROPAGATED_FLAG_COLLISION'` when a command flag
  *   shadows a spelling propagated from an ancestor command.
- * @throws {CLIError} With code `'INVALID_BUILDER_STATE'` when one arg is both
- *   variadic and stdin-backed, or `'DUPLICATE_STDIN_INPUT'` when two inputs on
- *   one command consume stdin and either is exclusive.
+ * @throws {CLIError} With code `'INVALID_BUILDER_STATE'` when a positional comes
+ *   after a variadic one, or `'DUPLICATE_STDIN_INPUT'` when two inputs on one
+ *   command consume stdin and either is exclusive.
  * @throws {CLIError} With code `'RESERVED_FLAG'` when a command spells a flag
  *   the same way as a root-owned flag (`--json`, `--quiet`/`-q`, `--help`/`-h`,
  *   `--version`/`-V` once `version` is set, and `--completions` once

--- a/src/core/cli/stdin-eligibility.test.ts
+++ b/src/core/cli/stdin-eligibility.test.ts
@@ -257,6 +257,53 @@ describe('collection stdin eligibility', () => {
 		expect(seen).toEqual([{ A: '1', B: '2' }]);
 	});
 
+	it('reads stdin for a `-` among the tail of a variadic positional', async () => {
+		const seen: unknown[] = [];
+		const app = cli('mycli').default(
+			command('run')
+				.arg('files', arg.string().variadic().stdin())
+				.action(({ args }) => {
+					seen.push(args.files);
+				}),
+		);
+		const host = countingAdapter({ argv: ['before', '-', 'after'], stdinData: 'a\nb\n' });
+
+		await runQuietly(() => app.run({ adapter: host.adapter }));
+
+		expect(host.reads()).toBe(1);
+		expect(seen).toEqual([['before', 'a', 'b', 'after']]);
+	});
+
+	it('reads stdin once for an empty tail the binding covers', async () => {
+		const seen: unknown[] = [];
+		const app = cli('mycli').default(
+			command('run')
+				.arg('files', arg.string().variadic().stdin())
+				.action(({ args }) => {
+					seen.push(args.files);
+				}),
+		);
+		const host = countingAdapter({ argv: [], stdinData: 'a\nb\n' });
+
+		await runQuietly(() => app.run({ adapter: host.adapter }));
+
+		expect(host.reads()).toBe(1);
+		expect(seen).toEqual([['a', 'b']]);
+	});
+
+	it('does not read stdin when the tail is fully typed', async () => {
+		const app = cli('mycli').default(
+			command('run')
+				.arg('files', arg.string().variadic().stdin())
+				.action(() => {}),
+		);
+		const host = countingAdapter({ argv: ['a', 'b'], stdinData: 'piped' });
+
+		await runQuietly(() => app.run({ adapter: host.adapter }));
+
+		expect(host.reads()).toBe(0);
+	});
+
 	it('does not read stdin for a literal `-` element on an array flag without a stdin binding', async () => {
 		const seen: unknown[] = [];
 		const app = cli('mycli').default(

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -1283,7 +1283,7 @@ const definitionMetaSchema: Record<string, unknown> = withDefinitionMetaSchemaDe
 					consume: { enum: ['exclusive', 'broadcast'] },
 					trim: { type: 'boolean' },
 				} satisfies Record<keyof StdinBindingFragmentV1, Record<string, unknown>>,
-				required: ['when', 'consume', 'trim'],
+				required: ['when', 'consume'],
 			},
 			split: {
 				type: 'object',

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -166,12 +166,13 @@ type PromptDefinitionFragmentV1 = {
 /**
  * Stdin binding of a flag or arg fragment.
  *
- * Both fields are always written, so a document states the trigger and the
- * sharing mode without a reader having to know the builder's defaults.
+ * Every field is always written, so a document states the trigger, the sharing
+ * mode, and the trimming without a reader having to know the builder's defaults.
  */
 type StdinBindingFragmentV1 = {
 	readonly when: 'dash' | 'missing' | 'dash-or-missing';
 	readonly consume: 'exclusive' | 'broadcast';
+	readonly trim: boolean;
 };
 
 /**
@@ -641,10 +642,11 @@ function serializeSplit(split: SourceSplitBinding): SourceSplitFragmentV1 {
  * Serialize a {@link StdinBinding} into a plain object.
  *
  * @param stdin - The stdin axis to serialize.
- * @returns JSON-serializable object naming the trigger and the sharing mode.
+ * @returns JSON-serializable object naming the trigger, the sharing mode, and
+ *   the trimming.
  */
 function serializeStdin(stdin: StdinBinding): StdinBindingFragmentV1 {
-	return { when: stdin.when, consume: stdin.consume };
+	return { when: stdin.when, consume: stdin.consume, trim: stdin.trim };
 }
 
 // --- Prompt serialization
@@ -1279,8 +1281,9 @@ const definitionMetaSchema: Record<string, unknown> = withDefinitionMetaSchemaDe
 				properties: {
 					when: { enum: ['dash', 'missing', 'dash-or-missing'] },
 					consume: { enum: ['exclusive', 'broadcast'] },
+					trim: { type: 'boolean' },
 				} satisfies Record<keyof StdinBindingFragmentV1, Record<string, unknown>>,
-				required: ['when', 'consume'],
+				required: ['when', 'consume', 'trim'],
 			},
 			split: {
 				type: 'object',

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -1056,6 +1056,7 @@ describe('generateSchema — definition metadata', () => {
 		expect(expectRecord(flags.piped)).toHaveProperty('stdin', {
 			when: 'dash',
 			consume: 'broadcast',
+			trim: false,
 		});
 	});
 

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -157,6 +157,13 @@ describe('generateSchema — definition metadata', () => {
 		]);
 	});
 
+	it('keeps trim optional in v1 stdin fragments', () => {
+		expect(definitionMetaSchema).toHaveProperty(
+			['$defs', 'stdin', 'required'],
+			['when', 'consume'],
+		);
+	});
+
 	it('accepts standalone command documents via a dedicated def', () => {
 		const defs = expectRecord(definitionMetaSchema.$defs);
 		const command = expectRecord(defs.command);

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -588,6 +588,33 @@ describe('generateSchema — definition metadata', () => {
 		});
 	});
 
+	it('serializes the stdin binding of a flag and of an arg with every field', () => {
+		const flagOnly = commandDef({
+			name: 'test',
+			flags: { body: flagDef({ kind: 'string', stdin: { when: 'dash', trim: true } }) },
+		});
+		const argOnly = commandDef({
+			name: 'other',
+			args: [
+				argEntry('input', {
+					stdin: { when: 'dash-or-missing', consume: 'broadcast', trim: false },
+				}),
+			],
+		});
+		const result = generateSchema(minimalCLI({ commands: [flagOnly, argOnly] }));
+
+		expect(result).toHaveProperty(['commands', 0, 'flags', 'body', 'stdin'], {
+			when: 'dash',
+			consume: 'exclusive',
+			trim: true,
+		});
+		expect(result).toHaveProperty(['commands', 1, 'args', 0, 'stdin'], {
+			when: 'dash-or-missing',
+			consume: 'broadcast',
+			trim: false,
+		});
+	});
+
 	it('omits prompt config when includePrompts is false', () => {
 		const cmd = commandDef({
 			name: 'test',
@@ -666,15 +693,15 @@ describe('generateSchema — definition metadata', () => {
 		const cmd = commandDef({
 			name: 'test',
 			args: [
-				argEntry('files', { variadic: true, description: 'Files to process' }),
 				argEntry('region', { kind: 'enum', enumValues: ['us', 'eu'], envVar: 'REGION' }),
+				argEntry('files', { variadic: true, description: 'Files to process' }),
 			],
 		});
 		const result = generateSchema(minimalCLI({ commands: [cmd] }));
-		expect(result).toHaveProperty(['commands', 0, 'args', 0, 'variadic'], true);
-		expect(result).toHaveProperty(['commands', 0, 'args', 0, 'description'], 'Files to process');
-		expect(result).toHaveProperty(['commands', 0, 'args', 1, 'enumValues'], ['us', 'eu']);
-		expect(result).toHaveProperty(['commands', 0, 'args', 1, 'envVar'], 'REGION');
+		expect(result).toHaveProperty(['commands', 0, 'args', 0, 'enumValues'], ['us', 'eu']);
+		expect(result).toHaveProperty(['commands', 0, 'args', 0, 'envVar'], 'REGION');
+		expect(result).toHaveProperty(['commands', 0, 'args', 1, 'variadic'], true);
+		expect(result).toHaveProperty(['commands', 0, 'args', 1, 'description'], 'Files to process');
 	});
 
 	it('includes arg defaultValue when defaulted', () => {
@@ -1099,15 +1126,9 @@ describe('generateSchema — definition metadata', () => {
 				stringConstraints: { nonEmpty: true, minLength: 2, maxLength: 12, pattern: /^v\d+$/ },
 				pathChecks: { mustExist: true, type: 'directory', create: true },
 			}),
-			argEntry('extras', {
-				variadic: true,
-				separator: ',',
-				split: { env: { format: 'json' }, stdin: { format: 'lines' } },
-				unique: true,
-			}),
 			argEntry('vars', { kind: 'keyValue', duplicateKeys: 'error' }),
 			argEntry('piped', {
-				stdin: { when: 'dash-or-missing', consume: 'exclusive' },
+				stdin: { when: 'dash-or-missing', consume: 'exclusive', trim: true },
 				configPath: 'release.piped',
 				prompt: { kind: 'input', message: 'Piped?' },
 			}),
@@ -1121,6 +1142,12 @@ describe('generateSchema — definition metadata', () => {
 						validate: (value: unknown) => ({ value }),
 					},
 				},
+			}),
+			argEntry('extras', {
+				variadic: true,
+				separator: ',',
+				split: { env: { format: 'json' }, stdin: { format: 'lines' } },
+				unique: true,
 			}),
 		];
 		const cli = minimalCLI({ commands: [commandDef({ args: allFieldsArgs })] });
@@ -1157,7 +1184,7 @@ describe('generateSchema — definition metadata', () => {
 		});
 
 		const withoutPrompts = generateSchema(cli, { includePrompts: false });
-		expect(withoutPrompts).not.toHaveProperty(['commands', 0, 'args', 5, 'prompt']);
+		expect(withoutPrompts).not.toHaveProperty(['commands', 0, 'args', 4, 'prompt']);
 	});
 });
 

--- a/src/core/json-schema/meta-descriptions.generated.ts
+++ b/src/core/json-schema/meta-descriptions.generated.ts
@@ -159,6 +159,9 @@ const definitionMetaSchemaDescriptions = {
 				consume: {
 					description: 'Whether this input consumes the stream alone.',
 				},
+				trim: {
+					description: 'Whether one trailing line terminator is dropped from a single value.',
+				},
 			},
 		},
 		negation: {

--- a/src/core/parse/AGENTS.md
+++ b/src/core/parse/AGENTS.md
@@ -2,24 +2,44 @@
 
 ## OVERVIEW
 
-Single-file parser module. It tokenizes raw argv without schema knowledge, then parses against
-`CommandSchema` into raw values for the resolve layer.
+Two source files. `index.ts` tokenizes raw argv without schema knowledge, then parses against
+`CommandSchema` into raw values for the resolve layer. `occurrences.ts` holds the representation
+those two phases meet in.
 
 ## FILES
 
-| File            | Purpose                                                    |
-| --------------- | ---------------------------------------------------------- |
-| `index.ts`      | `tokenize()`, `parse()`, flag/arg coercion, lookup helpers |
-| `parse.test.ts` | parser contract, edge cases, regressions                   |
+| File                        | Lines | Purpose                                                         |
+| --------------------------- | ----: | --------------------------------------------------------------- |
+| `index.ts`                  |  1272 | `tokenize()`, `parse()`, flag/arg token reading, lookup helpers |
+| `occurrences.ts`            |   186 | `Occurrence`, `projectOccurrences()`, `liftOccurrences()`       |
+| `parse.test.ts`             |  1045 | parser contract, edge cases, regressions                        |
+| `parse-case-parity.test.ts` |   118 | kebab↔camel counterpart spellings                               |
+| `occurrences.test.ts`       |   198 | the representation: projection, lifting, entry pairs            |
+
+## OCCURRENCE MODEL
+
+One input's command-line occurrences are one ordered `Occurrence[]`: a decoded `value`, a decoded
+`entry` pair, the position a `-` `stdin` sentinel holds, a `negated` spelling, one count
+`increment`, or an `aggregated` value a caller supplied ready-made. Nothing folds while argv is
+being read.
+
+`parse()` accumulates `Map<canonical name, FlagOccurrences>`, where each `FlagOccurrence` carries
+what the duplicate policy reports for it and the items it contributes. `projectOccurrences()` then
+turns each list into what `ParseResult` carries: the last occurrence for a scalar, the folded total
+for a count, the ordered elements for a collection. `resolve/coerce.ts` calls `liftOccurrences()` to
+read such a value back as occurrences, so a caller-built `ParseResult` and a parsed one aggregate
+through one list.
 
 ## WHERE TO LOOK
 
-| Task                             | Location                                | Notes                                                          |
-| -------------------------------- | --------------------------------------- | -------------------------------------------------------------- |
-| Change raw argv splitting        | `tokenize()`                            | `--`, `--flag=value`, grouped short flags, lone `-`            |
-| Change alias or canonical lookup | `buildFlagLookup()`                     | names and aliases normalize to canonical keys                  |
-| Change parse-time coercion       | `coerceFlagValue()`, `coerceArgValue()` | parse-time only, before resolve and defaults                   |
-| Change main parse flow           | `parse()`                               | consumes tokens into raw flags and args or throws `ParseError` |
+| Task                             | Location                                        | Notes                                                            |
+| -------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------- |
+| Change raw argv splitting        | `tokenize()`                                    | `--`, `--flag=value`, grouped short flags, lone `-`              |
+| Change alias or canonical lookup | `buildFlagLookup()`                             | names and aliases normalize to canonical keys                    |
+| Change parse-time coercion       | `flagTokenOccurrence()`, `argTokenOccurrence()` | parse-time only, before resolve and defaults                     |
+| Change duplicate policy          | `recordFlagOccurrence()`                        | governs supplied values; count increments stay outside it        |
+| Change what a parse result shows | `projectOccurrences()` in `occurrences.ts`      | the public projection of an occurrence list                      |
+| Change main parse flow           | `parse()`                                       | consumes tokens into occurrences and args or throws `ParseError` |
 
 ## CONVENTIONS
 
@@ -27,14 +47,18 @@ Single-file parser module. It tokenizes raw argv without schema knowledge, then 
 - Single `-` is a positional stdin sentinel, not a flag
 - Boolean explicit values accept only `true`/`false` and `1`/`0`
 - Parse errors use `ParseError` with structured codes and details, not ad hoc strings
+- A token is decoded where it is read, so an error names the spelling the user typed
 
 ## ANTI-PATTERNS
 
 - Do not read env, config, prompts, or defaults here; that is `resolve/`
 - Do not bypass canonical alias mapping when storing parsed flags
 - Do not blur tokenization and parsing responsibilities to simplify a small change
+- Do not fold an occurrence list anywhere but `projectOccurrences()` and the resolver
 
 ## NOTES
 
 - Custom flag parsers may throw; non-`ParseError` failures get wrapped with parse context
-- This file is small in count, not in surface area. Respect the tests.
+- `coerceFlagValue()` stays exported for `cli/root-output-flags.ts`; it is one token read through
+  `flagTokenOccurrence()`
+- This module is small in count, not in surface area. Respect the tests.

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -33,7 +33,6 @@ import {
 	describeStringConstraintViolation,
 	stringConstraintDetails,
 } from '#internals/core/schema/index.ts';
-import { STDIN_SENTINEL } from '#internals/core/schema/source.ts';
 import type { StdinBinding } from '#internals/core/schema/stdin.ts';
 import { stdinReadsOnDash } from '#internals/core/schema/stdin.ts';
 import type { ValueFailure } from '#internals/core/schema/value.ts';
@@ -307,7 +306,7 @@ interface FlagOccurrence {
 	/** The value a duplicate diagnostic reports for it. */
 	readonly reported: unknown;
 	/** What the occurrence contributes, in the order it was typed. */
-	items: readonly Occurrence[];
+	readonly items: readonly Occurrence[];
 }
 
 /** Every CLI occurrence of one logical flag, in the order they were typed. */
@@ -349,8 +348,8 @@ function occurrencesOf(
  * @param schema - Flag schema (read for {@link FlagSchema.duplicates})
  * @param reported - The occurrence's raw value (or the boolean it implies)
  * @param displayName - User-facing spelling for error messages
- * @returns The recorded occurrence, ready for its items; `undefined` when the
- *   `'first'` policy suppresses it (the token is still consumed)
+ * @param items - Lazily builds what the occurrence contributes when policy
+ *   keeps it
  * @throws ParseError `DUPLICATE_FLAG` on a repeat under the `'error'` policy
  */
 function recordFlagOccurrence(
@@ -359,25 +358,27 @@ function recordFlagOccurrence(
 	schema: FlagSchema,
 	reported: unknown,
 	displayName: string,
-): FlagOccurrence | undefined {
+	items: () => readonly Occurrence[],
+): void {
 	const record = occurrencesOf(occurrences, name, schema);
-	const occurrence: FlagOccurrence = { policed: true, reported, items: [] };
-	record.occurrences.push(occurrence);
 	record.counted += 1;
 
-	if (record.counted === 1) return occurrence;
-	if (schema.duplicates === 'error') {
+	if (record.counted > 1 && schema.duplicates === 'error') {
 		throw new ParseError(`Flag --${name} may only be specified once`, {
 			code: 'DUPLICATE_FLAG',
 			details: {
 				flag: name,
 				input: displayName,
 				count: record.counted,
-				values: record.occurrences.filter((entry) => entry.policed).map((entry) => entry.reported),
+				values: [
+					...record.occurrences.filter((entry) => entry.policed).map((entry) => entry.reported),
+					reported,
+				],
 			},
 		});
 	}
-	return schema.duplicates === 'first' ? undefined : occurrence;
+	if (record.counted > 1 && schema.duplicates === 'first') return;
+	record.occurrences.push({ policed: true, reported, items: items() });
 }
 
 /**
@@ -821,14 +822,9 @@ function parseLongFlag(
 				details: { flag: canonicalName, input: token.name, value: token.value },
 			});
 		}
-		const occurrence = recordFlagOccurrence(
-			occurrences,
-			canonicalName,
-			flagSchema,
-			false,
-			displayName,
-		);
-		if (occurrence !== undefined) occurrence.items = [NEGATED_OCCURRENCE];
+		recordFlagOccurrence(occurrences, canonicalName, flagSchema, false, displayName, () => [
+			NEGATED_OCCURRENCE,
+		]);
 		return startIdx + 1;
 	}
 
@@ -836,41 +832,30 @@ function parseLongFlag(
 		// Boolean or count flag — consumes no value token
 		if (token.value !== undefined) {
 			const item = flagTokenOccurrence(canonicalName, token.value, flagSchema, displayName);
-			const occurrence = recordFlagOccurrence(
+			recordFlagOccurrence(
 				occurrences,
 				canonicalName,
 				flagSchema,
 				occurrenceValue(item),
 				displayName,
+				() => [item],
 			);
-			if (occurrence !== undefined) occurrence.items = [item];
 		} else if (flagSchema.kind === 'count') {
 			recordCountIncrement(occurrences, canonicalName, flagSchema);
 		} else {
-			const occurrence = recordFlagOccurrence(
-				occurrences,
-				canonicalName,
-				flagSchema,
-				true,
-				displayName,
-			);
-			if (occurrence !== undefined) occurrence.items = [{ kind: 'value', value: true }];
+			recordFlagOccurrence(occurrences, canonicalName, flagSchema, true, displayName, () => [
+				{ kind: 'value', value: true },
+			]);
 		}
 		return startIdx + 1;
 	}
 
 	if (token.value !== undefined) {
 		// --flag=value (inline)
-		const occurrence = recordFlagOccurrence(
-			occurrences,
-			canonicalName,
-			flagSchema,
-			token.value,
-			displayName,
+		const inlineValue = token.value;
+		recordFlagOccurrence(occurrences, canonicalName, flagSchema, inlineValue, displayName, () =>
+			flagTokenOccurrences(canonicalName, flagSchema, inlineValue, displayName),
 		);
-		if (occurrence !== undefined) {
-			occurrence.items = flagTokenOccurrences(canonicalName, flagSchema, token.value);
-		}
 		return startIdx + 1;
 	}
 
@@ -882,21 +867,9 @@ function parseLongFlag(
 			details: { flag: canonicalName, input: token.name, kind: flagSchema.kind },
 		});
 	}
-	const occurrence = recordFlagOccurrence(
-		occurrences,
-		canonicalName,
-		flagSchema,
-		nextToken.value,
-		displayName,
+	recordFlagOccurrence(occurrences, canonicalName, flagSchema, nextToken.value, displayName, () =>
+		flagTokenOccurrences(canonicalName, flagSchema, nextToken.value, displayName),
 	);
-	if (occurrence !== undefined) {
-		occurrence.items = flagTokenOccurrences(
-			canonicalName,
-			flagSchema,
-			nextToken.value,
-			displayName,
-		);
-	}
 	return startIdx + 2;
 }
 
@@ -940,14 +913,9 @@ function parseShortFlags(
 			if (flagSchema.kind === 'count') {
 				recordCountIncrement(occurrences, canonicalName, flagSchema);
 			} else {
-				const occurrence = recordFlagOccurrence(
-					occurrences,
-					canonicalName,
-					flagSchema,
-					true,
-					displayName,
-				);
-				if (occurrence !== undefined) occurrence.items = [{ kind: 'value', value: true }];
+				recordFlagOccurrence(occurrences, canonicalName, flagSchema, true, displayName, () => [
+					{ kind: 'value', value: true },
+				]);
 			}
 			continue;
 		}
@@ -956,21 +924,9 @@ function parseShortFlags(
 			// Value-expecting flag in the middle of combined shorts:
 			// -oFile → -o with value "File" (rest of chars is the value)
 			const inlineValue = chars.slice(ci + 1);
-			const occurrence = recordFlagOccurrence(
-				occurrences,
-				canonicalName,
-				flagSchema,
-				inlineValue,
-				displayName,
+			recordFlagOccurrence(occurrences, canonicalName, flagSchema, inlineValue, displayName, () =>
+				flagTokenOccurrences(canonicalName, flagSchema, inlineValue, displayName),
 			);
-			if (occurrence !== undefined) {
-				occurrence.items = flagTokenOccurrences(
-					canonicalName,
-					flagSchema,
-					inlineValue,
-					displayName,
-				);
-			}
 			break; // consumed all remaining chars
 		}
 
@@ -982,21 +938,9 @@ function parseShortFlags(
 				details: { flag: canonicalName, input: ch, kind: flagSchema.kind },
 			});
 		}
-		const occurrence = recordFlagOccurrence(
-			occurrences,
-			canonicalName,
-			flagSchema,
-			nextToken.value,
-			displayName,
+		recordFlagOccurrence(occurrences, canonicalName, flagSchema, nextToken.value, displayName, () =>
+			flagTokenOccurrences(canonicalName, flagSchema, nextToken.value, displayName),
 		);
-		if (occurrence !== undefined) {
-			occurrence.items = flagTokenOccurrences(
-				canonicalName,
-				flagSchema,
-				nextToken.value,
-				displayName,
-			);
-		}
 		nextIdx++;
 	}
 
@@ -1101,8 +1045,14 @@ function mapPositionals(
 
 		const rawPositional = positionals[posIdx];
 		if (rawPositional !== undefined) {
-			const occurrence = argTokenOccurrence(entry.name, rawPositional, entry.schema);
-			args[entry.name] = projectOccurrences(cardinality, [occurrence]);
+			const policy =
+				cardinality.kind === 'many' || cardinality.kind === 'entries'
+					? cardinality.splitting.cli
+					: WHOLE_TOKEN;
+			const occurrences = splitCliToken(policy, rawPositional, {
+				stdin: entry.schema.stdin,
+			}).map((part) => argTokenOccurrence(entry.name, part, entry.schema));
+			args[entry.name] = projectOccurrences(cardinality, occurrences);
 			posIdx++;
 		}
 		// If no positional available, leave absent (resolution/validation handles defaults/required)

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -38,6 +38,15 @@ import type { StdinBinding } from '#internals/core/schema/stdin.ts';
 import { stdinReadsOnDash } from '#internals/core/schema/stdin.ts';
 import type { ValueFailure } from '#internals/core/schema/value.ts';
 import { argValueSchema, decodeValue, flagValueSchema } from '#internals/core/schema/value.ts';
+import type { Occurrence } from './occurrences.ts';
+import {
+	INCREMENT_OCCURRENCE,
+	NEGATED_OCCURRENCE,
+	occurrenceValue,
+	projectOccurrences,
+	STDIN_OCCURRENCE,
+	STDIN_SENTINEL,
+} from './occurrences.ts';
 
 // --- Tokenizer — schema-agnostic argv splitting
 
@@ -289,12 +298,46 @@ function buildFlagLookup(
 	return lookup;
 }
 
-// --- Duplicate-occurrence tracking
+// --- Occurrence tracking
 
-/** Mutable per-parse record of CLI occurrences for one logical flag. */
+/** One CLI occurrence of a logical flag, and what it contributes. */
+interface FlagOccurrence {
+	/** Whether the flag's duplicate policy governs this occurrence. */
+	readonly policed: boolean;
+	/** The value a duplicate diagnostic reports for it. */
+	readonly reported: unknown;
+	/** What the occurrence contributes, in the order it was typed. */
+	items: readonly Occurrence[];
+}
+
+/** Every CLI occurrence of one logical flag, in the order they were typed. */
 interface FlagOccurrences {
-	count: number;
-	readonly values: unknown[];
+	/** The schema the occurrences belong to. */
+	readonly schema: FlagSchema;
+	/** The occurrences, latest last. */
+	readonly occurrences: FlagOccurrence[];
+	/** How many of them the duplicate policy governs. */
+	counted: number;
+}
+
+/**
+ * The occurrence list of one logical flag, started on its first occurrence.
+ *
+ * @param occurrences - Per-parse accumulator keyed by canonical name
+ * @param name - Canonical flag name
+ * @param schema - Flag schema the occurrences belong to
+ * @returns The flag's list
+ */
+function occurrencesOf(
+	occurrences: Map<string, FlagOccurrences>,
+	name: string,
+	schema: FlagSchema,
+): FlagOccurrences {
+	const existing = occurrences.get(name);
+	if (existing !== undefined) return existing;
+	const started: FlagOccurrences = { schema, occurrences: [], counted: 0 };
+	occurrences.set(name, started);
+	return started;
 }
 
 /**
@@ -304,9 +347,9 @@ interface FlagOccurrences {
  * @param occurrences - Per-parse accumulator keyed by canonical name
  * @param name - Canonical flag name
  * @param schema - Flag schema (read for {@link FlagSchema.duplicates})
- * @param value - The occurrence's raw value (or the boolean it implies)
+ * @param reported - The occurrence's raw value (or the boolean it implies)
  * @param displayName - User-facing spelling for error messages
- * @returns `true` when the occurrence should be applied; `false` when the
+ * @returns The recorded occurrence, ready for its items; `undefined` when the
  *   `'first'` policy suppresses it (the token is still consumed)
  * @throws ParseError `DUPLICATE_FLAG` on a repeat under the `'error'` policy
  */
@@ -314,27 +357,66 @@ function recordFlagOccurrence(
 	occurrences: Map<string, FlagOccurrences>,
 	name: string,
 	schema: FlagSchema,
-	value: unknown,
+	reported: unknown,
 	displayName: string,
-): boolean {
-	const record = occurrences.get(name) ?? { count: 0, values: [] };
-	record.count += 1;
-	record.values.push(value);
-	occurrences.set(name, record);
+): FlagOccurrence | undefined {
+	const record = occurrencesOf(occurrences, name, schema);
+	const occurrence: FlagOccurrence = { policed: true, reported, items: [] };
+	record.occurrences.push(occurrence);
+	record.counted += 1;
 
-	if (record.count === 1) return true;
+	if (record.counted === 1) return occurrence;
 	if (schema.duplicates === 'error') {
 		throw new ParseError(`Flag --${name} may only be specified once`, {
 			code: 'DUPLICATE_FLAG',
 			details: {
 				flag: name,
 				input: displayName,
-				count: record.count,
-				values: [...record.values],
+				count: record.counted,
+				values: record.occurrences.filter((entry) => entry.policed).map((entry) => entry.reported),
 			},
 		});
 	}
-	return schema.duplicates !== 'first';
+	return schema.duplicates === 'first' ? undefined : occurrence;
+}
+
+/**
+ * Record one bare occurrence of a count flag.
+ *
+ * A bare `-v` raises the count rather than supplying a value, and the duplicate
+ * policy governs supplied values, so the increment stays outside it.
+ *
+ * @param occurrences - Per-parse accumulator keyed by canonical name
+ * @param name - Canonical flag name
+ * @param schema - Flag schema the occurrence belongs to
+ */
+function recordCountIncrement(
+	occurrences: Map<string, FlagOccurrences>,
+	name: string,
+	schema: FlagSchema,
+): void {
+	occurrencesOf(occurrences, name, schema).occurrences.push({
+		policed: false,
+		reported: undefined,
+		items: [INCREMENT_OCCURRENCE],
+	});
+}
+
+/**
+ * Project every flag's occurrences onto the values a parse result carries.
+ *
+ * @param occurrences - Per-parse accumulator keyed by canonical name
+ * @returns Flag values keyed by canonical name, in first-occurrence order
+ */
+function projectFlags(occurrences: ReadonlyMap<string, FlagOccurrences>): Record<string, unknown> {
+	const flags: Record<string, unknown> = {};
+	for (const [name, record] of occurrences) {
+		flags[name] = projectOccurrences(
+			flagCardinality(record.schema),
+			record.occurrences.flatMap((occurrence) => occurrence.items),
+		);
+	}
+	return flags;
 }
 
 /**
@@ -368,10 +450,6 @@ function isStdinSentinel(raw: string, stdin: StdinBinding | undefined): boolean 
 /**
  * Coerce one raw CLI token to what the flag's value axis declares.
  *
- * The cardinality axis decides what a token IS: one value, one element of a
- * collection, one entry of a record, or an explicit count. The value axis then
- * decides what that token means.
- *
  * @param flagName - Canonical flag name (for error messages)
  * @param raw - Raw string value from argv
  * @param schema - {@link FlagSchema} declaring the expected kind
@@ -385,16 +463,41 @@ function coerceFlagValue(
 	schema: FlagSchema,
 	displayName = `--${flagName}`,
 ): unknown {
-	if (isStdinSentinel(raw, schema.stdin)) return raw;
+	return occurrenceValue(flagTokenOccurrence(flagName, raw, schema, displayName));
+}
+
+/**
+ * Read one raw CLI token of a flag as the occurrence it contributes.
+ *
+ * The cardinality axis decides what a token IS: one value, one element of a
+ * collection, one entry of a record, or an explicit count. The value axis then
+ * decides what that token means. A `-` names the stdin source, so it holds its
+ * position without being decoded.
+ *
+ * @param flagName - Canonical flag name (for error messages)
+ * @param raw - Raw string value from argv
+ * @param schema - {@link FlagSchema} declaring the expected kind
+ * @param displayName - Spelling the user typed
+ * @returns The occurrence the token contributes
+ * @throws ParseError on type mismatch
+ */
+function flagTokenOccurrence(
+	flagName: string,
+	raw: string,
+	schema: FlagSchema,
+	displayName: string,
+): Occurrence {
+	if (isStdinSentinel(raw, schema.stdin)) return STDIN_OCCURRENCE;
 
 	const cardinality = flagCardinality(schema);
 	if (cardinality.kind === 'count') {
-		return coerceCountToken(flagName, raw, displayName);
+		return { kind: 'value', value: coerceCountToken(flagName, raw, displayName) };
 	}
 	if (cardinality.kind === 'entries') {
-		return coerceEntryToken(flagName, raw, schema, displayName);
+		const [key, value] = coerceEntryToken(flagName, raw, schema, displayName);
+		return { kind: 'entry', key, value };
 	}
-	return coerceElementToken(flagName, raw, schema, displayName);
+	return { kind: 'value', value: coerceElementToken(flagName, raw, schema, displayName) };
 }
 
 /** Decode one token through the flag's element value axis. */
@@ -556,16 +659,18 @@ function flagValueError(
 }
 
 /**
- * Coerce a raw string to the arg's declared kind.
+ * Read one raw positional token as the occurrence it contributes.
+ *
+ * A `-` names the stdin source, so it holds its position without being decoded.
  *
  * @param argName - Positional arg name (for error messages)
  * @param raw - Raw string value from argv
  * @param schema - {@link ArgSchema} declaring the expected kind
- * @returns Coerced value matching the schema's kind
+ * @returns The occurrence the token contributes
  * @throws ParseError on type mismatch or custom parse failure
  */
-function coerceArgValue(argName: string, raw: string, schema: ArgSchema): unknown {
-	if (isStdinSentinel(raw, schema.stdin)) return raw;
+function argTokenOccurrence(argName: string, raw: string, schema: ArgSchema): Occurrence {
+	if (isStdinSentinel(raw, schema.stdin)) return STDIN_OCCURRENCE;
 
 	if (argCardinality(schema).kind === 'entries') {
 		const pair = splitEntryPair(raw);
@@ -575,10 +680,10 @@ function coerceArgValue(argName: string, raw: string, schema: ArgSchema): unknow
 				details: { arg: argName, value: raw, expected: 'key=value' },
 			});
 		}
-		return [pair[0], decodeArgToken(argName, pair[1], schema)];
+		return { kind: 'entry', key: pair[0], value: decodeArgToken(argName, pair[1], schema) };
 	}
 
-	return decodeArgToken(argName, raw, schema);
+	return { kind: 'value', value: decodeArgToken(argName, raw, schema) };
 }
 
 /** Decode one token through the arg's element value axis. */
@@ -638,8 +743,7 @@ function parse(
 	const tokens = tokenize(argv);
 	const flagLookup = buildFlagLookup(schema.flags, options);
 
-	// Mutable accumulators — frozen in the result
-	const flags: Record<string, unknown> = {};
+	// Mutable accumulators — projected into the result
 	const positionals: string[] = [];
 	const occurrences = new Map<string, FlagOccurrences>();
 
@@ -660,18 +764,18 @@ function parse(
 		}
 
 		if (token.kind === 'long-flag') {
-			i = parseLongFlag(token, tokens, i, flagLookup, flags, occurrences);
+			i = parseLongFlag(token, tokens, i, flagLookup, occurrences);
 			continue;
 		}
 
 		// token.kind === 'short-flags'
-		i = parseShortFlags(token, tokens, i, flagLookup, flags, occurrences);
+		i = parseShortFlags(token, tokens, i, flagLookup, occurrences);
 	}
 
 	// Map positionals to named args
 	const args = mapPositionals(schema.args, positionals);
 
-	return { flags, args };
+	return { flags: projectFlags(occurrences), args };
 }
 
 // --- Long flag parsing
@@ -683,8 +787,7 @@ function parse(
  * @param tokens - Full token array (for lookahead)
  * @param startIdx - Current index of `token` in the array
  * @param flagLookup - Spelling → {@link FlagLookupEntry} map from {@link buildFlagLookup}
- * @param flags - Mutable accumulator for resolved flag values
- * @param occurrences - Per-parse duplicate-occurrence accumulator
+ * @param occurrences - Per-parse occurrence accumulator
  * @returns Next index to continue parsing from
  */
 function parseLongFlag(
@@ -692,7 +795,6 @@ function parseLongFlag(
 	tokens: readonly Token[],
 	startIdx: number,
 	flagLookup: ReadonlyMap<string, FlagLookupEntry>,
-	flags: Record<string, unknown>,
 	occurrences: Map<string, FlagOccurrences>,
 ): number {
 	const entry = flagLookup.get(token.name);
@@ -719,32 +821,55 @@ function parseLongFlag(
 				details: { flag: canonicalName, input: token.name, value: token.value },
 			});
 		}
-		if (recordFlagOccurrence(occurrences, canonicalName, flagSchema, false, displayName)) {
-			flags[canonicalName] = false;
-		}
+		const occurrence = recordFlagOccurrence(
+			occurrences,
+			canonicalName,
+			flagSchema,
+			false,
+			displayName,
+		);
+		if (occurrence !== undefined) occurrence.items = [NEGATED_OCCURRENCE];
 		return startIdx + 1;
 	}
 
 	if (!flagExpectsValue(flagSchema)) {
 		// Boolean or count flag — consumes no value token
 		if (token.value !== undefined) {
-			const coerced = coerceFlagValue(canonicalName, token.value, flagSchema, displayName);
-			if (recordFlagOccurrence(occurrences, canonicalName, flagSchema, coerced, displayName)) {
-				flags[canonicalName] = coerced;
-			}
+			const item = flagTokenOccurrence(canonicalName, token.value, flagSchema, displayName);
+			const occurrence = recordFlagOccurrence(
+				occurrences,
+				canonicalName,
+				flagSchema,
+				occurrenceValue(item),
+				displayName,
+			);
+			if (occurrence !== undefined) occurrence.items = [item];
 		} else if (flagSchema.kind === 'count') {
-			const existing = flags[canonicalName];
-			flags[canonicalName] = (typeof existing === 'number' ? existing : 0) + 1;
-		} else if (recordFlagOccurrence(occurrences, canonicalName, flagSchema, true, displayName)) {
-			flags[canonicalName] = true;
+			recordCountIncrement(occurrences, canonicalName, flagSchema);
+		} else {
+			const occurrence = recordFlagOccurrence(
+				occurrences,
+				canonicalName,
+				flagSchema,
+				true,
+				displayName,
+			);
+			if (occurrence !== undefined) occurrence.items = [{ kind: 'value', value: true }];
 		}
 		return startIdx + 1;
 	}
 
 	if (token.value !== undefined) {
 		// --flag=value (inline)
-		if (recordFlagOccurrence(occurrences, canonicalName, flagSchema, token.value, displayName)) {
-			setFlagValue(flags, canonicalName, flagSchema, token.value);
+		const occurrence = recordFlagOccurrence(
+			occurrences,
+			canonicalName,
+			flagSchema,
+			token.value,
+			displayName,
+		);
+		if (occurrence !== undefined) {
+			occurrence.items = flagTokenOccurrences(canonicalName, flagSchema, token.value);
 		}
 		return startIdx + 1;
 	}
@@ -757,8 +882,20 @@ function parseLongFlag(
 			details: { flag: canonicalName, input: token.name, kind: flagSchema.kind },
 		});
 	}
-	if (recordFlagOccurrence(occurrences, canonicalName, flagSchema, nextToken.value, displayName)) {
-		setFlagValue(flags, canonicalName, flagSchema, nextToken.value, displayName);
+	const occurrence = recordFlagOccurrence(
+		occurrences,
+		canonicalName,
+		flagSchema,
+		nextToken.value,
+		displayName,
+	);
+	if (occurrence !== undefined) {
+		occurrence.items = flagTokenOccurrences(
+			canonicalName,
+			flagSchema,
+			nextToken.value,
+			displayName,
+		);
 	}
 	return startIdx + 2;
 }
@@ -772,8 +909,7 @@ function parseLongFlag(
  * @param tokens - Full token array (for lookahead)
  * @param startIdx - Current index of `token` in the array
  * @param flagLookup - Spelling → {@link FlagLookupEntry} map from {@link buildFlagLookup}
- * @param flags - Mutable accumulator for resolved flag values
- * @param occurrences - Per-parse duplicate-occurrence accumulator
+ * @param occurrences - Per-parse occurrence accumulator
  * @returns Next index to continue parsing from
  */
 function parseShortFlags(
@@ -781,7 +917,6 @@ function parseShortFlags(
 	tokens: readonly Token[],
 	startIdx: number,
 	flagLookup: ReadonlyMap<string, FlagLookupEntry>,
-	flags: Record<string, unknown>,
 	occurrences: Map<string, FlagOccurrences>,
 ): number {
 	const { chars } = token;
@@ -803,10 +938,16 @@ function parseShortFlags(
 		if (!flagExpectsValue(flagSchema)) {
 			// Boolean or count short flag — consumes no value
 			if (flagSchema.kind === 'count') {
-				const existing = flags[canonicalName];
-				flags[canonicalName] = (typeof existing === 'number' ? existing : 0) + 1;
-			} else if (recordFlagOccurrence(occurrences, canonicalName, flagSchema, true, displayName)) {
-				flags[canonicalName] = true;
+				recordCountIncrement(occurrences, canonicalName, flagSchema);
+			} else {
+				const occurrence = recordFlagOccurrence(
+					occurrences,
+					canonicalName,
+					flagSchema,
+					true,
+					displayName,
+				);
+				if (occurrence !== undefined) occurrence.items = [{ kind: 'value', value: true }];
 			}
 			continue;
 		}
@@ -815,8 +956,20 @@ function parseShortFlags(
 			// Value-expecting flag in the middle of combined shorts:
 			// -oFile → -o with value "File" (rest of chars is the value)
 			const inlineValue = chars.slice(ci + 1);
-			if (recordFlagOccurrence(occurrences, canonicalName, flagSchema, inlineValue, displayName)) {
-				setFlagValue(flags, canonicalName, flagSchema, inlineValue, displayName);
+			const occurrence = recordFlagOccurrence(
+				occurrences,
+				canonicalName,
+				flagSchema,
+				inlineValue,
+				displayName,
+			);
+			if (occurrence !== undefined) {
+				occurrence.items = flagTokenOccurrences(
+					canonicalName,
+					flagSchema,
+					inlineValue,
+					displayName,
+				);
 			}
 			break; // consumed all remaining chars
 		}
@@ -829,10 +982,20 @@ function parseShortFlags(
 				details: { flag: canonicalName, input: ch, kind: flagSchema.kind },
 			});
 		}
-		if (
-			recordFlagOccurrence(occurrences, canonicalName, flagSchema, nextToken.value, displayName)
-		) {
-			setFlagValue(flags, canonicalName, flagSchema, nextToken.value, displayName);
+		const occurrence = recordFlagOccurrence(
+			occurrences,
+			canonicalName,
+			flagSchema,
+			nextToken.value,
+			displayName,
+		);
+		if (occurrence !== undefined) {
+			occurrence.items = flagTokenOccurrences(
+				canonicalName,
+				flagSchema,
+				nextToken.value,
+				displayName,
+			);
 		}
 		nextIdx++;
 	}
@@ -840,46 +1003,38 @@ function parseShortFlags(
 	return nextIdx;
 }
 
-// --- Flag value setter (handles collection accumulation)
+// --- Flag value tokens (one occurrence, one or more elements)
 
 /**
- * Set or accumulate a flag value.
+ * Read one value token of a flag as the occurrences it contributes.
  *
  * A collection keeps its CLI occurrences in the order they were typed, elements
  * for `many` and `[key, value]` pairs for `entries`. Aggregation happens during
  * resolution, where the stdin buffer an occurrence of `-` stands for is spliced
  * into that order.
  *
- * @param flags - Mutable accumulator for resolved flag values
  * @param name - Canonical flag name
  * @param schema - {@link FlagSchema} declaring the expected kind
  * @param rawValue - Raw string value from argv
  * @param displayName - Spelling the user typed
+ * @returns The occurrences the token contributes, in order
  */
-function setFlagValue(
-	flags: Record<string, unknown>,
+function flagTokenOccurrences(
 	name: string,
 	schema: FlagSchema,
 	rawValue: string,
 	displayName = `--${name}`,
-): void {
+): readonly Occurrence[] {
 	const cardinality = flagCardinality(schema);
 	if (!isCollection(cardinality)) {
-		flags[name] = coerceFlagValue(name, rawValue, schema, displayName);
-		return;
+		return [flagTokenOccurrence(name, rawValue, schema, displayName)];
 	}
 
 	// One occurrence may carry several elements (--tag a,b); each is coerced
 	// individually so errors name the offending element, not the whole token.
-	const coerced = splitCliToken(cardinality.splitting.cli, rawValue, schema).map((part) =>
-		coerceFlagValue(name, part, schema, displayName),
+	return splitCliToken(cardinality.splitting.cli, rawValue, schema).map((part) =>
+		flagTokenOccurrence(name, part, schema, displayName),
 	);
-	const existing = flags[name];
-	if (Array.isArray(existing)) {
-		existing.push(...coerced);
-	} else {
-		flags[name] = coerced;
-	}
 }
 
 /**
@@ -934,19 +1089,20 @@ function mapPositionals(
 				cardinality.kind === 'many' || cardinality.kind === 'entries'
 					? cardinality.splitting.cli
 					: WHOLE_TOKEN;
-			args[entry.name] = remaining.flatMap((raw) =>
+			const occurrences = remaining.flatMap((raw) =>
 				splitCliToken(policy, raw, { stdin: entry.schema.stdin }).map((part) =>
-					coerceArgValue(entry.name, part, entry.schema),
+					argTokenOccurrence(entry.name, part, entry.schema),
 				),
 			);
+			args[entry.name] = projectOccurrences(cardinality, occurrences);
 			posIdx = positionals.length;
 			break;
 		}
 
 		const rawPositional = positionals[posIdx];
 		if (rawPositional !== undefined) {
-			const coerced = coerceArgValue(entry.name, rawPositional, entry.schema);
-			args[entry.name] = cardinality.kind === 'entries' ? [coerced] : coerced;
+			const occurrence = argTokenOccurrence(entry.name, rawPositional, entry.schema);
+			args[entry.name] = projectOccurrences(cardinality, [occurrence]);
 			posIdx++;
 		}
 		// If no positional available, leave absent (resolution/validation handles defaults/required)

--- a/src/core/parse/occurrences.test.ts
+++ b/src/core/parse/occurrences.test.ts
@@ -45,6 +45,7 @@ describe('occurrenceValue', () => {
 		expect(occurrenceValue({ kind: 'entry', key: 'A', value: '1' })).toEqual(['A', '1']);
 		expect(occurrenceValue(STDIN_OCCURRENCE)).toBe('-');
 		expect(occurrenceValue(NEGATED_OCCURRENCE)).toBe(false);
+		expect(occurrenceValue(INCREMENT_OCCURRENCE)).toBe(1);
 		expect(occurrenceValue({ kind: 'aggregated', value: { A: '1' } })).toEqual({ A: '1' });
 	});
 });
@@ -191,6 +192,15 @@ describe('readAggregated', () => {
 	it('names nothing for occurrences the parser produced', () => {
 		expect(readAggregated([{ kind: 'value', value: 7 }])).toBeUndefined();
 		expect(readAggregated([])).toBeUndefined();
+	});
+
+	it('names nothing when an aggregate sits beside another occurrence', () => {
+		expect(
+			readAggregated([
+				{ kind: 'aggregated', value: 7 },
+				{ kind: 'value', value: 8 },
+			]),
+		).toBeUndefined();
 	});
 });
 

--- a/src/core/parse/occurrences.test.ts
+++ b/src/core/parse/occurrences.test.ts
@@ -37,6 +37,8 @@ function collection(
 const MANY_COLLECTION = collection(MANY);
 const ENTRIES_COLLECTION = collection(ENTRIES);
 
+// === Projection
+
 describe('occurrenceValue', () => {
 	it('reads each kind as the value a parse result carries', () => {
 		expect(occurrenceValue({ kind: 'value', value: 42 })).toBe(42);
@@ -46,6 +48,8 @@ describe('occurrenceValue', () => {
 		expect(occurrenceValue({ kind: 'aggregated', value: { A: '1' } })).toEqual({ A: '1' });
 	});
 });
+
+// --- Scalar projection
 
 describe('projectOccurrences, one', () => {
 	it('keeps the last occurrence', () => {
@@ -75,6 +79,8 @@ describe('projectOccurrences, one', () => {
 	});
 });
 
+// --- Count projection
+
 describe('projectOccurrences, count', () => {
 	it('adds one per bare occurrence', () => {
 		expect(
@@ -94,6 +100,8 @@ describe('projectOccurrences, count', () => {
 		expect(projectOccurrences(COUNT, [])).toBeUndefined();
 	});
 });
+
+// --- Collection projection
 
 describe('projectOccurrences, collections', () => {
 	it('keeps every element in the order it was typed', () => {
@@ -123,6 +131,8 @@ describe('projectOccurrences, collections', () => {
 		expect(projectOccurrences(ENTRIES, [])).toEqual([]);
 	});
 });
+
+// === Lifting
 
 describe('liftOccurrences', () => {
 	it('round-trips what a projection produced', () => {
@@ -171,6 +181,8 @@ describe('liftOccurrences', () => {
 	});
 });
 
+// === Aggregation
+
 describe('readAggregated', () => {
 	it('names the aggregate a caller supplied', () => {
 		expect(readAggregated([{ kind: 'aggregated', value: 7 }])).toEqual({ value: 7 });
@@ -181,6 +193,8 @@ describe('readAggregated', () => {
 		expect(readAggregated([])).toBeUndefined();
 	});
 });
+
+// === Entry pairs
 
 describe('entryPairsOf', () => {
 	it('keeps every entry in order and drops the rest', () => {

--- a/src/core/parse/occurrences.test.ts
+++ b/src/core/parse/occurrences.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The occurrence representation itself: what a list projects to, and what a
+ * parse result lifts back to.
+ *
+ * @module dreamcli/core/parse/occurrences.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Cardinality } from '#internals/core/schema/cardinality.ts';
+import { flagCardinality } from '#internals/core/schema/cardinality.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import type { Occurrence } from './occurrences.ts';
+import {
+	entryPairsOf,
+	INCREMENT_OCCURRENCE,
+	liftOccurrences,
+	NEGATED_OCCURRENCE,
+	occurrenceValue,
+	projectOccurrences,
+	readAggregated,
+	STDIN_OCCURRENCE,
+} from './occurrences.ts';
+
+const ONE: Cardinality = flagCardinality(flag.string().schema);
+const COUNT: Cardinality = flagCardinality(flag.count().schema);
+const MANY = flagCardinality(flag.array(flag.string()).schema);
+const ENTRIES = flagCardinality(flag.keyValue().schema);
+
+/** Narrow a cardinality to the collection arm the lift accepts. */
+function collection(
+	cardinality: Cardinality,
+): Extract<Cardinality, { kind: 'many' } | { kind: 'entries' }> {
+	if (cardinality.kind === 'many' || cardinality.kind === 'entries') return cardinality;
+	throw new Error(`expected a collection, got ${cardinality.kind}`);
+}
+
+const MANY_COLLECTION = collection(MANY);
+const ENTRIES_COLLECTION = collection(ENTRIES);
+
+describe('occurrenceValue', () => {
+	it('reads each kind as the value a parse result carries', () => {
+		expect(occurrenceValue({ kind: 'value', value: 42 })).toBe(42);
+		expect(occurrenceValue({ kind: 'entry', key: 'A', value: '1' })).toEqual(['A', '1']);
+		expect(occurrenceValue(STDIN_OCCURRENCE)).toBe('-');
+		expect(occurrenceValue(NEGATED_OCCURRENCE)).toBe(false);
+		expect(occurrenceValue({ kind: 'aggregated', value: { A: '1' } })).toEqual({ A: '1' });
+	});
+});
+
+describe('projectOccurrences, one', () => {
+	it('keeps the last occurrence', () => {
+		expect(
+			projectOccurrences(ONE, [
+				{ kind: 'value', value: 'us' },
+				{ kind: 'value', value: 'eu' },
+			]),
+		).toBe('eu');
+	});
+
+	it('reads a negation as false', () => {
+		expect(projectOccurrences(ONE, [{ kind: 'value', value: true }, NEGATED_OCCURRENCE])).toBe(
+			false,
+		);
+		expect(projectOccurrences(ONE, [NEGATED_OCCURRENCE, { kind: 'value', value: true }])).toBe(
+			true,
+		);
+	});
+
+	it('keeps the sentinel for the resolver to read', () => {
+		expect(projectOccurrences(ONE, [STDIN_OCCURRENCE])).toBe('-');
+	});
+
+	it('produces nothing without an occurrence', () => {
+		expect(projectOccurrences(ONE, [])).toBeUndefined();
+	});
+});
+
+describe('projectOccurrences, count', () => {
+	it('adds one per bare occurrence', () => {
+		expect(
+			projectOccurrences(COUNT, [INCREMENT_OCCURRENCE, INCREMENT_OCCURRENCE, INCREMENT_OCCURRENCE]),
+		).toBe(3);
+	});
+
+	it('lets an explicit value replace the running count', () => {
+		expect(projectOccurrences(COUNT, [INCREMENT_OCCURRENCE, { kind: 'value', value: 2 }])).toBe(2);
+	});
+
+	it('resumes counting from an explicit value', () => {
+		expect(projectOccurrences(COUNT, [{ kind: 'value', value: 2 }, INCREMENT_OCCURRENCE])).toBe(3);
+	});
+
+	it('produces nothing without an occurrence', () => {
+		expect(projectOccurrences(COUNT, [])).toBeUndefined();
+	});
+});
+
+describe('projectOccurrences, collections', () => {
+	it('keeps every element in the order it was typed', () => {
+		expect(
+			projectOccurrences(MANY, [
+				{ kind: 'value', value: 'a' },
+				STDIN_OCCURRENCE,
+				{ kind: 'value', value: 'b' },
+			]),
+		).toEqual(['a', '-', 'b']);
+	});
+
+	it('keeps entries as ordered pairs rather than folding them', () => {
+		expect(
+			projectOccurrences(ENTRIES, [
+				{ kind: 'entry', key: 'A', value: '1' },
+				{ kind: 'entry', key: 'A', value: '2' },
+			]),
+		).toEqual([
+			['A', '1'],
+			['A', '2'],
+		]);
+	});
+
+	it('produces an empty collection without an occurrence', () => {
+		expect(projectOccurrences(MANY, [])).toEqual([]);
+		expect(projectOccurrences(ENTRIES, [])).toEqual([]);
+	});
+});
+
+describe('liftOccurrences', () => {
+	it('round-trips what a projection produced', () => {
+		const occurrences: readonly Occurrence[] = [
+			{ kind: 'value', value: 'a' },
+			STDIN_OCCURRENCE,
+			{ kind: 'value', value: 'b' },
+		];
+		const projected = projectOccurrences(MANY, occurrences);
+		expect(liftOccurrences(MANY_COLLECTION, projected, true)).toEqual(occurrences);
+	});
+
+	it('round-trips a projected entries list', () => {
+		const occurrences: readonly Occurrence[] = [
+			{ kind: 'entry', key: 'A', value: '1' },
+			STDIN_OCCURRENCE,
+		];
+		const projected = projectOccurrences(ENTRIES, occurrences);
+		expect(liftOccurrences(ENTRIES_COLLECTION, projected, true)).toEqual(occurrences);
+	});
+
+	it('reads a dash as an element when the input never reads stdin', () => {
+		expect(liftOccurrences(MANY_COLLECTION, ['-'], false)).toEqual([{ kind: 'value', value: '-' }]);
+	});
+
+	it('keeps a pair-shaped element of a many collection as one element', () => {
+		expect(liftOccurrences(MANY_COLLECTION, [['A', '1']], false)).toEqual([
+			{ kind: 'value', value: ['A', '1'] },
+		]);
+	});
+
+	it('reads an element that is not a pair as a value inside an entries collection', () => {
+		expect(liftOccurrences(ENTRIES_COLLECTION, ['junk', [1, 'v']], false)).toEqual([
+			{ kind: 'value', value: 'junk' },
+			{ kind: 'value', value: [1, 'v'] },
+		]);
+	});
+
+	it('holds an aggregate a caller built by hand as one occurrence', () => {
+		expect(liftOccurrences(ENTRIES_COLLECTION, { A: '1' }, false)).toEqual([
+			{ kind: 'aggregated', value: { A: '1' } },
+		]);
+		expect(liftOccurrences(MANY_COLLECTION, 'a,b', false)).toEqual([
+			{ kind: 'aggregated', value: 'a,b' },
+		]);
+	});
+});
+
+describe('readAggregated', () => {
+	it('names the aggregate a caller supplied', () => {
+		expect(readAggregated([{ kind: 'aggregated', value: 7 }])).toEqual({ value: 7 });
+	});
+
+	it('names nothing for occurrences the parser produced', () => {
+		expect(readAggregated([{ kind: 'value', value: 7 }])).toBeUndefined();
+		expect(readAggregated([])).toBeUndefined();
+	});
+});
+
+describe('entryPairsOf', () => {
+	it('keeps every entry in order and drops the rest', () => {
+		expect(
+			entryPairsOf([
+				{ kind: 'entry', key: 'A', value: '1' },
+				{ kind: 'value', value: 'junk' },
+				{ kind: 'entry', key: 'B', value: '2' },
+			]),
+		).toEqual([
+			['A', '1'],
+			['B', '2'],
+		]);
+	});
+});

--- a/src/core/parse/occurrences.ts
+++ b/src/core/parse/occurrences.ts
@@ -1,0 +1,186 @@
+/**
+ * What the command line produced for one input, in the order it was typed.
+ *
+ * The parser keeps every occurrence of an input as its own {@link Occurrence}:
+ * a decoded value token, a `KEY=VALUE` entry, the position a stdin sentinel
+ * holds, a negated spelling, or one increment of a count. Nothing folds while
+ * argv is being read. {@link projectOccurrences} turns a list into the value a
+ * parse result carries, and {@link liftOccurrences} reads such a value back as
+ * occurrences, so a caller-built parse result and a parsed one aggregate
+ * through the same list.
+ *
+ * @module dreamcli/core/parse/occurrences
+ * @internal
+ */
+
+import type { Cardinality } from '#internals/core/schema/cardinality.ts';
+
+/** The stdin selector, which names a source rather than a value. */
+const STDIN_SENTINEL = '-';
+
+/**
+ * One occurrence of an input on the command line.
+ *
+ * - `'value'`: one decoded value, or one element of a collection
+ * - `'entry'`: one decoded `KEY=VALUE` pair
+ * - `'stdin'`: the position a `-` selector holds
+ * - `'negated'`: a `--no-x` spelling
+ * - `'increment'`: one bare occurrence of a count flag
+ * - `'aggregated'`: a value a caller aggregated before the resolver saw it
+ */
+type Occurrence =
+	| { readonly kind: 'value'; readonly value: unknown }
+	| { readonly kind: 'entry'; readonly key: string; readonly value: unknown }
+	| { readonly kind: 'stdin' }
+	| { readonly kind: 'negated' }
+	| { readonly kind: 'increment' }
+	| { readonly kind: 'aggregated'; readonly value: unknown };
+
+/** The sentinel occurrence, shared by every `-` position. */
+const STDIN_OCCURRENCE: Occurrence = { kind: 'stdin' };
+
+/** The negated occurrence, shared by every `--no-x` spelling. */
+const NEGATED_OCCURRENCE: Occurrence = { kind: 'negated' };
+
+/** One bare occurrence of a count flag. */
+const INCREMENT_OCCURRENCE: Occurrence = { kind: 'increment' };
+
+/**
+ * The value one occurrence stands for in a parse result.
+ *
+ * @param occurrence - The occurrence to read.
+ * @returns What a parse result carries for it.
+ */
+function occurrenceValue(occurrence: Occurrence): unknown {
+	switch (occurrence.kind) {
+		case 'value':
+			return occurrence.value;
+		case 'entry':
+			return [occurrence.key, occurrence.value];
+		case 'stdin':
+			return STDIN_SENTINEL;
+		case 'negated':
+			return false;
+		case 'increment':
+			return 1;
+		case 'aggregated':
+			return occurrence.value;
+	}
+}
+
+/**
+ * Project one input's occurrences onto the value a parse result carries.
+ *
+ * A scalar keeps its last occurrence, a count folds its increments and its
+ * explicit values, and a collection keeps every occurrence in order for the
+ * resolver to aggregate.
+ *
+ * @param cardinality - How the input's values combine.
+ * @param occurrences - Every occurrence of the input, in order.
+ * @returns The parse result's value for it.
+ */
+function projectOccurrences(cardinality: Cardinality, occurrences: readonly Occurrence[]): unknown {
+	if (cardinality.kind === 'count') {
+		return projectCount(occurrences);
+	}
+	if (cardinality.kind === 'one') {
+		const last = occurrences[occurrences.length - 1];
+		return last === undefined ? undefined : occurrenceValue(last);
+	}
+	return occurrences.map(occurrenceValue);
+}
+
+/** Fold a count flag's increments and explicit values in occurrence order. */
+function projectCount(occurrences: readonly Occurrence[]): unknown {
+	let count: unknown;
+	for (const occurrence of occurrences) {
+		count =
+			occurrence.kind === 'increment'
+				? (typeof count === 'number' ? count : 0) + 1
+				: occurrenceValue(occurrence);
+	}
+	return count;
+}
+
+/**
+ * Read what a parse result carries for a collection back as occurrences.
+ *
+ * A value the parser did not leave as a list is an aggregate a caller built by
+ * hand, so it stays one opaque occurrence and reaches the resolved value
+ * untouched.
+ *
+ * @param cardinality - The `many` or `entries` axis being filled.
+ * @param value - What the parse result carries.
+ * @param readsOnDash - Whether the input's stdin binding reacts to `-`.
+ * @returns The occurrences behind that value.
+ */
+function liftOccurrences(
+	cardinality: Extract<Cardinality, { kind: 'many' } | { kind: 'entries' }>,
+	value: unknown,
+	readsOnDash: boolean,
+): readonly Occurrence[] {
+	if (!Array.isArray(value)) return [{ kind: 'aggregated', value }];
+	return value.map((element: unknown) => liftElement(cardinality, element, readsOnDash));
+}
+
+/** Read one element of a parse result's collection as its occurrence. */
+function liftElement(
+	cardinality: Extract<Cardinality, { kind: 'many' } | { kind: 'entries' }>,
+	element: unknown,
+	readsOnDash: boolean,
+): Occurrence {
+	if (readsOnDash && element === STDIN_SENTINEL) return STDIN_OCCURRENCE;
+	if (cardinality.kind === 'entries') {
+		const pair = entryPairOf(element);
+		if (pair !== undefined) return { kind: 'entry', key: pair[0], value: pair[1] };
+	}
+	return { kind: 'value', value: element };
+}
+
+/** Read one element as the `[key, value]` pair an entry occurrence carries. */
+function entryPairOf(element: unknown): readonly [string, unknown] | undefined {
+	if (!Array.isArray(element) || element.length !== 2) return undefined;
+	const key: unknown = element[0];
+	const value: unknown = element[1];
+	return typeof key === 'string' ? [key, value] : undefined;
+}
+
+/**
+ * The aggregate a caller supplied ready-made.
+ *
+ * @param occurrences - One input's occurrences.
+ * @returns The aggregate, or `undefined` when the occurrences are the parser's.
+ */
+function readAggregated(
+	occurrences: readonly Occurrence[],
+): { readonly value: unknown } | undefined {
+	const only = occurrences.length === 1 ? occurrences[0] : undefined;
+	return only?.kind === 'aggregated' ? { value: only.value } : undefined;
+}
+
+/**
+ * The pairs an `entries` collection folds, in occurrence order.
+ *
+ * @param occurrences - The occurrences left after splicing.
+ * @returns Every pair among them.
+ */
+function entryPairsOf(occurrences: readonly Occurrence[]): readonly (readonly [string, unknown])[] {
+	const pairs: (readonly [string, unknown])[] = [];
+	for (const occurrence of occurrences) {
+		if (occurrence.kind === 'entry') pairs.push([occurrence.key, occurrence.value]);
+	}
+	return pairs;
+}
+
+export type { Occurrence };
+export {
+	entryPairsOf,
+	INCREMENT_OCCURRENCE,
+	liftOccurrences,
+	NEGATED_OCCURRENCE,
+	occurrenceValue,
+	projectOccurrences,
+	readAggregated,
+	STDIN_OCCURRENCE,
+	STDIN_SENTINEL,
+};

--- a/src/core/parse/occurrences.ts
+++ b/src/core/parse/occurrences.ts
@@ -14,9 +14,7 @@
  */
 
 import type { Cardinality } from '#internals/core/schema/cardinality.ts';
-
-/** The stdin selector, which names a source rather than a value. */
-const STDIN_SENTINEL = '-';
+import { STDIN_SENTINEL } from '#internals/core/schema/source.ts';
 
 /**
  * One occurrence of an input on the command line.

--- a/src/core/parse/parse.test.ts
+++ b/src/core/parse/parse.test.ts
@@ -437,6 +437,17 @@ describe('parse', () => {
 			expect(result.args.files).toEqual(['a.ts', 'b.ts', 'c.ts']);
 		});
 
+		it('splits a non-variadic key-value arg with its CLI separator', () => {
+			const schema = makeSchema({
+				args: [{ name: 'vars', schema: createArgSchema('keyValue', { separator: ',' }) }],
+			});
+			const result = parse(schema, ['A=1,B=2']);
+			expect(result.args.vars).toEqual([
+				['A', '1'],
+				['B', '2'],
+			]);
+		});
+
 		it('variadic arg with no remaining positionals produces empty array', () => {
 			const schema = makeSchema({
 				args: [

--- a/src/core/read-flags/read-flags-stdin.test.ts
+++ b/src/core/read-flags/read-flags-stdin.test.ts
@@ -123,4 +123,38 @@ describe('readFlags() stdin contract', () => {
 
 		expect(values.enabled).toBe(true);
 	});
+
+	it('trims a piped value when the binding asks for it', async () => {
+		const host = countingAdapter({ stdinData: 'piped\n' });
+
+		const values = await readFlags(
+			{ body: flag.string().stdin({ trim: true }) },
+			{ argv: [], adapter: host.adapter },
+		);
+
+		expect(values.body).toBe('piped');
+	});
+
+	it('splices a dash occurrence into a collection the way a command does', async () => {
+		const host = countingAdapter({ stdinData: 'a\nb\n' });
+
+		const values = await readFlags(
+			{ tag: flag.array(flag.string()).stdin() },
+			{ argv: ['--tag', 'before', '--tag', '-'], adapter: host.adapter },
+		);
+
+		expect(values.tag).toEqual(['before', 'a', 'b']);
+		expect(host.reads()).toBe(1);
+	});
+
+	it('fails on a dash occurrence with nothing piped', async () => {
+		const host = countingAdapter();
+
+		await expect(
+			readFlags(
+				{ tag: flag.array(flag.string()).stdin() },
+				{ argv: ['--tag', 'a', '--tag', '-'], adapter: host.adapter },
+			),
+		).rejects.toThrow("No piped stdin for the '-' occurrence of flag --tag");
+	});
 });

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -22,12 +22,12 @@ a source the projection omits is a source no stage can produce.
 | `index.ts`       |   130 | `resolve()` — orchestrates the chain, then the Standard Schema pass           |
 | `stages.ts`      |   249 | `runStages()` — one `SourceBinding` per stage, shared by both surfaces        |
 | `flags.ts`       |   376 | `resolveFlags()` — two-pass walk over each flag's source bindings             |
-| `args.ts`        |   277 | `resolveArgs()` — single-pass walk over each arg's bindings, then path checks |
-| `coerce.ts`      |  1015 | `coerceValue()` — unified raw value -> flag's declared kind                   |
+| `args.ts`        |   275 | `resolveArgs()` — single-pass walk over each arg's bindings, then path checks |
+| `coerce.ts`      |  1159 | `coerceValue()` — unified raw value -> flag's declared kind                   |
 | `path-checks.ts` |   127 | `validatePathChecks()` — shared `flag.path()` / `arg.path()` filesystem pass  |
 | `config.ts`      |    26 | `resolveConfigPath()` — dotted path lookup in config object                   |
 | `errors.ts`      |   227 | Error aggregation + `throwAggregatedErrors()`                                 |
-| `contracts.ts`   |   188 | `ResolveOptions`, `ResolutionProvenance`, `resolverContract`                  |
+| `contracts.ts`   |   198 | `ResolveOptions`, `ResolutionProvenance`, `resolverContract`                  |
 | `standard.ts`    |   254 | Standard Schema v1 validation pass over resolved values                       |
 
 ## KEY FUNCTIONS
@@ -83,6 +83,14 @@ it, so a scalar is unaffected and a collection aggregates in one place.
 `Occurrence[]`. A value the parser did not leave as a list is an aggregate a caller built by hand:
 it lifts to a single `aggregated` occurrence and reaches the resolved value untouched.
 
+Each spliced occurrence keeps the source it came from, `{ kind: 'cli' }` for a typed token and
+`{ kind: 'stdin' }` for one the buffer supplied. `AggregationErrors` takes that source, so a
+duplicate-key message names `from stdin` only for a key the pipe carried and names nothing for a key
+the user typed. `foldEntries()` reports the index of the repeating pair, which is how the source is
+found without re-parsing. A `-` occurrence with no buffer is `dash-without-stdin`: an error when it
+sits beside typed occurrences, and absence when every occurrence is `-`, which keeps the later
+stages reachable.
+
 `valueCoercionError()` owns the flag-facing half. It turns a `ValueFailure` into the message, code,
 details, and suggestion for one source. The value layer never spells a subject, so every
 `--flag`-shaped string in the resolver comes from this file.
@@ -111,6 +119,8 @@ once.
 | `resolve-path-checks.test.ts`     | `flag.path()` / `arg.path()` filesystem checks               |
 | `resolve-standard-schema.test.ts` | Standard Schema v1 validation pass                           |
 | `resolve-cardinality.test.ts`     | Per-source aggregation matrix, splicing, element validation  |
+| `resolve-arg-tail.test.ts`        | Positional tail splicing + which source a duplicate names    |
+| `resolve-stdin-trim.test.ts`      | `.stdin({ trim: true })` across surfaces and entry points    |
 | `resolve-hand-built.test.ts`      | The projection a caller-built `ParseResult` resolves through |
 | `contracts.test.ts`               | Contract verification                                        |
 
@@ -135,7 +145,7 @@ an actionable `suggest`. This mirrors the compile-time `AllowedPromptConfig<C>` 
 
 ## GOTCHAS
 
-- Split from ~940-line monolithic index — `coerce.ts` (1015 lines) is the largest piece
+- Split from ~940-line monolithic index — `coerce.ts` (1159 lines) is the largest piece
 - `ResolveOptions` injects everything: env, config, prompter, answers — never touches `process`
 - Imports `schema/prompt.ts` directly (not through barrel) — circular dep avoidance
 - `DeprecationWarning` structs collected during resolution for deprecated flag/arg usage

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -1,6 +1,6 @@
 # resolve — Flag/arg value resolution chain
 
-Multi-file module (split from monolithic index). 10 source files, ~2400 source lines.
+Multi-file module (split from monolithic index). 10 source files, ~2870 source lines.
 
 ## RESOLUTION ORDER
 
@@ -20,15 +20,15 @@ a source the projection omits is a source no stage can produce.
 | File             | Lines | Purpose                                                                       |
 | ---------------- | ----: | ----------------------------------------------------------------------------- |
 | `index.ts`       |   130 | `resolve()` — orchestrates the chain, then the Standard Schema pass           |
-| `stages.ts`      |   226 | `runStages()` — one `SourceBinding` per stage, shared by both surfaces        |
-| `flags.ts`       |   372 | `resolveFlags()` — two-pass walk over each flag's source bindings             |
-| `args.ts`        |   281 | `resolveArgs()` — single-pass walk over each arg's bindings, then path checks |
-| `coerce.ts`      |   655 | `coerceValue()` — unified raw value -> flag's declared kind                   |
-| `path-checks.ts` |   108 | `validatePathChecks()` — shared `flag.path()` / `arg.path()` filesystem pass  |
+| `stages.ts`      |   249 | `runStages()` — one `SourceBinding` per stage, shared by both surfaces        |
+| `flags.ts`       |   376 | `resolveFlags()` — two-pass walk over each flag's source bindings             |
+| `args.ts`        |   277 | `resolveArgs()` — single-pass walk over each arg's bindings, then path checks |
+| `coerce.ts`      |  1015 | `coerceValue()` — unified raw value -> flag's declared kind                   |
+| `path-checks.ts` |   127 | `validatePathChecks()` — shared `flag.path()` / `arg.path()` filesystem pass  |
 | `config.ts`      |    26 | `resolveConfigPath()` — dotted path lookup in config object                   |
 | `errors.ts`      |   227 | Error aggregation + `throwAggregatedErrors()`                                 |
 | `contracts.ts`   |   188 | `ResolveOptions`, `ResolutionProvenance`, `resolverContract`                  |
-| `standard.ts`    |   177 | Standard Schema v1 validation pass over resolved values                       |
+| `standard.ts`    |   254 | Standard Schema v1 validation pass over resolved values                       |
 
 ## KEY FUNCTIONS
 
@@ -78,6 +78,11 @@ occurrences in the order they were typed, and each `-` occurrence is replaced by
 buffer decodes to under the input's stdin policy. `StageInput.finishCli` is where `cliStage()` calls
 it, so a scalar is unaffected and a collection aggregates in one place.
 
+`spliceCliCollection()` reads what the parse result carries through `liftOccurrences()` in
+`parse/occurrences.ts`, so the splice, the `many` order, and the `entries` fold all consume one
+`Occurrence[]`. A value the parser did not leave as a list is an aggregate a caller built by hand:
+it lifts to a single `aggregated` occurrence and reaches the resolved value untouched.
+
 `valueCoercionError()` owns the flag-facing half. It turns a `ValueFailure` into the message, code,
 details, and suggestion for one source. The value layer never spells a subject, so every
 `--flag`-shaped string in the resolver comes from this file.
@@ -88,7 +93,7 @@ details, and suggestion for one source. The value layer never spells a subject, 
 aggregated `ValidationError` via `throwAggregatedErrors()`. Users see all validation messages at
 once.
 
-## TEST FILES (15, aspect-split)
+## TEST FILES (16, aspect-split)
 
 | File                              | Tests                                                        |
 | --------------------------------- | ------------------------------------------------------------ |
@@ -106,6 +111,7 @@ once.
 | `resolve-path-checks.test.ts`     | `flag.path()` / `arg.path()` filesystem checks               |
 | `resolve-standard-schema.test.ts` | Standard Schema v1 validation pass                           |
 | `resolve-cardinality.test.ts`     | Per-source aggregation matrix, splicing, element validation  |
+| `resolve-hand-built.test.ts`      | The projection a caller-built `ParseResult` resolves through |
 | `contracts.test.ts`               | Contract verification                                        |
 
 ## PROMPT — FLAG KIND COMPATIBILITY
@@ -129,7 +135,7 @@ an actionable `suggest`. This mirrors the compile-time `AllowedPromptConfig<C>` 
 
 ## GOTCHAS
 
-- Split from ~940-line monolithic index — `coerce.ts` (655 lines) is the largest piece
+- Split from ~940-line monolithic index — `coerce.ts` (1015 lines) is the largest piece
 - `ResolveOptions` injects everything: env, config, prompter, answers — never touches `process`
 - Imports `schema/prompt.ts` directly (not through barrel) — circular dep avoidance
 - `DeprecationWarning` structs collected during resolution for deprecated flag/arg usage

--- a/src/core/resolve/args.ts
+++ b/src/core/resolve/args.ts
@@ -12,7 +12,7 @@ import { argCardinality, dedupe } from '#internals/core/schema/cardinality.ts';
 import type { ArgSchema, CommandArgEntry } from '#internals/core/schema/index.ts';
 import type { PromptConfig } from '#internals/core/schema/prompt.ts';
 import type { SourceBinding } from '#internals/core/schema/source.ts';
-import { sourceBindings } from '#internals/core/schema/source.ts';
+import { argCollectedNothing, sourceBindings } from '#internals/core/schema/source.ts';
 import { argValueSchema, valueEnumValues } from '#internals/core/schema/value.ts';
 import { coerceArgValue, finishCliArgValue } from './coerce.ts';
 import type { DeprecationWarning, ResolutionProvenance } from './contracts.ts';
@@ -167,13 +167,11 @@ function stageInput(
 	// inherited method as a supplied positional.
 	const present = Object.hasOwn(parsedArgs, name);
 	const parsedValue = present ? parsedArgs[name] : undefined;
-	// A variadic arg that collected nothing is an absent positional, not an
-	// empty CLI value, so the later stages stay reachable.
-	const collectedNothing =
-		schema.variadic && Array.isArray(parsedValue) && parsedValue.length === 0;
 
 	return {
-		cli: collectedNothing ? { kind: 'absent' } : readCliValue(present, parsedValue, bindings),
+		cli: argCollectedNothing(schema, parsedValue)
+			? { kind: 'absent' }
+			: readCliValue(present, parsedValue, bindings),
 		coerce: (source, raw) => coerceArgValue(name, source, raw, schema),
 		finishCli: (value, stdinData) => finishCliArgValue(name, schema, value, stdinData),
 		runPrompt: async (config) =>

--- a/src/core/resolve/coerce.ts
+++ b/src/core/resolve/coerce.ts
@@ -31,7 +31,6 @@ import {
 } from '#internals/core/schema/cardinality.ts';
 import type { ArgSchema, FlagSchema } from '#internals/core/schema/index.ts';
 import { describeNumberConstraintViolation } from '#internals/core/schema/number-constraints.ts';
-import { STDIN_SENTINEL } from '#internals/core/schema/source.ts';
 import type { StdinBinding } from '#internals/core/schema/stdin.ts';
 import { stdinReadsOnDash } from '#internals/core/schema/stdin.ts';
 import type { StringConstraintViolation } from '#internals/core/schema/string-constraints.ts';
@@ -185,7 +184,7 @@ function trimmedStdinValue(
 	value: ValueSchema,
 ): unknown {
 	if (source.kind !== 'stdin' || stdin?.trim !== true || typeof raw !== 'string') return raw;
-	return keepsStdinTerminator(value.codec) ? stripTerminator(raw) : raw;
+	return keepsStdinTerminator(value) ? stripTerminator(raw) : raw;
 }
 
 /** Read a raw value as a non-negative integer occurrence count. */
@@ -1113,10 +1112,7 @@ function spliceCliCollection(
 		if (entry.occurrence.kind !== 'entry') {
 			return {
 				kind: 'error',
-				error: errors(
-					{ kind: 'shape', expected: 'object' },
-					occurrenceValue(entry.occurrence),
-				),
+				error: errors({ kind: 'shape', expected: 'object' }, occurrenceValue(entry.occurrence)),
 			};
 		}
 		entries.push(entry);

--- a/src/core/resolve/coerce.ts
+++ b/src/core/resolve/coerce.ts
@@ -27,10 +27,12 @@ import {
 	isCollection,
 	splitEntriesText,
 	splitManyText,
+	stripTerminator,
 } from '#internals/core/schema/cardinality.ts';
 import type { ArgSchema, FlagSchema } from '#internals/core/schema/index.ts';
 import { describeNumberConstraintViolation } from '#internals/core/schema/number-constraints.ts';
 import { STDIN_SENTINEL } from '#internals/core/schema/source.ts';
+import type { StdinBinding } from '#internals/core/schema/stdin.ts';
 import { stdinReadsOnDash } from '#internals/core/schema/stdin.ts';
 import type { StringConstraintViolation } from '#internals/core/schema/string-constraints.ts';
 import {
@@ -43,8 +45,17 @@ import type {
 	ValueSchema,
 	ValueTypeName,
 } from '#internals/core/schema/value.ts';
-import { argValueSchema, decodeValue, flagValueSchema } from '#internals/core/schema/value.ts';
-import type { ArgDiagnosticSource, FlagDiagnosticSource } from './contracts.ts';
+import {
+	argValueSchema,
+	decodeValue,
+	flagValueSchema,
+	keepsStdinTerminator,
+} from '#internals/core/schema/value.ts';
+import type {
+	ArgDiagnosticSource,
+	FlagDiagnosticSource,
+	ResolutionDiagnosticSource,
+} from './contracts.ts';
 
 type CoerceSource = FlagDiagnosticSource;
 
@@ -135,7 +146,13 @@ function coerceValue(
 		return coerceCount(flagName, source, raw);
 	}
 	if (cardinality.kind === 'one') {
-		return coerceValueSchema(flagName, source, raw, flagValueSchema(schema));
+		const value = flagValueSchema(schema);
+		return coerceValueSchema(
+			flagName,
+			source,
+			trimmedStdinValue(schema.stdin, source, raw, value),
+			value,
+		);
 	}
 	return coerceCollection(
 		cardinality,
@@ -143,7 +160,32 @@ function coerceValue(
 		raw,
 		(element) => coerceValueSchema(flagName, source, element, flagValueSchema(schema)),
 		flagCollectionErrors(flagName, source),
+		flagAggregationErrors(flagName),
 	);
+}
+
+/**
+ * Apply `.stdin({ trim: true })` to a single value read off the stream.
+ *
+ * Only the string codec keeps the terminator a pipe appends, and only a single
+ * value carries one: a collection's terminators frame its elements and the
+ * split policy consumes them. Every other codec drops it while decoding, so
+ * trimming there would take a second terminator off the value.
+ *
+ * @param stdin - The input's stdin axis.
+ * @param source - Which stage produced the value.
+ * @param raw - The value that stage produced.
+ * @param value - The value axis about to decode it.
+ * @returns The value to decode.
+ */
+function trimmedStdinValue(
+	stdin: StdinBinding | undefined,
+	source: CoerceSource,
+	raw: unknown,
+	value: ValueSchema,
+): unknown {
+	if (source.kind !== 'stdin' || stdin?.trim !== true || typeof raw !== 'string') return raw;
+	return keepsStdinTerminator(value.codec) ? stripTerminator(raw) : raw;
 }
 
 /** Read a raw value as a non-negative integer occurrence count. */
@@ -174,16 +216,47 @@ function coerceCount(flagName: string, source: CoerceSource, raw: unknown): Coer
 
 // --- Collection coercion
 
-/** What a collection failure looks like before a surface words it. */
+/** What reading one source's value as a collection rejected. */
 type CollectionFault =
 	| { readonly kind: 'shape'; readonly expected: 'array' | 'object' }
 	| { readonly kind: 'pair'; readonly segment: string }
 	| { readonly kind: 'json'; readonly error: unknown }
-	| { readonly kind: 'json-shape'; readonly expected: 'array' | 'object' }
-	| { readonly kind: 'duplicate-key'; readonly key: string };
+	| { readonly kind: 'json-shape'; readonly expected: 'array' | 'object' };
 
-/** How one surface words the faults a collection can produce. */
+/** How one surface words the faults reading a source can produce. */
 type CollectionErrors = (fault: CollectionFault, raw: unknown) => ValidationError;
+
+/**
+ * What combining a collection's decoded elements rejected.
+ *
+ * Elements reach aggregation from several sources at once, so each fault is
+ * worded for the source of the element that caused it.
+ */
+type AggregationFault =
+	| { readonly kind: 'duplicate-key'; readonly key: string }
+	| { readonly kind: 'dash-without-stdin' };
+
+/** How one surface words an aggregation fault for the source that carried it. */
+type AggregationErrors = (
+	fault: AggregationFault,
+	source: ResolutionDiagnosticSource,
+) => ValidationError;
+
+/**
+ * The clause naming where a value came from, empty for the tokens the user
+ * typed.
+ *
+ * @param source - The source that carried the value.
+ * @returns A trailing-spaced clause, or `''` for the CLI.
+ */
+function sourceClause(source: ResolutionDiagnosticSource): string {
+	return source.kind === 'cli' ? '' : `${sourceLabel(source)} `;
+}
+
+/** The identification fields a source contributes to an aggregation error. */
+function aggregationSourceDetails(source: ResolutionDiagnosticSource): Record<string, unknown> {
+	return source.kind === 'cli' ? {} : sourceDetails(source);
+}
 
 /**
  * Read a source value as a collection and aggregate it.
@@ -192,7 +265,8 @@ type CollectionErrors = (fault: CollectionFault, raw: unknown) => ValidationErro
  * @param source - Which stage produced the value.
  * @param raw - The value that stage produced.
  * @param decodeElement - Decodes one element through the value axis.
- * @param errors - Words a fault for the surface being resolved.
+ * @param errors - Words a read fault for the surface being resolved.
+ * @param aggregationErrors - Words an aggregation fault for the same surface.
  * @returns The aggregated array or record, or the first failure.
  */
 function coerceCollection(
@@ -201,6 +275,7 @@ function coerceCollection(
 	raw: unknown,
 	decodeElement: (element: unknown) => CoerceResult,
 	errors: CollectionErrors,
+	aggregationErrors: AggregationErrors,
 ): CoerceResult {
 	if (cardinality.kind === 'many') {
 		const parts = readManyParts(source, raw, cardinality.splitting);
@@ -224,7 +299,10 @@ function coerceCollection(
 	}
 	const folded = foldEntries(coerced, cardinality.duplicateKeys);
 	if (!folded.ok) {
-		return { ok: false, error: errors({ kind: 'duplicate-key', key: folded.duplicateKey }, raw) };
+		return {
+			ok: false,
+			error: aggregationErrors({ kind: 'duplicate-key', key: folded.duplicateKey }, source),
+		};
 	}
 	return { ok: true, value: folded.value };
 }
@@ -359,16 +437,28 @@ function flagCollectionErrors(flagName: string, source: CoerceSource): Collectio
 					`Invalid JSON value, expected an ${fault.expected}`,
 					`Provide a JSON ${fault.expected} for --${flagName}`,
 				);
-			case 'duplicate-key':
-				return new ValidationError(
-					`Duplicate key '${fault.key}' ${sourceLabel(source)} for flag --${flagName}`,
-					{
-						code: 'CONSTRAINT_VIOLATED',
-						details: { flag: flagName, ...sourceDetails(source), key: fault.key },
-						suggest: `Set '${fault.key}' once for --${flagName}`,
-					},
-				);
 		}
+	};
+}
+
+/** Word an aggregation fault for a flag, naming the source that carried it. */
+function flagAggregationErrors(flagName: string): AggregationErrors {
+	return (fault, source) => {
+		if (fault.kind === 'dash-without-stdin') {
+			return new ValidationError(`No piped stdin for the '-' occurrence of flag --${flagName}`, {
+				code: 'REQUIRED_FLAG',
+				details: { flag: flagName, source: 'stdin' },
+				suggest: `Pipe a value to stdin, or drop the '-' occurrence of --${flagName}`,
+			});
+		}
+		return new ValidationError(
+			`Duplicate key '${fault.key}' ${sourceClause(source)}for flag --${flagName}`,
+			{
+				code: 'CONSTRAINT_VIOLATED',
+				details: { flag: flagName, ...aggregationSourceDetails(source), key: fault.key },
+				suggest: `Set '${fault.key}' once for --${flagName}`,
+			},
+		);
 	};
 }
 
@@ -412,16 +502,28 @@ function argCollectionErrors(argName: string, source: ArgStringSource): Collecti
 						suggest: `Provide a JSON ${fault.expected} for <${argName}>`,
 					},
 				);
-			case 'duplicate-key':
-				return new ValidationError(
-					`Duplicate key '${fault.key}' ${argSourceLabel(source)} for argument <${argName}>`,
-					{
-						code: 'CONSTRAINT_VIOLATED',
-						details: { arg: argName, ...argSourceDetails(source), key: fault.key },
-						suggest: `Set '${fault.key}' once for <${argName}>`,
-					},
-				);
 		}
+	};
+}
+
+/** Word an aggregation fault for a positional, naming the source that carried it. */
+function argAggregationErrors(argName: string): AggregationErrors {
+	return (fault, source) => {
+		if (fault.kind === 'dash-without-stdin') {
+			return new ValidationError(`No piped stdin for the '-' occurrence of argument <${argName}>`, {
+				code: 'REQUIRED_ARG',
+				details: { arg: argName, source: 'stdin' },
+				suggest: `Pipe a value to stdin, or drop the '-' from <${argName}>`,
+			});
+		}
+		return new ValidationError(
+			`Duplicate key '${fault.key}' ${sourceClause(source)}for argument <${argName}>`,
+			{
+				code: 'CONSTRAINT_VIOLATED',
+				details: { arg: argName, ...aggregationSourceDetails(source), key: fault.key },
+				suggest: `Set '${fault.key}' once for <${argName}>`,
+			},
+		);
 	};
 }
 
@@ -810,9 +912,15 @@ function coerceArgValue(
 			raw,
 			(element) => coerceArgElement(argName, source, element, schema),
 			argCollectionErrors(argName, source),
+			argAggregationErrors(argName),
 		);
 	}
-	return coerceArgElement(argName, source, raw, schema);
+	return coerceArgElement(
+		argName,
+		source,
+		trimmedStdinValue(schema.stdin, source, raw, argValueSchema(schema)),
+		schema,
+	);
 }
 
 /**
@@ -893,6 +1001,7 @@ function finishCliFlagValue(
 		schema.stdin !== undefined && stdinReadsOnDash(schema.stdin),
 		(element) => coerceValueSchema(flagName, { kind: 'stdin' }, element, flagValueSchema(schema)),
 		flagCollectionErrors(flagName, { kind: 'stdin' }),
+		flagAggregationErrors(flagName),
 	);
 }
 
@@ -923,7 +1032,22 @@ function finishCliArgValue(
 		schema.stdin !== undefined && stdinReadsOnDash(schema.stdin),
 		(element) => coerceArgElement(argName, { kind: 'stdin' }, element, schema),
 		argCollectionErrors(argName, { kind: 'stdin' }),
+		argAggregationErrors(argName),
 	);
+}
+
+/** The tokens the user typed, as the source of an occurrence. */
+const CLI_SOURCE: ResolutionDiagnosticSource = { kind: 'cli' };
+
+/** The buffer a `-` stood for, as the source of an occurrence. */
+const STDIN_SOURCE: ResolutionDiagnosticSource = { kind: 'stdin' };
+
+/** One occurrence of a spliced collection, with where it came from. */
+interface SourcedOccurrence {
+	/** The occurrence itself. */
+	readonly occurrence: Occurrence;
+	/** The source that produced it. */
+	readonly source: ResolutionDiagnosticSource;
 }
 
 /**
@@ -931,7 +1055,9 @@ function finishCliArgValue(
  * then aggregate what is left.
  *
  * A value the parser did not leave as an occurrence list is the aggregate a
- * caller built by hand, and it reaches the resolved value untouched.
+ * caller built by hand, and it reaches the resolved value untouched. Each
+ * occurrence keeps the source it came from, so an aggregation failure names
+ * either the typed token or the pipe.
  */
 function spliceCliCollection(
 	cardinality: Extract<Cardinality, { kind: 'many' } | { kind: 'entries' }>,
@@ -940,6 +1066,7 @@ function spliceCliCollection(
 	readsOnDash: boolean,
 	decodeElement: (element: unknown) => CoerceResult,
 	errors: CollectionErrors,
+	aggregationErrors: AggregationErrors,
 ): CliFinish {
 	const occurrences = liftOccurrences(cardinality, value, readsOnDash);
 	const aggregated = readAggregated(occurrences);
@@ -947,12 +1074,12 @@ function spliceCliCollection(
 		return { kind: 'value', value: aggregated.value, viaStdin: false };
 	}
 
-	const spliced: Occurrence[] = [];
+	const spliced: SourcedOccurrence[] = [];
 	let sentinels = 0;
 	let viaStdin = false;
 	for (const occurrence of occurrences) {
 		if (occurrence.kind !== 'stdin') {
-			spliced.push(occurrence);
+			spliced.push({ occurrence, source: CLI_SOURCE });
 			continue;
 		}
 		sentinels += 1;
@@ -960,31 +1087,52 @@ function spliceCliCollection(
 		const read = readStdinOccurrence(cardinality, stdinData, decodeElement, errors);
 		if (read.kind !== 'value') return read;
 		viaStdin = true;
-		spliced.push(...read.occurrences);
-	}
-
-	if (sentinels === occurrences.length && sentinels > 0 && typeof stdinData !== 'string') {
-		return { kind: 'absent' };
-	}
-
-	if (cardinality.kind === 'many') {
-		return { kind: 'value', value: spliced.map(occurrenceValue), viaStdin };
-	}
-
-	for (const occurrence of spliced) {
-		if (occurrence.kind !== 'entry') {
-			return {
-				kind: 'error',
-				error: errors({ kind: 'shape', expected: 'object' }, occurrenceValue(occurrence)),
-			};
+		for (const element of read.occurrences) {
+			spliced.push({ occurrence: element, source: STDIN_SOURCE });
 		}
 	}
 
-	const folded = foldEntries(entryPairsOf(spliced), cardinality.duplicateKeys);
+	if (sentinels > 0 && typeof stdinData !== 'string') {
+		if (sentinels === occurrences.length) return { kind: 'absent' };
+		return {
+			kind: 'error',
+			error: aggregationErrors({ kind: 'dash-without-stdin' }, CLI_SOURCE),
+		};
+	}
+
+	if (cardinality.kind === 'many') {
+		return {
+			kind: 'value',
+			value: spliced.map((entry) => occurrenceValue(entry.occurrence)),
+			viaStdin,
+		};
+	}
+
+	const entries: SourcedOccurrence[] = [];
+	for (const entry of spliced) {
+		if (entry.occurrence.kind !== 'entry') {
+			return {
+				kind: 'error',
+				error: errors(
+					{ kind: 'shape', expected: 'object' },
+					occurrenceValue(entry.occurrence),
+				),
+			};
+		}
+		entries.push(entry);
+	}
+
+	const folded = foldEntries(
+		entryPairsOf(entries.map((entry) => entry.occurrence)),
+		cardinality.duplicateKeys,
+	);
 	if (!folded.ok) {
 		return {
 			kind: 'error',
-			error: errors({ kind: 'duplicate-key', key: folded.duplicateKey }, value),
+			error: aggregationErrors(
+				{ kind: 'duplicate-key', key: folded.duplicateKey },
+				entries[folded.at]?.source ?? CLI_SOURCE,
+			),
 		};
 	}
 	return { kind: 'value', value: folded.value, viaStdin };

--- a/src/core/resolve/coerce.ts
+++ b/src/core/resolve/coerce.ts
@@ -7,6 +7,13 @@
 
 import type { ValidationErrorCode } from '#internals/core/errors/index.ts';
 import { ValidationError } from '#internals/core/errors/index.ts';
+import type { Occurrence } from '#internals/core/parse/occurrences.ts';
+import {
+	entryPairsOf,
+	liftOccurrences,
+	occurrenceValue,
+	readAggregated,
+} from '#internals/core/parse/occurrences.ts';
 import type {
 	Cardinality,
 	SplitBinding,
@@ -281,7 +288,7 @@ function readEntryPairs(source: CoerceSource, raw: unknown, splitting: SplitBind
 	return { ok: true, pairs: split.parts };
 }
 
-/** Whether a value is the ordered pair list the parser produces for entries. */
+/** Whether a value is an ordered list of key/value pairs. */
 function isPairList(value: unknown): value is readonly (readonly [string, unknown])[] {
 	return (
 		Array.isArray(value) &&
@@ -919,7 +926,13 @@ function finishCliArgValue(
 	);
 }
 
-/** Replace every stdin sentinel among the occurrences with what stdin decodes to. */
+/**
+ * Replace every stdin sentinel among the occurrences with what stdin decodes to,
+ * then aggregate what is left.
+ *
+ * A value the parser did not leave as an occurrence list is the aggregate a
+ * caller built by hand, and it reaches the resolved value untouched.
+ */
 function spliceCliCollection(
 	cardinality: Extract<Cardinality, { kind: 'many' } | { kind: 'entries' }>,
 	value: unknown,
@@ -928,13 +941,17 @@ function spliceCliCollection(
 	decodeElement: (element: unknown) => CoerceResult,
 	errors: CollectionErrors,
 ): CliFinish {
-	if (!Array.isArray(value)) return { kind: 'value', value, viaStdin: false };
+	const occurrences = liftOccurrences(cardinality, value, readsOnDash);
+	const aggregated = readAggregated(occurrences);
+	if (aggregated !== undefined) {
+		return { kind: 'value', value: aggregated.value, viaStdin: false };
+	}
 
-	const spliced: unknown[] = [];
+	const spliced: Occurrence[] = [];
 	let sentinels = 0;
 	let viaStdin = false;
-	for (const occurrence of value) {
-		if (!readsOnDash || occurrence !== STDIN_SENTINEL) {
+	for (const occurrence of occurrences) {
+		if (occurrence.kind !== 'stdin') {
 			spliced.push(occurrence);
 			continue;
 		}
@@ -943,26 +960,27 @@ function spliceCliCollection(
 		const read = readStdinOccurrence(cardinality, stdinData, decodeElement, errors);
 		if (read.kind !== 'value') return read;
 		viaStdin = true;
-		spliced.push(...read.elements);
+		spliced.push(...read.occurrences);
 	}
 
-	if (sentinels === value.length && sentinels > 0 && typeof stdinData !== 'string') {
+	if (sentinels === occurrences.length && sentinels > 0 && typeof stdinData !== 'string') {
 		return { kind: 'absent' };
 	}
 
-	if (cardinality.kind === 'many') return { kind: 'value', value: spliced, viaStdin };
+	if (cardinality.kind === 'many') {
+		return { kind: 'value', value: spliced.map(occurrenceValue), viaStdin };
+	}
 
-	const pairs: (readonly [string, unknown])[] = [];
-	for (const entry of spliced) {
-		if (!Array.isArray(entry) || entry.length !== 2 || typeof entry[0] !== 'string') {
+	for (const occurrence of spliced) {
+		if (occurrence.kind !== 'entry') {
 			return {
 				kind: 'error',
-				error: errors({ kind: 'shape', expected: 'object' }, entry),
+				error: errors({ kind: 'shape', expected: 'object' }, occurrenceValue(occurrence)),
 			};
 		}
-		pairs.push([entry[0], entry[1]]);
 	}
-	const folded = foldEntries(pairs, cardinality.duplicateKeys);
+
+	const folded = foldEntries(entryPairsOf(spliced), cardinality.duplicateKeys);
 	if (!folded.ok) {
 		return {
 			kind: 'error',
@@ -972,38 +990,38 @@ function spliceCliCollection(
 	return { kind: 'value', value: folded.value, viaStdin };
 }
 
-/** Decode the stdin buffer into the elements one `-` occurrence stands for. */
+/** Decode the stdin buffer into the occurrences one `-` stands for. */
 function readStdinOccurrence(
 	cardinality: Extract<Cardinality, { kind: 'many' } | { kind: 'entries' }>,
 	stdinData: string,
 	decodeElement: (element: unknown) => CoerceResult,
 	errors: CollectionErrors,
 ):
-	| { readonly kind: 'value'; readonly elements: readonly unknown[] }
+	| { readonly kind: 'value'; readonly occurrences: readonly Occurrence[] }
 	| { readonly kind: 'error'; readonly error: ValidationError } {
 	const source: CoerceSource = { kind: 'stdin' };
 
 	if (cardinality.kind === 'many') {
 		const parts = readManyParts(source, stdinData, cardinality.splitting);
 		if (!parts.ok) return { kind: 'error', error: errors(parts.fault, stdinData) };
-		const elements: unknown[] = [];
+		const occurrences: Occurrence[] = [];
 		for (const part of parts.parts) {
 			const decoded = decodeElement(part);
 			if (!decoded.ok) return { kind: 'error', error: decoded.error };
-			elements.push(decoded.value);
+			occurrences.push({ kind: 'value', value: decoded.value });
 		}
-		return { kind: 'value', elements };
+		return { kind: 'value', occurrences };
 	}
 
 	const pairs = readEntryPairs(source, stdinData, cardinality.splitting);
 	if (!pairs.ok) return { kind: 'error', error: errors(pairs.fault, stdinData) };
-	const elements: unknown[] = [];
+	const occurrences: Occurrence[] = [];
 	for (const [key, raw] of pairs.pairs) {
 		const decoded = decodeElement(raw);
 		if (!decoded.ok) return { kind: 'error', error: decoded.error };
-		elements.push([key, decoded.value]);
+		occurrences.push({ kind: 'entry', key, value: decoded.value });
 	}
-	return { kind: 'value', elements };
+	return { kind: 'value', occurrences };
 }
 
 export type { CliFinish, CoerceResult };

--- a/src/core/resolve/coerce.ts
+++ b/src/core/resolve/coerce.ts
@@ -225,6 +225,9 @@ type CollectionFault =
 /** How one surface words the faults reading a source can produce. */
 type CollectionErrors = (fault: CollectionFault, raw: unknown) => ValidationError;
 
+/** How one CLI surface words a caller-built non-pair occurrence. */
+type CliCollectionShapeError = (raw: unknown) => ValidationError;
+
 /**
  * What combining a collection's decoded elements rejected.
  *
@@ -461,6 +464,16 @@ function flagAggregationErrors(flagName: string): AggregationErrors {
 	};
 }
 
+/** Word a caller-built non-pair occurrence in a key-value flag's CLI slot. */
+function flagCliCollectionShapeError(flagName: string): CliCollectionShapeError {
+	return (raw) =>
+		new ValidationError(`Invalid object value for flag --${flagName}`, {
+			code: 'TYPE_MISMATCH',
+			details: { flag: flagName, source: 'cli', expected: 'object', value: raw },
+			suggest: `Use KEY=VALUE occurrences for --${flagName}`,
+		});
+}
+
 /** Word a collection fault for a positional, without echoing the value. */
 function argCollectionErrors(argName: string, source: ArgStringSource): CollectionErrors {
 	return (fault) => {
@@ -524,6 +537,16 @@ function argAggregationErrors(argName: string): AggregationErrors {
 			},
 		);
 	};
+}
+
+/** Word a caller-built non-pair occurrence in a key-value argument's CLI slot. */
+function argCliCollectionShapeError(argName: string): CliCollectionShapeError {
+	return (raw) =>
+		new ValidationError(`Invalid object value for argument <${argName}>`, {
+			code: 'TYPE_MISMATCH',
+			details: { arg: argName, source: 'cli', expected: 'object', value: raw },
+			suggest: `Use KEY=VALUE occurrences for <${argName}>`,
+		});
 }
 
 /** Name what JSON parsing rejected, without echoing the text. */
@@ -1000,6 +1023,7 @@ function finishCliFlagValue(
 		schema.stdin !== undefined && stdinReadsOnDash(schema.stdin),
 		(element) => coerceValueSchema(flagName, { kind: 'stdin' }, element, flagValueSchema(schema)),
 		flagCollectionErrors(flagName, { kind: 'stdin' }),
+		flagCliCollectionShapeError(flagName),
 		flagAggregationErrors(flagName),
 	);
 }
@@ -1031,6 +1055,7 @@ function finishCliArgValue(
 		schema.stdin !== undefined && stdinReadsOnDash(schema.stdin),
 		(element) => coerceArgElement(argName, { kind: 'stdin' }, element, schema),
 		argCollectionErrors(argName, { kind: 'stdin' }),
+		argCliCollectionShapeError(argName),
 		argAggregationErrors(argName),
 	);
 }
@@ -1065,6 +1090,7 @@ function spliceCliCollection(
 	readsOnDash: boolean,
 	decodeElement: (element: unknown) => CoerceResult,
 	errors: CollectionErrors,
+	cliShapeError: CliCollectionShapeError,
 	aggregationErrors: AggregationErrors,
 ): CliFinish {
 	const occurrences = liftOccurrences(cardinality, value, readsOnDash);
@@ -1112,7 +1138,7 @@ function spliceCliCollection(
 		if (entry.occurrence.kind !== 'entry') {
 			return {
 				kind: 'error',
-				error: errors({ kind: 'shape', expected: 'object' }, occurrenceValue(entry.occurrence)),
+				error: cliShapeError(occurrenceValue(entry.occurrence)),
 			};
 		}
 		entries.push(entry);

--- a/src/core/resolve/contracts.ts
+++ b/src/core/resolve/contracts.ts
@@ -17,21 +17,30 @@ import { RESOLUTION_ORDER } from '#internals/core/schema/source.ts';
 /**
  * Source-aware diagnostic context for a resolution failure.
  *
- * CLI and default failures surface as missing-value or parse errors, so only
- * the stages that decode a foreign value need a payload here. Both surfaces
- * read the same set.
+ * `'cli'` covers the tokens the user typed, which a message names by the input
+ * alone; the other stages each carry what a message needs to point at the value
+ * they produced. Both surfaces read the same set.
  */
 type ResolutionDiagnosticSource =
+	| { readonly kind: 'cli' }
 	| { readonly kind: 'stdin' }
 	| { readonly kind: 'env'; readonly envVar: string }
 	| { readonly kind: 'config'; readonly configPath: string }
 	| { readonly kind: 'prompt' };
 
+/**
+ * The sources whose raw values a resolution stage decodes.
+ *
+ * A CLI token is decoded at the parse boundary, so it never reaches the
+ * coercion diagnostics these name.
+ */
+type DecodedDiagnosticSource = Exclude<ResolutionDiagnosticSource, { readonly kind: 'cli' }>;
+
 /** Source-aware diagnostic context for flag resolution failures. */
-type FlagDiagnosticSource = ResolutionDiagnosticSource;
+type FlagDiagnosticSource = DecodedDiagnosticSource;
 
 /** Source-aware diagnostic context for arg resolution failures. */
-type ArgDiagnosticSource = ResolutionDiagnosticSource;
+type ArgDiagnosticSource = DecodedDiagnosticSource;
 
 /**
  * Which stage produced a resolved value, and how.
@@ -175,6 +184,7 @@ const resolverContract: ResolverContract = {
 
 export type {
 	ArgDiagnosticSource,
+	DecodedDiagnosticSource,
 	DeprecationWarning,
 	FlagDiagnosticSource,
 	ResolutionDiagnosticSource,

--- a/src/core/resolve/resolve-arg-tail.test.ts
+++ b/src/core/resolve/resolve-arg-tail.test.ts
@@ -1,0 +1,258 @@
+/**
+ * The positional tail: how a variadic arg collects its tokens, how a `-` among
+ * them splices the stdin buffer, and how an aggregation failure names the source
+ * that carried the offending element.
+ *
+ * @module dreamcli/core/resolve/resolve-arg-tail.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isValidationError } from '#internals/core/errors/index.ts';
+import { parse } from '#internals/core/parse/index.ts';
+import type { ArgBuilder, ArgConfig } from '#internals/core/schema/arg.ts';
+import { arg, createArgSchema } from '#internals/core/schema/arg.ts';
+import { command, createCommandSchema } from '#internals/core/schema/command.ts';
+import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import type { ResolveOptions } from './index.ts';
+import { resolve } from './index.ts';
+
+// --- helpers
+
+/** Resolve one positional against the given argv and sources. */
+async function resolveArg(
+	builder: ArgBuilder<ArgConfig>,
+	argv: readonly string[],
+	options: ResolveOptions = {},
+): Promise<unknown> {
+	const schema = command('deploy')
+		.arg('files', builder)
+		.action(() => {}).schema;
+	const result = await resolve(schema, parse(schema, argv), options);
+	return result.args.files;
+}
+
+/** Resolve one flag against the given argv and sources. */
+async function resolveFlag(
+	builder: FlagBuilder<FlagConfig>,
+	argv: readonly string[],
+	options: ResolveOptions = {},
+): Promise<unknown> {
+	const schema = command('deploy')
+		.flag('value', builder)
+		.action(() => {}).schema;
+	const result = await resolve(schema, parse(schema, argv), options);
+	return result.flags.value;
+}
+
+/** Run a resolution expected to fail, returning the message it reported. */
+async function resolutionError(run: () => Promise<unknown>): Promise<string> {
+	try {
+		await run();
+	} catch (error) {
+		if (isValidationError(error)) return error.message;
+		throw error;
+	}
+	throw new Error('expected resolution to fail');
+}
+
+// === a `-` among the tail tokens
+
+describe('a variadic arg reads stdin from its tail', () => {
+	it('splices the buffer at the position the dash holds', async () => {
+		expect(
+			await resolveArg(arg.string().variadic().stdin(), ['before', '-', 'after'], {
+				stdinData: 'a\nb\n',
+			}),
+		).toEqual(['before', 'a', 'b', 'after']);
+	});
+
+	it('splices at the front and the back', async () => {
+		const files = arg.string().variadic().stdin({ when: 'dash' });
+		expect(await resolveArg(files, ['-', 'last'], { stdinData: 'a\n' })).toEqual(['a', 'last']);
+		expect(await resolveArg(files, ['first', '-'], { stdinData: 'a\n' })).toEqual(['first', 'a']);
+	});
+
+	it('splices the buffer once per dash', async () => {
+		expect(
+			await resolveArg(arg.string().variadic().stdin(), ['-', '-'], { stdinData: 'a\nb\n' }),
+		).toEqual(['a', 'b', 'a', 'b']);
+	});
+
+	it('decodes each spliced element through the element value axis', async () => {
+		expect(
+			await resolveArg(arg.number().variadic().stdin(), ['1', '-'], { stdinData: '2\n3\n' }),
+		).toEqual([1, 2, 3]);
+	});
+
+	it('reads the whole buffer when the tail is empty and the binding covers missing', async () => {
+		expect(await resolveArg(arg.string().variadic().stdin(), [], { stdinData: 'a\nb\n' })).toEqual([
+			'a',
+			'b',
+		]);
+	});
+
+	it('decodes the same elements the explicit dash would', async () => {
+		const files = arg.string().variadic().stdin();
+		expect(await resolveArg(files, ['-'], { stdinData: 'a\nb\n' })).toEqual(
+			await resolveArg(files, [], { stdinData: 'a\nb\n' }),
+		);
+	});
+
+	it('keeps CLI tokens when the binding only covers missing', async () => {
+		expect(
+			await resolveArg(arg.string().variadic().stdin({ when: 'missing' }), ['a', '-'], {
+				stdinData: 'piped\n',
+			}),
+		).toEqual(['a', '-']);
+	});
+
+	it('reads the stdin split policy of the arg', async () => {
+		expect(
+			await resolveArg(arg.string().variadic().stdin().split({ stdin: ',' }), ['-'], {
+				stdinData: 'a,b',
+			}),
+		).toEqual(['a', 'b']);
+	});
+
+	it('aggregates a variadic keyValue tail across CLI and stdin', async () => {
+		expect(
+			await resolveArg(arg.keyValue().variadic().stdin(), ['A=1', '-'], { stdinData: 'B=2\n' }),
+		).toEqual({ A: '1', B: '2' });
+	});
+});
+
+// === both construction paths agree
+
+describe('the definition path accepts the same tail bindings', () => {
+	it('builds a variadic stdin arg', () => {
+		const schema = createCommandSchema({
+			name: 'run',
+			args: [
+				{ name: 'files', schema: { kind: 'string', variadic: true, stdin: { when: 'dash' } } },
+			],
+		});
+		expect(schema.args[0]?.schema.stdin).toEqual({
+			when: 'dash',
+			consume: 'exclusive',
+			trim: false,
+		});
+	});
+
+	it('resolves a definition-built tail the way the builder-built one resolves', async () => {
+		const definition = createCommandSchema({
+			name: 'deploy',
+			hasAction: true,
+			args: [{ name: 'files', schema: { kind: 'string', variadic: true, stdin: {} } }],
+		});
+		const result = await resolve(definition, parse(definition, ['a', '-']), {
+			stdinData: 'b\nc\n',
+		});
+		expect(result.args.files).toEqual(['a', 'b', 'c']);
+	});
+
+	it('rebuilds a deep-equal schema from a variadic stdin arg', () => {
+		const built = createArgSchema('string', { variadic: true, stdin: { trim: true } });
+		expect(createArgSchema(built)).toEqual(built);
+	});
+});
+
+// === an explicit dash with nothing piped
+
+describe("a '-' the user typed with nothing piped", () => {
+	it('fails for a positional tail rather than dropping the token', async () => {
+		const message = await resolutionError(() =>
+			resolveArg(arg.string().variadic().stdin(), ['a', '-', 'b']),
+		);
+		expect(message).toBe("No piped stdin for the '-' occurrence of argument <files>");
+	});
+
+	it('falls through to a later source when the tail is nothing but dashes', async () => {
+		expect(
+			await resolveArg(arg.string().variadic().stdin().env('FILES'), ['-'], {
+				env: { FILES: 'from-env' },
+			}),
+		).toEqual(['from-env']);
+	});
+
+	it('suggests piping or dropping the token', async () => {
+		try {
+			await resolveArg(arg.keyValue().variadic().stdin(), ['A=1', '-']);
+		} catch (error) {
+			expect(isValidationError(error) && error.suggest).toBe(
+				"Pipe a value to stdin, or drop the '-' from <files>",
+			);
+			expect(isValidationError(error) && error.code).toBe('REQUIRED_ARG');
+			return;
+		}
+		throw new Error('expected resolution to fail');
+	});
+});
+
+// === which source a duplicate key names
+
+describe('a duplicate key names the source that carried it', () => {
+	it('names no source for keys the user typed on a flag', async () => {
+		expect(
+			await resolutionError(() =>
+				resolveFlag(flag.keyValue().duplicateKeys('error'), ['--value', 'A=1', '--value', 'A=2']),
+			),
+		).toBe("Duplicate key 'A' for flag --value");
+	});
+
+	it('names no source for keys the user typed in a positional tail', async () => {
+		expect(
+			await resolutionError(() =>
+				resolveArg(arg.keyValue().variadic().duplicateKeys('error'), ['A=1', 'A=2']),
+			),
+		).toBe("Duplicate key 'A' for argument <files>");
+	});
+
+	it('names stdin for a key the buffer spliced in', async () => {
+		expect(
+			await resolutionError(() =>
+				resolveFlag(
+					flag.keyValue().stdin().duplicateKeys('error'),
+					['--value', 'A=1', '--value', '-'],
+					{
+						stdinData: 'A=2\n',
+					},
+				),
+			),
+		).toBe("Duplicate key 'A' from stdin for flag --value");
+	});
+
+	it('names stdin for a spliced key in a positional tail', async () => {
+		expect(
+			await resolutionError(() =>
+				resolveArg(arg.keyValue().variadic().stdin().duplicateKeys('error'), ['A=1', '-'], {
+					stdinData: 'A=2\n',
+				}),
+			),
+		).toBe("Duplicate key 'A' from stdin for argument <files>");
+	});
+
+	it('names the typed token when it is the one that repeats', async () => {
+		expect(
+			await resolutionError(() =>
+				resolveFlag(
+					flag.keyValue().stdin().duplicateKeys('error'),
+					['--value', '-', '--value', 'A=2'],
+					{
+						stdinData: 'A=1\n',
+					},
+				),
+			),
+		).toBe("Duplicate key 'A' for flag --value");
+	});
+
+	it('keeps naming env for a value the environment carried', async () => {
+		expect(
+			await resolutionError(() =>
+				resolveFlag(flag.keyValue().duplicateKeys('error').env('VARS'), [], {
+					env: { VARS: 'A=1,A=2' },
+				}),
+			),
+		).toBe("Duplicate key 'A' from env VARS for flag --value");
+	});
+});

--- a/src/core/resolve/resolve-cardinality.test.ts
+++ b/src/core/resolve/resolve-cardinality.test.ts
@@ -723,11 +723,43 @@ describe('collection provenance', () => {
 		});
 	});
 
-	it('names the CLI alone when a dash-enabled collection had nothing to splice', async () => {
-		const spec = flag.array(flag.string()).stdin();
-		const argv = ['--value', 'a', '--value', '-'];
-		expect(await resolveFlag(spec, argv)).toEqual(['a']);
-		expect(await flagProvenance(spec, argv)).toEqual({ stage: 'cli' });
+	it('names the CLI alone when every occurrence was typed', async () => {
+		expect(
+			await flagProvenance(flag.array(flag.string()).stdin(), ['--value', 'a', '--value', 'b']),
+		).toEqual({ stage: 'cli' });
+	});
+});
+
+// === an explicit dash with nothing piped
+
+describe("a '-' occurrence beside typed ones and no pipe", () => {
+	it('fails for a flag rather than dropping the occurrence', async () => {
+		const error = await resolutionError(() =>
+			resolveFlag(flag.array(flag.string()).stdin(), [
+				'--value',
+				'a',
+				'--value',
+				'-',
+				'--value',
+				'b',
+			]),
+		);
+		expect(error).toContain("No piped stdin for the '-' occurrence of flag --value");
+	});
+
+	it('fails for an entries flag the same way', async () => {
+		const error = await resolutionError(() =>
+			resolveFlag(flag.keyValue().stdin(), ['--value', 'A=1', '--value', '-']),
+		);
+		expect(error).toContain("No piped stdin for the '-' occurrence of flag --value");
+	});
+
+	it('still falls through when nothing but a dash was given', async () => {
+		expect(
+			await resolveFlag(flag.array(flag.string()).stdin().env('TAGS'), ['--value', '-'], {
+				env: { TAGS: 'from-env' },
+			}),
+		).toEqual(['from-env']);
 	});
 });
 

--- a/src/core/resolve/resolve-hand-built.test.ts
+++ b/src/core/resolve/resolve-hand-built.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The projection a caller-built {@link ParseResult} enters resolution through.
+ *
+ * `testkit`, `executeCommand()`, and `readFlags()` all accept a parse result
+ * nobody parsed, so the aggregation path has to read a value the parser never
+ * produced: an array of occurrences, or an aggregate already folded by hand.
+ *
+ * @module dreamcli/core/resolve/resolve-hand-built.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ParseResult } from '#internals/core/parse/index.ts';
+import type { ArgBuilder, ArgConfig } from '#internals/core/schema/arg.ts';
+import { arg } from '#internals/core/schema/arg.ts';
+import { command } from '#internals/core/schema/command.ts';
+import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import type { ResolveOptions } from './index.ts';
+import { resolve } from './index.ts';
+
+/** Resolve one flag from a parse result no parser produced. */
+async function resolveGivenFlag(
+	builder: FlagBuilder<FlagConfig>,
+	value: unknown,
+	options: ResolveOptions = {},
+): Promise<unknown> {
+	const schema = command('deploy')
+		.flag('value', builder)
+		.action(() => {}).schema;
+	const parsed: ParseResult = { flags: { value }, args: {} };
+	const result = await resolve(schema, parsed, options);
+	return result.flags.value;
+}
+
+/** Resolve one positional from a parse result no parser produced. */
+async function resolveGivenArg(
+	builder: ArgBuilder<ArgConfig>,
+	value: unknown,
+	options: ResolveOptions = {},
+): Promise<unknown> {
+	const schema = command('deploy')
+		.arg('value', builder)
+		.action(() => {}).schema;
+	const parsed: ParseResult = { flags: {}, args: { value } };
+	const result = await resolve(schema, parsed, options);
+	return result.args.value;
+}
+
+describe('a caller-built list of occurrences', () => {
+	it('aggregates a many flag element by element', async () => {
+		await expect(resolveGivenFlag(flag.array(flag.string()), ['a', 'b'])).resolves.toEqual([
+			'a',
+			'b',
+		]);
+	});
+
+	it('deduplicates a unique many flag', async () => {
+		await expect(
+			resolveGivenFlag(flag.array(flag.string()).unique(), ['a', 'b', 'a']),
+		).resolves.toEqual(['a', 'b']);
+	});
+
+	it('folds an entries flag given ordered pairs', async () => {
+		await expect(
+			resolveGivenFlag(flag.keyValue(), [
+				['A', '1'],
+				['B', '2'],
+			]),
+		).resolves.toEqual({ A: '1', B: '2' });
+	});
+
+	it('applies the duplicate-key policy to those pairs', async () => {
+		await expect(
+			resolveGivenFlag(flag.keyValue().duplicateKeys('first'), [
+				['A', '1'],
+				['A', '2'],
+			]),
+		).resolves.toEqual({ A: '1' });
+		await expect(
+			resolveGivenFlag(flag.keyValue(), [
+				['A', '1'],
+				['A', '2'],
+			]),
+		).resolves.toEqual({ A: '2' });
+	});
+
+	it('drops an element of an entries flag that is not a pair', async () => {
+		await expect(
+			resolveGivenFlag(flag.keyValue(), [['A', '1'], 'junk', ['B', '2']]),
+		).resolves.toEqual({ A: '1', B: '2' });
+	});
+
+	it('keeps a pair-shaped element of a many flag whole', async () => {
+		await expect(resolveGivenFlag(flag.array(flag.string()), [['A', '1']])).resolves.toEqual([
+			['A', '1'],
+		]);
+	});
+
+	it('splices the stdin buffer into a dash it carries', async () => {
+		await expect(
+			resolveGivenFlag(flag.array(flag.string()).stdin(), ['before', '-', 'after'], {
+				stdinData: 'a\nb\n',
+			}),
+		).resolves.toEqual(['before', 'a', 'b', 'after']);
+	});
+
+	it('keeps a dash literal when the flag never reads stdin', async () => {
+		await expect(
+			resolveGivenFlag(flag.array(flag.string()), ['before', '-', 'after'], {
+				stdinData: 'a\nb\n',
+			}),
+		).resolves.toEqual(['before', '-', 'after']);
+	});
+
+	it('aggregates a variadic arg the same way', async () => {
+		await expect(resolveGivenArg(arg.string().variadic(), ['a', 'b'])).resolves.toEqual(['a', 'b']);
+	});
+
+	it('folds a variadic keyValue arg given ordered pairs', async () => {
+		await expect(
+			resolveGivenArg(arg.keyValue().variadic(), [
+				['A', '1'],
+				['A', '2'],
+			]),
+		).resolves.toEqual({ A: '2' });
+	});
+});
+
+describe('a caller-built aggregate', () => {
+	it('reaches the resolved value untouched for a many flag', async () => {
+		await expect(resolveGivenFlag(flag.array(flag.string()), 'a,b')).resolves.toBe('a,b');
+	});
+
+	it('reaches the resolved value untouched for an entries flag', async () => {
+		const given = { A: '1' };
+		await expect(resolveGivenFlag(flag.keyValue(), given)).resolves.toEqual(given);
+	});
+
+	it('skips the stdin splice even when the value is the sentinel string', async () => {
+		await expect(
+			resolveGivenFlag(flag.array(flag.string()).stdin(), '-', { stdinData: 'a\nb\n' }),
+		).resolves.toEqual(['a', 'b']);
+	});
+
+	it('reaches the resolved value untouched for a variadic arg', async () => {
+		await expect(resolveGivenArg(arg.string().variadic(), 'a,b')).resolves.toBe('a,b');
+	});
+
+	it('reaches the resolved value untouched for a variadic keyValue arg', async () => {
+		const given = { A: '1' };
+		await expect(resolveGivenArg(arg.keyValue().variadic(), given)).resolves.toEqual(given);
+	});
+});

--- a/src/core/resolve/resolve-hand-built.test.ts
+++ b/src/core/resolve/resolve-hand-built.test.ts
@@ -84,10 +84,13 @@ describe('a caller-built list of occurrences', () => {
 		).resolves.toEqual({ A: '2' });
 	});
 
-	it('drops an element of an entries flag that is not a pair', async () => {
+	it('rejects an element of an entries flag that is not a pair', async () => {
 		await expect(
 			resolveGivenFlag(flag.keyValue(), [['A', '1'], 'junk', ['B', '2']]),
-		).resolves.toEqual({ A: '1', B: '2' });
+		).rejects.toMatchObject({
+			code: 'TYPE_MISMATCH',
+			details: { flag: 'value', expected: 'object' },
+		});
 	});
 
 	it('keeps a pair-shaped element of a many flag whole', async () => {

--- a/src/core/resolve/resolve-hand-built.test.ts
+++ b/src/core/resolve/resolve-hand-built.test.ts
@@ -91,7 +91,16 @@ describe('a caller-built list of occurrences', () => {
 			resolveGivenFlag(flag.keyValue(), [['A', '1'], 'junk', ['B', '2']]),
 		).rejects.toMatchObject({
 			code: 'TYPE_MISMATCH',
-			details: { flag: 'value', expected: 'object' },
+			message: 'Invalid object value for flag --value',
+			details: { flag: 'value', source: 'cli', expected: 'object', value: 'junk' },
+		});
+	});
+
+	it('rejects a non-pair argument occurrence as CLI input', async () => {
+		await expect(resolveGivenArg(arg.keyValue(), [['A', '1'], 'junk'])).rejects.toMatchObject({
+			code: 'TYPE_MISMATCH',
+			message: 'Invalid object value for argument <value>',
+			details: { arg: 'value', source: 'cli', expected: 'object', value: 'junk' },
 		});
 	});
 

--- a/src/core/resolve/resolve-hand-built.test.ts
+++ b/src/core/resolve/resolve-hand-built.test.ts
@@ -46,6 +46,8 @@ async function resolveGivenArg(
 	return result.args.value;
 }
 
+// === caller-built occurrence lists
+
 describe('a caller-built list of occurrences', () => {
 	it('aggregates a many flag element by element', async () => {
 		await expect(resolveGivenFlag(flag.array(flag.string()), ['a', 'b'])).resolves.toEqual([
@@ -128,6 +130,8 @@ describe('a caller-built list of occurrences', () => {
 		).resolves.toEqual({ A: '2' });
 	});
 });
+
+// === caller-built aggregates
 
 describe('a caller-built aggregate', () => {
 	it('reaches the resolved value untouched for a many flag', async () => {

--- a/src/core/resolve/resolve-stdin-trim.test.ts
+++ b/src/core/resolve/resolve-stdin-trim.test.ts
@@ -1,0 +1,186 @@
+/**
+ * `.stdin({ trim: true })`: dropping the single terminator a pipe appends from a
+ * value that would otherwise keep it.
+ *
+ * @module dreamcli/core/resolve/resolve-stdin-trim.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parse } from '#internals/core/parse/index.ts';
+import { readFlags } from '#internals/core/read-flags/index.ts';
+import type { ArgBuilder, ArgConfig } from '#internals/core/schema/arg.ts';
+import { arg } from '#internals/core/schema/arg.ts';
+import { command } from '#internals/core/schema/command.ts';
+import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import { runCommand } from '#internals/core/testkit/index.ts';
+import type { ResolveOptions } from './index.ts';
+import { resolve } from './index.ts';
+
+// --- helpers
+
+/** Resolve one flag against the given argv and sources. */
+async function resolveFlag(
+	builder: FlagBuilder<FlagConfig>,
+	argv: readonly string[],
+	options: ResolveOptions = {},
+): Promise<unknown> {
+	const schema = command('deploy')
+		.flag('value', builder)
+		.action(() => {}).schema;
+	const result = await resolve(schema, parse(schema, argv), options);
+	return result.flags.value;
+}
+
+/** Resolve one positional against the given argv and sources. */
+async function resolveArg(
+	builder: ArgBuilder<ArgConfig>,
+	argv: readonly string[],
+	options: ResolveOptions = {},
+): Promise<unknown> {
+	const schema = command('deploy')
+		.arg('value', builder)
+		.action(() => {}).schema;
+	const result = await resolve(schema, parse(schema, argv), options);
+	return result.args.value;
+}
+
+// === the buffer a scalar receives
+
+describe('trim on a scalar', () => {
+	it('keeps the terminator by default', async () => {
+		expect(await resolveFlag(flag.string().stdin(), [], { stdinData: 'hello\n' })).toBe('hello\n');
+		expect(await resolveArg(arg.string().stdin(), [], { stdinData: 'hello\n' })).toBe('hello\n');
+	});
+
+	it('drops one trailing newline when asked', async () => {
+		expect(
+			await resolveFlag(flag.string().stdin({ trim: true }), [], { stdinData: 'hello\n' }),
+		).toBe('hello');
+		expect(await resolveArg(arg.string().stdin({ trim: true }), [], { stdinData: 'hello\n' })).toBe(
+			'hello',
+		);
+	});
+
+	it('drops a carriage return pair and a lone carriage return', async () => {
+		const piped = flag.string().stdin({ trim: true });
+		expect(await resolveFlag(piped, [], { stdinData: 'hello\r\n' })).toBe('hello');
+		expect(await resolveFlag(piped, [], { stdinData: 'hello\r' })).toBe('hello');
+	});
+
+	it('drops one terminator only', async () => {
+		expect(
+			await resolveFlag(flag.string().stdin({ trim: true }), [], { stdinData: 'hello\n\n' }),
+		).toBe('hello\n');
+	});
+
+	it('leaves a value with no terminator alone', async () => {
+		expect(await resolveFlag(flag.string().stdin({ trim: true }), [], { stdinData: 'hello' })).toBe(
+			'hello',
+		);
+	});
+
+	it('applies to an explicit dash the same way', async () => {
+		expect(
+			await resolveFlag(flag.string().stdin({ trim: true }), ['--value', '-'], {
+				stdinData: 'hello\n',
+			}),
+		).toBe('hello');
+	});
+
+	it('changes nothing for a codec that already drops the terminator', async () => {
+		expect(await resolveFlag(flag.number().stdin({ trim: true }), [], { stdinData: '42\n' })).toBe(
+			42,
+		);
+		expect(await resolveFlag(flag.number().stdin(), [], { stdinData: '42\n' })).toBe(42);
+	});
+
+	it('never takes a second terminator off a codec that drops one', async () => {
+		const piped = { stdinData: 'x\n\n' };
+		expect(
+			await resolveFlag(flag.custom((raw: unknown) => raw).stdin({ trim: true }), [], piped),
+		).toBe(await resolveFlag(flag.custom((raw: unknown) => raw).stdin(), [], piped));
+		expect(
+			await resolveFlag(flag.custom((raw: unknown) => raw).stdin({ trim: true }), [], piped),
+		).toBe('x\n');
+	});
+
+	it('leaves the elements of a collection to the split policy', async () => {
+		expect(
+			await resolveFlag(flag.array(flag.string()).stdin({ trim: true }), [], {
+				stdinData: 'a\nb\n',
+			}),
+		).toEqual(['a', 'b']);
+	});
+
+	it('does not reach a value from another source', async () => {
+		expect(
+			await resolveFlag(flag.string().stdin({ trim: true }).env('BODY'), [], {
+				env: { BODY: 'from-env\n' },
+			}),
+		).toBe('from-env\n');
+	});
+});
+
+// === constraints and checks see the trimmed value
+
+describe('trim runs before everything that reads the value', () => {
+	it('lets a piped path satisfy a mustExist check', async () => {
+		const seen: string[] = [];
+		const result = await resolveArg(arg.path({ mustExist: true }).stdin({ trim: true }), [], {
+			stdinData: './dist\n',
+			stat: async (path: string) => {
+				seen.push(path);
+				return 'directory';
+			},
+		});
+		expect(result).toBe('./dist');
+		expect(seen).toEqual(['./dist']);
+	});
+
+	it('checks the untrimmed path when trim is off', async () => {
+		const seen: string[] = [];
+		await resolveArg(arg.path({ mustExist: true }).stdin(), [], {
+			stdinData: './dist\n',
+			stat: async (path: string) => {
+				seen.push(path);
+				return 'directory';
+			},
+		});
+		expect(seen).toEqual(['./dist\n']);
+	});
+
+	it('measures the trimmed value against a string constraint', async () => {
+		expect(
+			await resolveFlag(flag.string({ maxLength: 5 }).stdin({ trim: true }), [], {
+				stdinData: 'hello\n',
+			}),
+		).toBe('hello');
+	});
+});
+
+// === the surfaces outside a command
+
+describe('trim reaches every entry point', () => {
+	it('applies through readFlags()', async () => {
+		const options = await readFlags(
+			{ body: flag.string().stdin({ trim: true }) },
+			{ argv: [], stdinData: 'piped\n', env: {} },
+		);
+		expect(options.body).toBe('piped');
+	});
+
+	it('applies through runCommand()', async () => {
+		let seen: unknown;
+		const cmd = command('run')
+			.arg('input', arg.string().stdin({ trim: true }))
+			.action(({ args }) => {
+				seen = args.input;
+			});
+
+		const result = await runCommand(cmd, [], { stdinData: 'piped\n' });
+
+		expect(result.exitCode).toBe(0);
+		expect(seen).toBe('piped');
+	});
+});

--- a/src/core/resolve/stages.ts
+++ b/src/core/resolve/stages.ts
@@ -17,7 +17,7 @@ import { STDIN_SENTINEL } from '#internals/core/schema/source.ts';
 import { stdinReadsOnDash, stdinReadsWhenMissing } from '#internals/core/schema/stdin.ts';
 import type { CliFinish, CoerceResult } from './coerce.ts';
 import { resolveConfigPath } from './config.ts';
-import type { ResolutionDiagnosticSource, ResolutionProvenance } from './contracts.ts';
+import type { DecodedDiagnosticSource, ResolutionProvenance } from './contracts.ts';
 
 /** What the parser produced for one input in this invocation. */
 type CliValue =
@@ -41,7 +41,7 @@ interface StageInput {
 	/** What the parser produced for this input. */
 	readonly cli: CliValue;
 	/** Decode a raw value from a non-CLI source into the input's declared type. */
-	readonly coerce: (source: ResolutionDiagnosticSource, raw: unknown) => CoerceResult;
+	readonly coerce: (source: DecodedDiagnosticSource, raw: unknown) => CoerceResult;
 	/**
 	 * Aggregate what the parser produced, splicing the stdin buffer into the
 	 * position each `-` occurrence holds.
@@ -212,7 +212,7 @@ async function promptStage(
 /** Decode a raw value and attach the stage's provenance on success. */
 function coerced(
 	input: StageInput,
-	source: ResolutionDiagnosticSource,
+	source: DecodedDiagnosticSource,
 	raw: unknown,
 	provenance: ResolutionProvenance,
 ): StageOutcome {

--- a/src/core/schema/AGENTS.md
+++ b/src/core/schema/AGENTS.md
@@ -174,9 +174,10 @@ through `valueDefinitionFields()` in both factories; only steps 3 and 10–11 ap
    (duplicate signatures; keep both in sync)
 4. `value.ts` — add a codec and value constructor when the kind carries a value, then add
    `flagValueSchema()` / `argValueSchema()` handling. Collection kinds project their element value.
-5. `parse/index.ts` — `coerceFlagValue()` case for a collection kind, plus a `flagValueError()` /
+5. `parse/index.ts` — `flagTokenOccurrence()` case for a collection kind, plus a `flagValueError()` /
    `argValueError()` arm for any new `ValueFailure`; update `flagExpectsValue()` if the kind takes
-   no value token; `setFlagValue()` if occurrences accumulate (array/keyValue style)
+   no value token; `flagTokenOccurrences()` if one token carries several elements, and
+   `projectOccurrences()` in `parse/occurrences.ts` if the kind folds its occurrences its own way
 6. `resolve/coerce.ts` — `coerceValue()` case for a collection kind, plus a `valueCoercionError()`
    arm for any new `ValueFailure`
 7. `resolve/flags.ts` — `COMPATIBLE_PROMPT_KINDS` entry; unset-fallback branch in `resolveFlags()`

--- a/src/core/schema/AGENTS.md
+++ b/src/core/schema/AGENTS.md
@@ -6,20 +6,20 @@ Multi-file module in `core/`. All others (except resolve, output, completion) us
 
 | File                    | Lines | Purpose                                                                                                                     |
 | ----------------------- | ----: | --------------------------------------------------------------------------------------------------------------------------- |
-| `command.ts`            |  1900 | `CommandBuilder<F, A, C>` — fluent builder + `Out` interface + schema + `createCommandSchema()`                             |
-| `flag.ts`               |  2077 | `FlagBuilder` — `flag.string/number/boolean/enum/array/custom/url/path/date/duration/bytes/count/keyValue()`                |
-| `arg.ts`                |  1547 | `ArgBuilder` — `arg.string/number/boolean/enum/custom/url/path/date/duration/bytes/keyValue()`                              |
+| `command.ts`            |  1923 | `CommandBuilder<F, A, C>` — fluent builder + `Out` interface + schema + `createCommandSchema()`                             |
+| `flag.ts`               |  2406 | `FlagBuilder` — `flag.string/number/boolean/enum/array/custom/url/path/date/duration/bytes/count/keyValue()`                |
+| `arg.ts`                |  2009 | `ArgBuilder` — `arg.string/number/boolean/enum/custom/url/path/date/duration/bytes/keyValue()`                              |
 | `brand.ts`              |    19 | `schemaBrand` — type-only `unique symbol` sealing flag, arg, command, CLI, and config-settings schemas                      |
 | `activity.ts`           |   240 | Activity types — `SpinnerHandle`, `ProgressHandle`, `ActivityEvent`, etc.                                                   |
 | `middleware.ts`         |   171 | `middleware<Output>(handler)` factory — phantom-branded `Middleware<Output>`                                                |
 | `prompt.ts`             |   171 | Prompt config types — `PromptConfig` discriminated union (4 kinds)                                                          |
-| `stdin.ts`              |   134 | `StdinBinding` / `StdinOptions` — the stdin axis both factories carry, plus its normalizer                                  |
-| `cardinality.ts`        |   674 | Internal cardinality axis: `Cardinality`, split policies, aggregation rules, declared-default validation                    |
-| `source.ts`             |   235 | Internal source axis — `RESOLUTION_ORDER`, `sourceBindings()`, stdin eligibility and exclusivity helpers                    |
+| `stdin.ts`              |   156 | `StdinBinding` / `StdinOptions` — the stdin axis both factories carry, plus its normalizer                                  |
+| `cardinality.ts`        |   679 | Internal cardinality axis: `Cardinality`, split policies, aggregation rules, declared-default validation                    |
+| `source.ts`             |   252 | Internal source axis — `RESOLUTION_ORDER`, `sourceBindings()`, stdin eligibility and exclusivity helpers                    |
 | `number-constraints.ts` |   153 | `NumberConstraints` + shared `validateNumberConstraints()` (parse & resolve both import it)                                 |
 | `string-constraints.ts` |   172 | `StringConstraints` + shared `validateStringConstraints()` / `stringConstraintDetails()` (parse & resolve both import them) |
 | `standard.ts`           |   143 | Vendored Standard Schema v1 types (no runtime dep) + `isStandardSchemaV1()` guard                                           |
-| `value.ts`              |   731 | Internal value layer (`ValueSchema`, `ValueCodec`, `decodeValue()`, both schema projections)                                |
+| `value.ts`              |   742 | Internal value layer (`ValueSchema`, `ValueCodec`, `decodeValue()`, both schema projections)                                |
 | `value-parsers.ts`      |   329 | Value machinery behind the sugar factories on both `flag` and `arg` — parsers, path option types, `buildPathChecks()`       |
 | `run.ts`                |   241 | `RunOptions` / `RunResult` — execution options + structured result (re-exported by testkit)                                 |
 | `index.ts`              |   157 | Barrel — re-exports all public symbols                                                                                      |
@@ -136,10 +136,14 @@ the chain was written in.
 ## SOURCE AXIS (`source.ts`, `stdin.ts`)
 
 Both internal. `stdin.ts` owns the stdin axis a flag or arg stores:
-`StdinBinding = { when: 'dash' | 'missing' | 'dash-or-missing', consume: 'exclusive' | 'broadcast' }`,
+`StdinBinding = { when: 'dash' | 'missing' | 'dash-or-missing', consume: 'exclusive' | 'broadcast', trim: boolean }`,
 normalized from the partial `StdinOptions` a caller writes. `stdinReadsOnDash()` and
 `stdinReadsWhenMissing()` are the only two places that decide what a `when` means, so the parse
-boundary, the preflight eligibility check, and the resolver cannot drift on it.
+boundary, the preflight eligibility check, and the resolver cannot drift on it. `trim` is read once,
+by `trimmedStdinValue()` in `resolve/coerce.ts`, which routes the scalar value through
+`stripTerminator()` from `cardinality.ts`. It applies only where `keepsStdinTerminator()` in
+`value.ts` says the codec still carries the terminator, which is the same predicate `decodeValue()`
+uses to drop it for every other codec, so the two cannot take a terminator each.
 
 `source.ts` owns the rest of the axis:
 
@@ -154,6 +158,9 @@ boundary, the preflight eligibility check, and the resolver cannot drift on it.
   stage would select it. A collection's occurrences reach it as a list, so it looks for the `-`
   sentinel among them as well as for a lone `-`, which is what makes `--tag before --tag -` read the
   stream at all.
+- `argCollectedNothing()` is the one definition of an empty positional tail. The preflight and
+  `resolve/args.ts` both read it, so a variadic arg that collected no token is missing for the stdin
+  fallback in the same way at both ends.
 - `stdinConsumers()` and `stdinConsumerReference()` back the `DUPLICATE_STDIN_INPUT` rule in
   `command.ts`, which spans flags and args together.
 
@@ -263,8 +270,9 @@ Runtime enforcement lives in `resolve/flags.ts` (`COMPATIBLE_PROMPT_KINDS` + `va
   that would be lost. `readFlags()` carries its own copy of both checks, worded for a definitions
   record.
 - `buildCommandSchema()` runs `validateArgEntry()` over the accumulating arg list and
-  `validateFlagStdinEntry()` over each flag, so the stdin/variadic invariants `.arg()` and `.flag()`
-  enforce also apply to a definition composed as data. Stdin exclusivity spans both surfaces, so
+  `validateFlagStdinEntry()` over each flag, so the positional-order and stdin invariants `.arg()`
+  and `.flag()` enforce also apply to a definition composed as data. `assertVariadicIsLast()` is the
+  positional-order rule: a variadic arg consumes the whole tail, so nothing may follow it. Stdin exclusivity spans both surfaces, so
   each check sees the flags and args registered so far. It takes
   the command name and puts it in `details` on all three errors, since a definition tree reaches
   those throws at any depth and the arg name alone does not say which command declared it.
@@ -300,4 +308,5 @@ Runtime enforcement lives in `resolve/flags.ts` (`COMPATIBLE_PROMPT_KINDS` + `va
 | `middleware.test.ts`                | Middleware factory, context typing                            |
 | `prompt.test.ts`                    | Prompt config types                                           |
 | `stdin-exclusivity.test.ts`         | One exclusive stdin consumer per command + `sourceBindings()` |
+| `input-modifier-guards.test.ts`     | Arg collection modifiers + `.stdin()` on a count flag         |
 | `derive.test.ts`                    | Type derivation tests                                         |

--- a/src/core/schema/AGENTS.md
+++ b/src/core/schema/AGENTS.md
@@ -285,7 +285,7 @@ Runtime enforcement lives in `resolve/flags.ts` (`COMPATIBLE_PROMPT_KINDS` + `va
   `toString`, which then reads as a supplied value. `resolveFlags()` in `resolve/` guards its `env`
   lookup and the interactive resolver's override record with `Object.hasOwn()` for that reason.
 
-## TEST FILES (20)
+## TEST FILES (21)
 
 | File                                | Tests                                                         |
 | ----------------------------------- | ------------------------------------------------------------- |

--- a/src/core/schema/arg-value-factories.test.ts
+++ b/src/core/schema/arg-value-factories.test.ts
@@ -203,13 +203,13 @@ describe('createArgSchema — new fields', () => {
 		expect(() => arg.string().minLength(5).maxLength(2)).toThrow(RangeError);
 	});
 
-	it('rejects a sugar kind that is both variadic and stdin-backed, in either chain order', () => {
-		expect(() => command('c').arg('x', arg.url().variadic().stdin())).toThrow(
-			/cannot be both variadic and stdin-backed/,
-		);
-		expect(() => command('c').arg('x', arg.path().stdin().variadic())).toThrow(
-			/cannot be both variadic and stdin-backed/,
-		);
+	it('accepts a sugar kind that is both variadic and stdin-backed, in either chain order', () => {
+		expect(
+			command('c').arg('x', arg.url().variadic().stdin()).schema.args[0]?.schema,
+		).toMatchObject({ variadic: true, stdin: { when: 'dash-or-missing' } });
+		expect(
+			command('c').arg('x', arg.path().stdin().variadic()).schema.args[0]?.schema,
+		).toMatchObject({ variadic: true, stdin: { when: 'dash-or-missing' } });
 	});
 });
 

--- a/src/core/schema/arg.test.ts
+++ b/src/core/schema/arg.test.ts
@@ -216,14 +216,18 @@ describe('.variadic()', () => {
 });
 
 describe('.stdin()', () => {
-	it('binds stdin to dash-or-missing exclusive by default', () => {
+	it('binds stdin to dash-or-missing exclusive untrimmed by default', () => {
 		const a = arg.string().stdin();
-		expect(a.schema.stdin).toEqual({ when: 'dash-or-missing', consume: 'exclusive' });
+		expect(a.schema.stdin).toEqual({
+			when: 'dash-or-missing',
+			consume: 'exclusive',
+			trim: false,
+		});
 	});
 
-	it('carries an explicit trigger and consumption mode', () => {
-		const a = arg.string().stdin({ when: 'dash', consume: 'broadcast' });
-		expect(a.schema.stdin).toEqual({ when: 'dash', consume: 'broadcast' });
+	it('carries an explicit trigger, consumption mode, and trimming', () => {
+		const a = arg.string().stdin({ when: 'dash', consume: 'broadcast', trim: true });
+		expect(a.schema.stdin).toEqual({ when: 'dash', consume: 'broadcast', trim: true });
 	});
 
 	it('preserves type inference', () => {
@@ -235,7 +239,11 @@ describe('.stdin()', () => {
 		const base = arg.string();
 		const stdinArg = base.stdin();
 		expect(base.schema.stdin).toBeUndefined();
-		expect(stdinArg.schema.stdin).toEqual({ when: 'dash-or-missing', consume: 'exclusive' });
+		expect(stdinArg.schema.stdin).toEqual({
+			when: 'dash-or-missing',
+			consume: 'exclusive',
+			trim: false,
+		});
 	});
 });
 

--- a/src/core/schema/arg.ts
+++ b/src/core/schema/arg.ts
@@ -1460,6 +1460,7 @@ function nextArg<C extends ArgConfig>(schema: ArgSchema): ArgBuilder<C> {
  * @returns A builder over that schema.
  * @throws {CLIError} With code `'INVALID_SCHEMA'` when the field does not belong
  *   on the arg, or `'INVALID_DEFAULT'` when the default no longer holds.
+ * @internal
  */
 function nextCollectionArg<C extends ArgConfig>(schema: ArgSchema): ArgBuilder<C> {
 	assertValidArgDefinition(schema.kind, schema);

--- a/src/core/schema/arg.ts
+++ b/src/core/schema/arg.ts
@@ -179,6 +179,9 @@ const ARG_KINDS = ['string', 'number', 'boolean', 'enum', 'custom', 'keyValue'] 
 /** Discriminator for the kind of value an arg accepts. */
 type ArgKind = (typeof ARG_KINDS)[number];
 
+/** Arg kinds whose variadic form resolves to a list. @internal */
+type ListArgKind = Exclude<ArgKind, 'keyValue'>;
+
 /** Custom parse function for `arg.custom()`. */
 type ArgParseFn<T> = (raw: string) => T;
 
@@ -1020,7 +1023,10 @@ class ArgBuilder<C extends ArgConfig> {
 	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on an arg that resolves to
 	 *   one value or to a record.
 	 */
-	unique(this: ArgBuilder<C & { readonly variadic: true }>, value = true): ArgBuilder<C> {
+	unique(
+		this: ArgBuilder<C & { readonly variadic: true; readonly argKind: ListArgKind }>,
+		value = true,
+	): ArgBuilder<C> {
 		return nextCollectionArg({ ...this.schema, unique: value });
 	}
 

--- a/src/core/schema/arg.ts
+++ b/src/core/schema/arg.ts
@@ -504,6 +504,9 @@ type ArgDefinitionArguments<K extends ArgKind> = K extends 'enum'
 	? [overrides: ArgDefinitionOverrides<K>]
 	: [overrides?: ArgDefinitionOverrides<K>];
 
+/** Fields only an arg that aggregates can carry. */
+const COLLECTION_ARG_FIELDS: readonly (keyof ArgSchemaFields)[] = ['separator', 'split'];
+
 /**
  * Fields that are only meaningful on one {@link ArgKind}, mapped to that kind.
  */
@@ -557,7 +560,9 @@ function assertValidArgDefinition(kind: ArgKind, fields: ArgSchemaFieldOverrides
 		});
 	}
 
-	if (fields.aggregateStandard !== undefined && kind !== 'keyValue' && fields.variadic !== true) {
+	const aggregates = kind === 'keyValue' || fields.variadic === true;
+
+	if (fields.aggregateStandard !== undefined && !aggregates) {
 		throw new CLIError(
 			`Arg schema field 'aggregateStandard' requires a collection, received a non-variadic '${kind}' arg`,
 			{
@@ -567,11 +572,32 @@ function assertValidArgDefinition(kind: ArgKind, fields: ArgSchemaFieldOverrides
 			},
 		);
 	}
+
 	if (kind === 'keyValue' && fields.prompt !== undefined) {
 		throw new CLIError("Arg schema field 'prompt' is not available on kind 'keyValue'", {
 			code: 'INVALID_SCHEMA',
 			details: { kind, field: 'prompt' },
 			suggest: "Drop 'prompt' from the keyValue argument",
+		});
+	}
+
+	for (const field of COLLECTION_ARG_FIELDS) {
+		if (fields[field] === undefined || aggregates) continue;
+		throw new CLIError(
+			`Arg schema field '${field}' requires a collection, received a non-variadic '${kind}' arg`,
+			{
+				code: 'INVALID_SCHEMA',
+				details: { kind, field },
+				suggest: `Add 'variadic: true', declare the arg as kind 'keyValue', or drop '${field}'`,
+			},
+		);
+	}
+
+	if (fields.unique === true && (kind === 'keyValue' || fields.variadic !== true)) {
+		throw new CLIError("Arg schema field 'unique' requires a variadic arg of a list kind", {
+			code: 'INVALID_SCHEMA',
+			details: { kind, field: 'unique' },
+			suggest: "Add 'variadic: true' on a list kind, or drop 'unique'",
 		});
 	}
 }
@@ -892,7 +918,9 @@ class ArgBuilder<C extends ArgConfig> {
 	 * Mark this arg as variadic — it consumes all remaining positional
 	 * arguments. The inferred type becomes `T[]`.
 	 *
-	 * A variadic arg must be the last positional in a command.
+	 * A variadic arg is the last positional a command can declare. Registering
+	 * another positional after it throws `INVALID_BUILDER_STATE` from `.arg()`
+	 * and from `createCommandSchema()`.
 	 *
 	 * @example
 	 * ```ts
@@ -913,9 +941,7 @@ class ArgBuilder<C extends ArgConfig> {
 	 * @returns The builder (for chaining).
 	 */
 	variadic(): ArgBuilder<WithVariadic<C>> {
-		const schema: ArgSchema = { ...this.schema, variadic: true };
-		assertValidArgDefault(undefined, schema);
-		return new ArgBuilder(schema);
+		return nextArg({ ...this.schema, variadic: true });
 	}
 
 	/**
@@ -925,15 +951,22 @@ class ArgBuilder<C extends ArgConfig> {
 	 * The separator is the CLI policy alone. Env values split on `','` and the
 	 * stdin buffer on line terminators unless `.split()` says otherwise.
 	 *
-	 * Only an arg that aggregates reads this. On a single-value arg it is stored
-	 * and never applied, because there are no elements to split into.
+	 * Available on an arg that aggregates, so call it after `.variadic()` or on
+	 * `arg.keyValue()`.
 	 *
 	 * @param value - Separator string (e.g. `','`).
 	 * @returns The builder (for chaining).
+	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on an arg carrying a single
+	 *   value.
 	 */
-	separator(value: string): ArgBuilder<C> {
+	separator(
+		this:
+			| ArgBuilder<C & { readonly variadic: true }>
+			| ArgBuilder<C & { readonly argKind: 'keyValue' }>,
+		value: string,
+	): ArgBuilder<C> {
 		normalizeSplitPolicy('cli', value);
-		return new ArgBuilder({ ...this.schema, separator: value });
+		return nextCollectionArg({ ...this.schema, separator: value });
 	}
 
 	/**
@@ -947,13 +980,13 @@ class ArgBuilder<C extends ArgConfig> {
 	 * line-delimited stdin. For stdin, `'whole'` passes the complete buffer to a
 	 * string element, including its final line terminator.
 	 *
-	 * Only an arg that aggregates reads this. `arg.keyValue()` is the one arg
-	 * that both aggregates and reads stdin, since a variadic arg may not.
+	 * Available on an arg that aggregates, so call it after `.variadic()` or on
+	 * `arg.keyValue()`.
 	 *
 	 * @param options - Per-source split settings.
 	 * @returns The builder (for chaining).
 	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on a format the source does
-	 *   not accept, or an empty delimiter.
+	 *   not accept, an empty delimiter, or an arg carrying a single value.
 	 *
 	 * @example
 	 * ```ts
@@ -961,9 +994,14 @@ class ArgBuilder<C extends ArgConfig> {
 	 * // FILES='["a.ts","b.ts"]' → ['a.ts', 'b.ts']
 	 * ```
 	 */
-	split(options: SplitOptions): ArgBuilder<C> {
+	split(
+		this:
+			| ArgBuilder<C & { readonly variadic: true }>
+			| ArgBuilder<C & { readonly argKind: 'keyValue' }>,
+		options: SplitOptions,
+	): ArgBuilder<C> {
 		const normalized = normalizeSplitOptions(options, this.schema.split);
-		return new ArgBuilder({
+		return nextCollectionArg({
 			...this.schema,
 			...(normalized.setsSeparator ? { separator: normalized.separator } : {}),
 			split: normalized.split,
@@ -974,15 +1012,16 @@ class ArgBuilder<C extends ArgConfig> {
 	 * Deduplicate the resolved values of a variadic arg, preserving first-seen
 	 * order. Applied after all sources resolve, using `SameValueZero` semantics.
 	 *
-	 * Only a variadic arg reads this. On a single-value arg it is stored and
-	 * never applied, because there is no list to deduplicate.
+	 * Available on a variadic arg of a list kind, so call it after `.variadic()`.
 	 *
 	 * @param value - Whether to deduplicate.
 	 * @defaultValue `true`
 	 * @returns The builder (for chaining).
+	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on an arg that resolves to
+	 *   one value or to a record.
 	 */
-	unique(value = true): ArgBuilder<C> {
-		return new ArgBuilder({ ...this.schema, unique: value });
+	unique(this: ArgBuilder<C & { readonly variadic: true }>, value = true): ArgBuilder<C> {
+		return nextCollectionArg({ ...this.schema, unique: value });
 	}
 
 	/**
@@ -990,6 +1029,8 @@ class ArgBuilder<C extends ArgConfig> {
 	 *
 	 * @param policy - `'last'` (default), `'first'`, or `'error'`.
 	 * @returns The builder (for chaining).
+	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on an arg that is not
+	 *   `arg.keyValue()`.
 	 *
 	 * @example
 	 * ```ts
@@ -1002,7 +1043,7 @@ class ArgBuilder<C extends ArgConfig> {
 		this: ArgBuilder<C & { readonly argKind: 'keyValue' }>,
 		policy: DuplicateKeys,
 	): ArgBuilder<C> {
-		return new ArgBuilder({ ...this.schema, duplicateKeys: policy });
+		return nextCollectionArg({ ...this.schema, duplicateKeys: policy });
 	}
 
 	/**
@@ -1027,12 +1068,10 @@ class ArgBuilder<C extends ArgConfig> {
 	 */
 	standard(schema: StandardSchemaV1): ArgBuilder<C> {
 		const aggregate = isCollection(argCardinality(this.schema));
-		const next: ArgSchema = {
+		return nextArg({
 			...this.schema,
 			...(aggregate ? { aggregateStandard: schema } : { standard: schema }),
-		};
-		assertValidArgDefault(undefined, next);
-		return new ArgBuilder(next);
+		});
 	}
 
 	/**
@@ -1043,12 +1082,23 @@ class ArgBuilder<C extends ArgConfig> {
 	 * which sits between CLI and env, so an arg set in the environment still
 	 * reads stdin and stdin wins. The whole buffer becomes the value, byte for
 	 * byte for a string arg; every other kind drops the single line terminator a
-	 * pipe appends before decoding.
+	 * pipe appends before decoding, and `{ trim: true }` drops it for a string
+	 * arg too.
+	 *
+	 * On an arg that aggregates, a `-` among the tail tokens splices what the
+	 * buffer decodes to into that position, so `mycli build a - b` over
+	 * `'x\ny\n'` collects `['a', 'x', 'y', 'b']`. Each `-` stands for the whole
+	 * source, so two of them splice the buffer twice. A `-` typed beside other
+	 * tokens with nothing piped fails with `REQUIRED_ARG`; a tail of nothing but
+	 * `-` falls through to the later sources.
+	 *
+	 * A stdin-enabled arg cannot receive a literal `-` as its value, since the
+	 * token names the source.
 	 *
 	 * One command may declare a single exclusive stdin consumer; pass
 	 * `{ consume: 'broadcast' }` on every input that should share the buffer.
 	 *
-	 * @param options - When to read stdin and how to share it.
+	 * @param options - When to read stdin, how to share it, and whether to trim.
 	 * @returns The builder (for chaining).
 	 *
 	 * @example
@@ -1060,6 +1110,9 @@ class ArgBuilder<C extends ArgConfig> {
 	 *
 	 * arg.string().stdin({ when: 'dash' })
 	 * // only an explicit `-` reads stdin
+	 *
+	 * arg.path({ mustExist: true }).stdin({ trim: true })
+	 * // $ echo ./dist | mycli clean        → path = './dist', checked on disk
 	 * ```
 	 */
 	stdin(options?: StdinOptions): ArgBuilder<C> {
@@ -1385,6 +1438,23 @@ class ArgBuilder<C extends ArgConfig> {
 function nextArg<C extends ArgConfig>(schema: ArgSchema): ArgBuilder<C> {
 	assertValidArgDefault(undefined, schema);
 	return new ArgBuilder(schema);
+}
+
+/**
+ * Continue a builder chain past a modifier only an arg that aggregates carries.
+ *
+ * The `this` constraints on those modifiers state the rule to the compiler; this
+ * states it to a caller who reaches the builder from JavaScript, with the error
+ * the definition path already gives.
+ *
+ * @param schema - The schema the modifier produced.
+ * @returns A builder over that schema.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` when the field does not belong
+ *   on the arg, or `'INVALID_DEFAULT'` when the default no longer holds.
+ */
+function nextCollectionArg<C extends ArgConfig>(schema: ArgSchema): ArgBuilder<C> {
+	assertValidArgDefinition(schema.kind, schema);
+	return nextArg(schema);
 }
 
 // --- Factory namespace

--- a/src/core/schema/arg.ts
+++ b/src/core/schema/arg.ts
@@ -1027,6 +1027,9 @@ class ArgBuilder<C extends ArgConfig> {
 		this: ArgBuilder<C & { readonly variadic: true; readonly argKind: ListArgKind }>,
 		value = true,
 	): ArgBuilder<C> {
+		if (this.schema.kind === 'keyValue' || this.schema.variadic !== true) {
+			assertValidArgDefinition(this.schema.kind, { ...this.schema, unique: true });
+		}
 		return nextCollectionArg({ ...this.schema, unique: value });
 	}
 

--- a/src/core/schema/cardinality.test.ts
+++ b/src/core/schema/cardinality.test.ts
@@ -151,8 +151,8 @@ describe('foldEntries()', () => {
 		expect(foldEntries(pairs, 'first')).toEqual({ ok: true, value: { A: '1', B: '2' } });
 	});
 
-	it('reports the repeated key under error', () => {
-		expect(foldEntries(pairs, 'error')).toEqual({ ok: false, duplicateKey: 'A' });
+	it('reports the repeated key and where it repeated under error', () => {
+		expect(foldEntries(pairs, 'error')).toEqual({ ok: false, duplicateKey: 'A', at: 2 });
 	});
 
 	it('stores a __proto__ key as an own entry', () => {

--- a/src/core/schema/cardinality.ts
+++ b/src/core/schema/cardinality.ts
@@ -494,6 +494,13 @@ function parseJson(
 	}
 }
 
+/** Drop the single line terminator a pipe appends. */
+function stripTerminator(text: string): string {
+	if (text.endsWith('\r\n')) return text.slice(0, -2);
+	if (text.endsWith('\n') || text.endsWith('\r')) return text.slice(0, -1);
+	return text;
+}
+
 // --- Aggregation
 
 /** Deduplicate a resolved array, preserving first-seen order. */
@@ -501,10 +508,15 @@ function dedupe(values: readonly unknown[]): readonly unknown[] {
 	return [...new Set(values)];
 }
 
-/** The record entries folded to, or the key a duplicate policy rejected. */
+/**
+ * The record entries folded to, or the key a duplicate policy rejected.
+ *
+ * `at` is the index of the repeating pair, so a caller that knows where each
+ * pair came from can name that source in its diagnostic.
+ */
 type FoldResult =
 	| { readonly ok: true; readonly value: Readonly<Record<string, unknown>> }
-	| { readonly ok: false; readonly duplicateKey: string };
+	| { readonly ok: false; readonly duplicateKey: string; readonly at: number };
 
 /**
  * Fold ordered pairs into a record under a duplicate-key policy.
@@ -514,16 +526,16 @@ type FoldResult =
  *
  * @param pairs - The pairs in occurrence order.
  * @param duplicateKeys - What a repeated key means.
- * @returns The record, or the key that repeated under `'error'`.
+ * @returns The record, or the key that repeated under `'error'` and where.
  */
 function foldEntries(
 	pairs: readonly (readonly [string, unknown])[],
 	duplicateKeys: DuplicateKeys,
 ): FoldResult {
 	const kept = new Map<string, unknown>();
-	for (const [key, value] of pairs) {
+	for (const [at, [key, value]] of pairs.entries()) {
 		if (kept.has(key)) {
-			if (duplicateKeys === 'error') return { ok: false, duplicateKey: key };
+			if (duplicateKeys === 'error') return { ok: false, duplicateKey: key, at };
 			if (duplicateKeys === 'first') continue;
 		}
 		kept.set(key, value);
@@ -692,5 +704,6 @@ export {
 	splitEntryPair,
 	splitLines,
 	splitManyText,
+	stripTerminator,
 	validateDefault,
 };

--- a/src/core/schema/command.test.ts
+++ b/src/core/schema/command.test.ts
@@ -253,9 +253,35 @@ describe('.arg()', () => {
 		}
 	});
 
-	it('rejects stdin then variadic args at build time', () => {
+	it('accepts a variadic stdin arg in either chain order', () => {
+		for (const builder of [arg.string().stdin().variadic(), arg.string().variadic().stdin()]) {
+			const entry = command('copy').arg('files', builder).schema.args[0];
+			expect(entry?.schema.variadic).toBe(true);
+			expect(entry?.schema.stdin).toEqual({
+				when: 'dash-or-missing',
+				consume: 'exclusive',
+				trim: false,
+			});
+		}
+	});
+
+	it('rejects a positional declared after a variadic one', () => {
 		try {
-			command('copy').arg('files', arg.string().stdin().variadic());
+			command('copy').arg('files', arg.string().variadic()).arg('target', arg.string());
+			expect.unreachable('should have thrown');
+		} catch (error) {
+			expect(error).toBeInstanceOf(CLIError);
+			if (error instanceof CLIError) {
+				expect(error.code).toBe('INVALID_BUILDER_STATE');
+				expect(error.message).toContain('comes after variadic argument <files>');
+				expect(error.details).toMatchObject({ arg: 'target', variadicArg: 'files' });
+			}
+		}
+	});
+
+	it('rejects a second variadic arg on one command', () => {
+		try {
+			command('copy').arg('files', arg.string().variadic()).arg('more', arg.string().variadic());
 			expect.unreachable('should have thrown');
 		} catch (error) {
 			expect(error).toBeInstanceOf(CLIError);
@@ -265,16 +291,11 @@ describe('.arg()', () => {
 		}
 	});
 
-	it('rejects variadic then stdin args at build time', () => {
-		try {
-			command('copy').arg('files', arg.string().variadic().stdin());
-			expect.unreachable('should have thrown');
-		} catch (error) {
-			expect(error).toBeInstanceOf(CLIError);
-			if (error instanceof CLIError) {
-				expect(error.code).toBe('INVALID_BUILDER_STATE');
-			}
-		}
+	it('accepts a variadic keyValue arg as the last positional', () => {
+		const schema = command('run')
+			.arg('target', arg.string())
+			.arg('vars', arg.keyValue().variadic()).schema;
+		expect(schema.args.map((entry) => entry.name)).toEqual(['target', 'vars']);
 	});
 });
 
@@ -1239,11 +1260,38 @@ describe('CommandBuilder.arg() prototype keys', () => {
 // === Arg invariants shared by both construction paths
 
 describe('createCommandSchema() arg invariants', () => {
-	it('rejects one arg that is both variadic and stdin-backed', () => {
+	it('accepts one arg that is both variadic and stdin-backed', () => {
+		const schema = createCommandSchema({
+			name: 'run',
+			args: [{ name: 'input', schema: { kind: 'string', variadic: true, stdin: {} } }],
+		});
+		expect(schema.args[0]?.schema.stdin).toEqual({
+			when: 'dash-or-missing',
+			consume: 'exclusive',
+			trim: false,
+		});
+	});
+
+	it('rejects a positional declared after a variadic one', () => {
 		const build = () =>
 			createCommandSchema({
 				name: 'run',
-				args: [{ name: 'input', schema: { kind: 'string', variadic: true, stdin: {} } }],
+				args: [
+					{ name: 'files', schema: { kind: 'string', variadic: true } },
+					{ name: 'target', schema: { kind: 'string' } },
+				],
+			});
+		expect(schemaErrorCode(build)).toBe('INVALID_BUILDER_STATE');
+	});
+
+	it('rejects two variadic args on one command', () => {
+		const build = () =>
+			createCommandSchema({
+				name: 'run',
+				args: [
+					{ name: 'files', schema: { kind: 'string', variadic: true } },
+					{ name: 'more', schema: { kind: 'string', variadic: true } },
+				],
 			});
 		expect(schemaErrorCode(build)).toBe('INVALID_BUILDER_STATE');
 	});
@@ -1315,14 +1363,17 @@ describe('createCommandSchema() arg error details', () => {
 		expect(thrown.details).toEqual({ command: 'up', arg: 'second', existingArg: 'first' });
 	});
 
-	it('names the command a nested variadic stdin arg was declared on', () => {
+	it('names the command a nested misplaced positional was declared on', () => {
 		const thrown = schemaError(() =>
 			createCommandSchema({
 				name: 'db',
 				commands: [
 					{
 						name: 'migrate',
-						args: [{ name: 'input', schema: { kind: 'string', stdin: {}, variadic: true } }],
+						args: [
+							{ name: 'files', schema: { kind: 'string', variadic: true } },
+							{ name: 'target', schema: { kind: 'string' } },
+						],
 					},
 				],
 			}),
@@ -1331,9 +1382,8 @@ describe('createCommandSchema() arg error details', () => {
 		expect(thrown.code).toBe('INVALID_BUILDER_STATE');
 		expect(thrown.details).toEqual({
 			command: 'migrate',
-			arg: 'input',
-			stdin: { when: 'dash-or-missing', consume: 'exclusive' },
-			variadic: true,
+			arg: 'target',
+			variadicArg: 'files',
 		});
 	});
 

--- a/src/core/schema/command.ts
+++ b/src/core/schema/command.ts
@@ -714,8 +714,8 @@ function assertUsableArgKey(commandName: string, name: string): void {
  * @throws {@link CLIError} `INVALID_SCHEMA` when a name at any depth is empty
  *   or contains whitespace, a flag or arg is named `__proto__` at any depth,
  *   or a flag record at any depth has a replaced prototype.
- * @throws {@link CLIError} `INVALID_BUILDER_STATE` or `DUPLICATE_STDIN_INPUT`
- *   when an input breaks the stdin/variadic invariants.
+ * @throws {@link CLIError} `INVALID_BUILDER_STATE` or `DUPLICATE_STDIN_INPUT` when
+ *   an input breaks the positional-order or stdin invariants.
  *
  * @internal
  */
@@ -792,9 +792,9 @@ function buildCommandSchema(definition: CommandDefinition): CommandSchema {
  *   command share a spelling.
  * @throws {CLIError} With code `'PROPAGATED_FLAG_COLLISION'` when a flag shadows
  *   a spelling propagated from an ancestor command.
- * @throws {CLIError} With code `'INVALID_BUILDER_STATE'` when an arg is both
- *   variadic and stdin-backed, or `'DUPLICATE_STDIN_INPUT'` when two inputs on
- *   one command consume stdin and either is exclusive.
+ * @throws {CLIError} With code `'INVALID_BUILDER_STATE'` when a positional comes
+ *   after a variadic one, or `'DUPLICATE_STDIN_INPUT'` when two inputs on one
+ *   command consume stdin and either is exclusive.
  *
  * @example
  * ```ts
@@ -823,10 +823,8 @@ function createCommandSchema(definition: CommandDefinition): CommandSchema {
  * @param args - Already-registered arg entries on this command.
  *
  * @throws {@link CLIError} `INVALID_SCHEMA` if the name is `__proto__`.
- * @throws {@link CLIError} `INVALID_BUILDER_STATE` if both `.stdin()` and
- *   `.variadic()` are set.
- * @throws {@link CLIError} `DUPLICATE_STDIN_INPUT` if another input already
- *   consumes stdin exclusively.
+ * @throws {@link CLIError} `INVALID_BUILDER_STATE` if an earlier arg is variadic.
+ * @throws {@link CLIError} `DUPLICATE_STDIN_INPUT` if another input already consumes stdin exclusively.
  *
  * @internal
  */
@@ -838,15 +836,39 @@ function validateArgEntry(
 	args: readonly CommandArgEntry[],
 ): void {
 	assertUsableArgKey(commandName, name);
-	if (schema.stdin !== undefined && schema.variadic) {
-		throw new CLIError(`Argument <${name}> cannot be both variadic and stdin-backed`, {
-			code: 'INVALID_BUILDER_STATE',
-			details: { command: commandName, arg: name, stdin: { ...schema.stdin }, variadic: true },
-			suggest: 'Remove .stdin() or .variadic() from this argument',
-		});
-	}
-
+	assertVariadicIsLast(commandName, name, args);
 	assertStdinExclusivity(commandName, { kind: 'arg', name, stdin: schema.stdin }, flags, args);
+}
+
+/**
+ * Reject a positional declared after one that consumes the whole tail.
+ *
+ * A variadic arg takes every remaining positional, so anything registered after
+ * it can never be filled, and a second variadic arg has nothing left to collect.
+ *
+ * @param commandName - Command the arg was declared on.
+ * @param name - Arg name being registered.
+ * @param args - Already-registered arg entries on this command.
+ * @throws {@link CLIError} `INVALID_BUILDER_STATE` when an earlier arg is variadic.
+ *
+ * @internal
+ */
+function assertVariadicIsLast(
+	commandName: string,
+	name: string,
+	args: readonly CommandArgEntry[],
+): void {
+	const greedy = args.find((entry) => entry.schema.variadic);
+	if (greedy === undefined) return;
+
+	throw new CLIError(
+		`Argument <${name}> comes after variadic argument <${greedy.name}>, which consumes every remaining positional`,
+		{
+			code: 'INVALID_BUILDER_STATE',
+			details: { command: commandName, arg: name, variadicArg: greedy.name },
+			suggest: `Declare <${name}> before <${greedy.name}>, or drop .variadic() from <${greedy.name}>`,
+		},
+	);
 }
 
 /**
@@ -1688,8 +1710,8 @@ class CommandBuilder<
 	 * @returns The builder (for chaining).
 	 * @throws {@link CLIError} `INVALID_SCHEMA` when the name is `__proto__`,
 	 *   which a plain record cannot carry.
-	 * @throws {@link CLIError} `INVALID_BUILDER_STATE` when the arg is both
-	 *   variadic and stdin-backed.
+	 * @throws {@link CLIError} `INVALID_BUILDER_STATE` when an earlier arg on this
+	 *   command is variadic, so this one could never be filled.
 	 * @throws {@link CLIError} `DUPLICATE_STDIN_INPUT` when another input on this
 	 *   command already consumes stdin exclusively.
 	 */

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -913,13 +913,28 @@ function assertValidFlagDefinition(kind: FlagKind, fields: FlagDefinitionFields)
 		});
 	}
 
-	if (fields.stdin !== undefined && !STDIN_CAPABLE_FLAG_KINDS.some((allowed) => allowed === kind)) {
-		throw new CLIError(`Flag schema field 'stdin' is not available on kind '${kind}'`, {
-			code: 'INVALID_SCHEMA',
-			details: { kind, field: 'stdin', allowedKinds: [...STDIN_CAPABLE_FLAG_KINDS] },
-			suggest: `Drop 'stdin' or declare the flag as one of: ${STDIN_CAPABLE_FLAG_KINDS.join(', ')}`,
-		});
+	if (fields.stdin !== undefined) {
+		assertStdinCapableKind(kind);
 	}
+}
+
+/**
+ * Reject a stdin binding on a flag kind that has no value to read.
+ *
+ * A `count` flag carries occurrences rather than a value, so both construction
+ * paths refuse the binding with the same error.
+ *
+ * @param kind - Declared kind of the flag.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` on a kind that cannot read stdin.
+ */
+function assertStdinCapableKind(kind: FlagKind): void {
+	if (STDIN_CAPABLE_FLAG_KINDS.some((allowed) => allowed === kind)) return;
+
+	throw new CLIError(`Flag schema field 'stdin' is not available on kind '${kind}'`, {
+		code: 'INVALID_SCHEMA',
+		details: { kind, field: 'stdin', allowedKinds: [...STDIN_CAPABLE_FLAG_KINDS] },
+		suggest: `Drop 'stdin' or declare the flag as one of: ${STDIN_CAPABLE_FLAG_KINDS.join(', ')}`,
+	});
 }
 
 /**
@@ -1266,19 +1281,28 @@ class FlagBuilder<C extends FlagConfig> {
 	 * between CLI and env, so a flag set in the environment still reads stdin
 	 * and stdin wins. The whole buffer becomes the value, byte for byte for a
 	 * string flag; every other kind drops the single line terminator a pipe
-	 * appends before decoding.
+	 * appends before decoding, and `{ trim: true }` drops it for a string flag
+	 * too.
 	 *
 	 * A collection reads the buffer as elements instead: `--tag -` splices what
 	 * stdin decodes into the position the `-` occupies, so
 	 * `--tag before --tag - --tag after` over `'a\nb\n'` resolves to
 	 * `['before', 'a', 'b', 'after']`. `.split({ stdin })` sets the decoding.
+	 * Each `-` stands for the whole source, so `--tag - --tag -` splices the
+	 * buffer twice. A `-` typed beside other occurrences with nothing piped fails
+	 * with `REQUIRED_FLAG`; occurrences of nothing but `-` fall through to the
+	 * later sources.
+	 *
+	 * A stdin-enabled flag cannot receive a literal `-` as its value, since the
+	 * token names the source.
 	 *
 	 * Available on every flag kind except `count`. One command may declare a
 	 * single exclusive stdin consumer; pass `{ consume: 'broadcast' }` on every
 	 * input that should share the buffer.
 	 *
-	 * @param options - When to read stdin and how to share it.
+	 * @param options - When to read stdin, how to share it, and whether to trim.
 	 * @returns The builder (for chaining).
+	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on a `count` flag.
 	 *
 	 * @example
 	 * ```ts
@@ -1289,12 +1313,16 @@ class FlagBuilder<C extends FlagConfig> {
 	 *
 	 * flag.string().stdin({ when: 'dash' })
 	 * // only `--body -` reads stdin
+	 *
+	 * flag.path({ mustExist: true }).stdin({ trim: true })
+	 * // $ echo ./dist | mycli clean       → path = './dist', checked on disk
 	 * ```
 	 */
 	stdin(
 		this: FlagBuilder<C & { readonly flagKind: StdinCapableFlagKind }>,
 		options?: StdinOptions,
 	): FlagBuilder<WithoutElementEligibility<C>> {
+		assertStdinCapableKind(this.schema.kind);
 		return new FlagBuilder({
 			...this.schema,
 			stdin: normalizeStdinBinding(options),

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -1680,9 +1680,9 @@ class FlagBuilder<C extends FlagConfig> {
 	/**
 	 * Set how a repeated key combines.
 	 *
-	 * Applies to every source: repeated CLI occurrences, delimited env pairs, a
-	 * JSON object cannot repeat a key, and a spliced stdin read joins the same
-	 * occurrence order.
+	 * Applies to repeated CLI occurrences, delimited env pairs, and spliced stdin
+	 * reads in the same occurrence order. JSON decoding does not preserve
+	 * repeated object member names, so it cannot reliably expose them here.
 	 *
 	 * @param policy - `'last'` (default), `'first'`, or `'error'`.
 	 * @returns The builder (for chaining).

--- a/src/core/schema/input-modifier-guards.test.ts
+++ b/src/core/schema/input-modifier-guards.test.ts
@@ -93,6 +93,13 @@ describe('.unique() on an arg', () => {
 		expect(schemaError(() => arg.keyValue().variadic().unique()).code).toBe('INVALID_SCHEMA');
 	});
 
+	it('is refused with false on unsupported args too', () => {
+		// @ts-expect-error .unique() is not available on a single-value arg
+		expect(schemaError(() => arg.string().unique(false)).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .unique() is unavailable on a key-value arg
+		expect(schemaError(() => arg.keyValue().variadic().unique(false)).code).toBe('INVALID_SCHEMA');
+	});
+
 	it('is refused on the definition path too', () => {
 		expect(schemaError(() => createArgSchema('string', { unique: true })).code).toBe(
 			'INVALID_SCHEMA',

--- a/src/core/schema/input-modifier-guards.test.ts
+++ b/src/core/schema/input-modifier-guards.test.ts
@@ -89,6 +89,7 @@ describe('.unique() on an arg', () => {
 	});
 
 	it('is refused on a variadic keyValue arg, which folds keys instead', () => {
+		// @ts-expect-error .unique() is unavailable on a key-value arg
 		expect(schemaError(() => arg.keyValue().variadic().unique()).code).toBe('INVALID_SCHEMA');
 	});
 

--- a/src/core/schema/input-modifier-guards.test.ts
+++ b/src/core/schema/input-modifier-guards.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Modifiers that only some inputs carry: the arg collection settings, and the
+ * stdin binding a `count` flag cannot have. Each is refused by the compiler and
+ * by both construction paths at run time.
+ *
+ * @module dreamcli/core/schema/input-modifier-guards.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { CLIError } from '#internals/core/errors/index.ts';
+import { arg, createArgSchema } from './arg.ts';
+import { createFlagSchema, flag } from './flag.ts';
+
+// --- helpers
+
+/** Run a build expected to fail, returning the error it threw. */
+function schemaError(build: () => unknown): CLIError {
+	try {
+		build();
+	} catch (error) {
+		if (error instanceof CLIError) return error;
+		throw error;
+	}
+	throw new Error('expected the schema to be rejected');
+}
+
+// === arg collection modifiers
+
+describe('.separator() and .split() on an arg', () => {
+	it('are available on a variadic arg', () => {
+		expect(arg.string().variadic().separator(',').schema.separator).toBe(',');
+		expect(arg.string().variadic().split({ env: 'json' }).schema.split).toEqual({
+			env: { format: 'json' },
+			stdin: undefined,
+		});
+	});
+
+	it('are available on arg.keyValue()', () => {
+		expect(arg.keyValue().separator(',').schema.separator).toBe(',');
+		expect(arg.keyValue().split({ stdin: 'json' }).schema.split).toEqual({
+			env: undefined,
+			stdin: { format: 'json' },
+		});
+	});
+
+	it('are refused on an arg that carries a single value', () => {
+		// @ts-expect-error .separator() is not available on a single-value arg
+		expect(schemaError(() => arg.string().separator(',')).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .split() is not available on a single-value arg
+		expect(schemaError(() => arg.number().split({ env: ',' })).code).toBe('INVALID_SCHEMA');
+	});
+
+	it('name the field and the kind that received it', () => {
+		// @ts-expect-error .separator() is not available on a single-value arg
+		const error = schemaError(() => arg.string().separator(','));
+		expect(error.message).toBe(
+			"Arg schema field 'separator' requires a collection, received a non-variadic 'string' arg",
+		);
+		expect(error.details).toEqual({ kind: 'string', field: 'separator' });
+	});
+
+	it('are refused on the definition path too', () => {
+		expect(schemaError(() => createArgSchema('string', { separator: ',' })).code).toBe(
+			'INVALID_SCHEMA',
+		);
+		expect(
+			schemaError(() =>
+				createArgSchema('string', { split: { env: { format: 'json' }, stdin: undefined } }),
+			).code,
+		).toBe('INVALID_SCHEMA');
+	});
+
+	it('are accepted on the definition path for a collection', () => {
+		expect(createArgSchema('string', { variadic: true, separator: ',' }).separator).toBe(',');
+		expect(createArgSchema('keyValue', { separator: ',' }).separator).toBe(',');
+	});
+});
+
+describe('.unique() on an arg', () => {
+	it('is available on a variadic list arg', () => {
+		expect(arg.string().variadic().unique().schema.unique).toBe(true);
+	});
+
+	it('is refused on an arg that carries a single value', () => {
+		// @ts-expect-error .unique() is not available on a single-value arg
+		const error = schemaError(() => arg.string().unique());
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toBe("Arg schema field 'unique' requires a variadic arg of a list kind");
+	});
+
+	it('is refused on a variadic keyValue arg, which folds keys instead', () => {
+		expect(schemaError(() => arg.keyValue().variadic().unique()).code).toBe('INVALID_SCHEMA');
+	});
+
+	it('is refused on the definition path too', () => {
+		expect(schemaError(() => createArgSchema('string', { unique: true })).code).toBe(
+			'INVALID_SCHEMA',
+		);
+		expect(
+			schemaError(() => createArgSchema('keyValue', { variadic: true, unique: true })).code,
+		).toBe('INVALID_SCHEMA');
+	});
+
+	it('accepts unique: false anywhere, which is the stored default', () => {
+		expect(createArgSchema('string', { unique: false }).unique).toBe(false);
+	});
+});
+
+describe('.duplicateKeys() on an arg', () => {
+	it('is available on arg.keyValue()', () => {
+		expect(arg.keyValue().duplicateKeys('error').schema.duplicateKeys).toBe('error');
+	});
+
+	it('is refused on every other kind', () => {
+		// @ts-expect-error .duplicateKeys() is not available on a string arg
+		const error = schemaError(() => arg.string().duplicateKeys('error'));
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.details).toMatchObject({ field: 'duplicateKeys', requiredKind: 'keyValue' });
+	});
+
+	it('is refused on the definition path too', () => {
+		expect(
+			// @ts-expect-error duplicateKeys requires kind 'keyValue'
+			schemaError(() => createArgSchema({ kind: 'string', duplicateKeys: 'error' })).code,
+		).toBe('INVALID_SCHEMA');
+	});
+});
+
+// === count flags and stdin
+
+describe('.stdin() on a count flag', () => {
+	it('is refused by the builder at run time', () => {
+		// @ts-expect-error .stdin() is not available on a count flag
+		const error = schemaError(() => flag.count().stdin());
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toBe("Flag schema field 'stdin' is not available on kind 'count'");
+	});
+
+	it('is refused by the definition path with the same error', () => {
+		const error = schemaError(() => createFlagSchema('count', { stdin: {} }));
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toBe("Flag schema field 'stdin' is not available on kind 'count'");
+	});
+
+	it('stays available on every other kind', () => {
+		expect(flag.string().stdin().schema.stdin?.when).toBe('dash-or-missing');
+		expect(flag.array(flag.string()).stdin().schema.stdin?.when).toBe('dash-or-missing');
+		expect(flag.keyValue().stdin().schema.stdin?.when).toBe('dash-or-missing');
+	});
+});

--- a/src/core/schema/schema-sealing.test.ts
+++ b/src/core/schema/schema-sealing.test.ts
@@ -396,16 +396,7 @@ describe('schema sealing', () => {
 			).toBe('INVALID_SCHEMA');
 		});
 
-		it('validates stdin invariants in command definitions', () => {
-			expect(
-				schemaErrorCode(() =>
-					createCommandSchema({
-						name: 'copy',
-						args: [{ name: 'input', schema: { kind: 'string', stdin: {}, variadic: true } }],
-					}),
-				),
-			).toBe('INVALID_BUILDER_STATE');
-
+		it('validates stdin and positional invariants in command definitions', () => {
 			expect(
 				schemaErrorCode(() =>
 					createCommandSchema({
@@ -417,6 +408,18 @@ describe('schema sealing', () => {
 					}),
 				),
 			).toBe('DUPLICATE_STDIN_INPUT');
+
+			expect(
+				schemaErrorCode(() =>
+					createCommandSchema({
+						name: 'copy',
+						args: [
+							{ name: 'files', schema: { kind: 'string', variadic: true } },
+							{ name: 'target', schema: { kind: 'string' } },
+						],
+					}),
+				),
+			).toBe('INVALID_BUILDER_STATE');
 		});
 
 		it('validates flag collisions across command definition trees', () => {

--- a/src/core/schema/source.ts
+++ b/src/core/schema/source.ts
@@ -194,12 +194,28 @@ function invocationSelectsStdin(
 
 	for (const { name, schema } of args) {
 		const present = Object.hasOwn(parsed.args, name);
-		if (inputSelectsStdin(schema.stdin, present, present ? parsed.args[name] : undefined)) {
+		const value = present ? parsed.args[name] : undefined;
+		if (inputSelectsStdin(schema.stdin, present && !argCollectedNothing(schema, value), value)) {
 			return true;
 		}
 	}
 
 	return false;
+}
+
+/**
+ * Whether a variadic arg's parsed value means its tail collected nothing.
+ *
+ * A variadic arg always has a key in the parser's record, and an empty list is
+ * how it spells an empty tail, so an input that reads stdin when missing is
+ * still missing here.
+ *
+ * @param schema - The positional's schema.
+ * @param value - What the parser produced for it.
+ * @returns `true` when the tail took no token.
+ */
+function argCollectedNothing(schema: ArgSchema, value: unknown): boolean {
+	return schema.variadic && Array.isArray(value) && value.length === 0;
 }
 
 /** The stdin selector, which names a source rather than a value. */
@@ -224,6 +240,7 @@ function inputSelectsStdin(
 
 export type { ParsedInputs, ResolutionStage, SourceBinding, StdinConsumer };
 export {
+	argCollectedNothing,
 	bindingsBeforePrompt,
 	bindingsFromPrompt,
 	invocationSelectsStdin,

--- a/src/core/schema/stdin-exclusivity.test.ts
+++ b/src/core/schema/stdin-exclusivity.test.ts
@@ -84,17 +84,26 @@ describe('builder path', () => {
 			.arg('input', arg.string().stdin({ consume: 'broadcast' }))
 			.action(() => {}).schema;
 
-		expect(schema.flags.body?.stdin).toEqual({ when: 'dash-or-missing', consume: 'broadcast' });
+		expect(schema.flags.body?.stdin).toEqual({
+			when: 'dash-or-missing',
+			consume: 'broadcast',
+			trim: false,
+		});
 		expect(schema.args[0]?.schema.stdin).toEqual({
 			when: 'dash-or-missing',
 			consume: 'broadcast',
+			trim: false,
 		});
 	});
 
-	it('still rejects a variadic stdin arg', () => {
-		const error = schemaError(() => command('run').arg('input', arg.string().variadic().stdin()));
+	it('counts a variadic stdin arg as a stdin consumer', () => {
+		const error = schemaError(() =>
+			command('run')
+				.flag('body', flag.string().stdin())
+				.arg('files', arg.string().variadic().stdin()),
+		);
 
-		expect(error.code).toBe('INVALID_BUILDER_STATE');
+		expect(error.code).toBe('DUPLICATE_STDIN_INPUT');
 	});
 
 	it('rejects a descendant arg beside a propagated stdin flag', () => {

--- a/src/core/schema/stdin.ts
+++ b/src/core/schema/stdin.ts
@@ -1,10 +1,10 @@
 /**
  * The stdin binding shared by the `flag` and `arg` factories.
  *
- * A {@link StdinBinding} says when an input reads the stdin stream and whether
- * it consumes the stream alone. Both factories store one of these under their
- * `stdin` field, and the parse, preflight, and resolve pipelines read the stdin
- * axis through it.
+ * A {@link StdinBinding} says when an input reads the stdin stream, whether it
+ * consumes the stream alone, and whether a single value drops the terminator a
+ * pipe appends. Both factories store one of these under their `stdin` field, and
+ * the parse, preflight, and resolve pipelines read the stdin axis through it.
  *
  * @module dreamcli/core/schema/stdin
  */
@@ -44,6 +44,8 @@ interface StdinBinding {
 	readonly when: StdinWhen;
 	/** Whether this input consumes the stream alone. */
 	readonly consume: StdinConsume;
+	/** Whether one trailing line terminator is dropped from a single value. */
+	readonly trim: boolean;
 }
 
 /** Stdin settings accepted by `.stdin()` and by the schema definitions. */
@@ -58,10 +60,22 @@ interface StdinOptions {
 	 * @defaultValue `'exclusive'`
 	 */
 	readonly consume?: StdinConsume | undefined;
+	/**
+	 * Drop one trailing `\n`, `\r\n`, or `\r` from a single value read off the
+	 * stream, so `echo ./dir | mycli` delivers `'./dir'`. A string is the one
+	 * kind that still carries the terminator at that point; every other kind
+	 * drops it while decoding and is unaffected.
+	 * @defaultValue `false`
+	 */
+	readonly trim?: boolean | undefined;
 }
 
 /** The binding `.stdin()` produces when called without options. */
-const DEFAULT_STDIN_BINDING: StdinBinding = { when: 'dash-or-missing', consume: 'exclusive' };
+const DEFAULT_STDIN_BINDING: StdinBinding = {
+	when: 'dash-or-missing',
+	consume: 'exclusive',
+	trim: false,
+};
 
 /**
  * Reject stdin settings that name a mode outside the declared unions.
@@ -84,6 +98,13 @@ function assertStdinOptions(options: StdinOptions): void {
 			suggest: `Use one of: ${STDIN_CONSUMES.join(', ')}`,
 		});
 	}
+	if (options.trim !== undefined && typeof options.trim !== 'boolean') {
+		throw new CLIError(`Stdin trim must be a boolean, received '${String(options.trim)}'`, {
+			code: 'INVALID_SCHEMA',
+			details: { trim: options.trim },
+			suggest: 'Pass trim: true or trim: false',
+		});
+	}
 }
 
 /**
@@ -99,26 +120,27 @@ function normalizeStdinBinding(options?: StdinOptions): StdinBinding {
 	return {
 		when: options.when ?? DEFAULT_STDIN_BINDING.when,
 		consume: options.consume ?? DEFAULT_STDIN_BINDING.consume,
+		trim: options.trim ?? DEFAULT_STDIN_BINDING.trim,
 	};
 }
 
 /**
  * Whether an explicit `-` selects stdin for this binding.
  *
- * @param binding - The stdin axis to read.
+ * @param binding - Anything carrying the stdin trigger.
  * @returns `true` for `'dash'` and `'dash-or-missing'`.
  */
-function stdinReadsOnDash(binding: StdinBinding): boolean {
+function stdinReadsOnDash(binding: Pick<StdinBinding, 'when'>): boolean {
 	return binding.when === 'dash' || binding.when === 'dash-or-missing';
 }
 
 /**
  * Whether an absent CLI value selects stdin for this binding.
  *
- * @param binding - The stdin axis to read.
+ * @param binding - Anything carrying the stdin trigger.
  * @returns `true` for `'missing'` and `'dash-or-missing'`.
  */
-function stdinReadsWhenMissing(binding: StdinBinding): boolean {
+function stdinReadsWhenMissing(binding: Pick<StdinBinding, 'when'>): boolean {
 	return binding.when === 'missing' || binding.when === 'dash-or-missing';
 }
 

--- a/src/core/schema/string-constraints.test.ts
+++ b/src/core/schema/string-constraints.test.ts
@@ -438,7 +438,11 @@ describe('arg.string() chained constraint methods', () => {
 		expectTypeOf<InferArg<typeof variadic>>().toEqualTypeOf<string[]>();
 
 		const piped = arg.string().stdin().nonEmpty();
-		expect(piped.schema.stdin).toEqual({ when: 'dash-or-missing', consume: 'exclusive' });
+		expect(piped.schema.stdin).toEqual({
+			when: 'dash-or-missing',
+			consume: 'exclusive',
+			trim: false,
+		});
 		expect(piped.schema.stringConstraints).toEqual({ nonEmpty: true });
 	});
 

--- a/src/core/schema/value.test.ts
+++ b/src/core/schema/value.test.ts
@@ -525,13 +525,13 @@ describe("the 'stdin' input", () => {
 		}
 	});
 
-	it('hands the string codec the buffer byte for byte', () => {
+	it('hands string codecs the buffer byte for byte', () => {
 		expect(decoded(stringValue(), 'hello\n', 'stdin')).toBe('hello\n');
 		expect(decoded(stringValue(), 'a\r\nb\r\n', 'stdin')).toBe('a\r\nb\r\n');
+		expect(decoded(pathValue(), './out\n', 'stdin')).toBe('./out\n');
 	});
 
-	it('drops one trailing terminator before path and non-string codecs', () => {
-		expect(decoded(pathValue(), './out\n', 'stdin')).toBe('./out');
+	it('drops one trailing terminator before non-string codecs', () => {
 		expect(decoded(numberValue(), '42\n', 'stdin')).toBe(42);
 		expect(decoded(numberValue(), '42\r\n', 'stdin')).toBe(42);
 		expect(decoded(numberValue(), '42\r', 'stdin')).toBe(42);

--- a/src/core/schema/value.ts
+++ b/src/core/schema/value.ts
@@ -309,7 +309,7 @@ function stringParsedCodec<P extends (raw: string) => unknown>(parseFn: P): Valu
  * @returns The decoded value, or the {@link ValueFailure} that rejected it.
  */
 function decodeValue(value: ValueSchema, raw: unknown, input: ValueInput): ValueResult<unknown> {
-	const decoded = value.codec.decode(stdinDecodeInput(value.codec, raw, input), input);
+	const decoded = value.codec.decode(stdinDecodeInput(value, raw, input), input);
 	if (!decoded.ok) return decoded;
 	const failure = checkValueConstraints(value.constraints, decoded.value);
 	return failure === undefined ? decoded : { ok: false, failure };
@@ -324,13 +324,13 @@ function decodeValue(value: ValueSchema, raw: unknown, input: ValueInput): Value
  * where a trailing terminator is framing rather than value: `'42\n'` is the
  * number 42, `'true\n'` the boolean `true`, `'30s\n'` a duration.
  *
- * @param codec - The codec about to read the value.
+ * @param value - The value axis about to read the value.
  * @param raw - The raw value the source produced.
  * @param input - Which surface produced `raw`.
  * @returns The value to decode.
  */
-function stdinDecodeInput(codec: ValueCodec, raw: unknown, input: ValueInput): unknown {
-	if (input !== 'stdin' || keepsStdinTerminator(codec) || typeof raw !== 'string') return raw;
+function stdinDecodeInput(value: ValueSchema, raw: unknown, input: ValueInput): unknown {
+	if (input !== 'stdin' || keepsStdinTerminator(value) || typeof raw !== 'string') return raw;
 	if (raw.endsWith('\r\n')) return raw.slice(0, -2);
 	if (raw.endsWith('\n') || raw.endsWith('\r')) return raw.slice(0, -1);
 	return raw;
@@ -339,11 +339,11 @@ function stdinDecodeInput(codec: ValueCodec, raw: unknown, input: ValueInput): u
 /**
  * Whether decoding leaves the line terminator a pipe appends on the value.
  *
- * @param codec - The codec about to read a stdin buffer.
+ * @param value - The value axis about to read a stdin buffer.
  * @returns `true` when the terminator survives decoding.
  */
-function keepsStdinTerminator(codec: ValueCodec): boolean {
-	return codec.name === 'string';
+function keepsStdinTerminator(value: ValueSchema): boolean {
+	return value.codec.name === 'string';
 }
 
 /**

--- a/src/core/schema/value.ts
+++ b/src/core/schema/value.ts
@@ -309,7 +309,7 @@ function stringParsedCodec<P extends (raw: string) => unknown>(parseFn: P): Valu
  * @returns The decoded value, or the {@link ValueFailure} that rejected it.
  */
 function decodeValue(value: ValueSchema, raw: unknown, input: ValueInput): ValueResult<unknown> {
-	const decoded = value.codec.decode(stdinDecodeInput(value, raw, input), input);
+	const decoded = value.codec.decode(stdinDecodeInput(value.codec, raw, input), input);
 	if (!decoded.ok) return decoded;
 	const failure = checkValueConstraints(value.constraints, decoded.value);
 	return failure === undefined ? decoded : { ok: false, failure };
@@ -324,22 +324,26 @@ function decodeValue(value: ValueSchema, raw: unknown, input: ValueInput): Value
  * where a trailing terminator is framing rather than value: `'42\n'` is the
  * number 42, `'true\n'` the boolean `true`, `'30s\n'` a duration.
  *
- * @param value - The value schema about to read the value.
+ * @param codec - The codec about to read the value.
  * @param raw - The raw value the source produced.
  * @param input - Which surface produced `raw`.
  * @returns The value to decode.
  */
-function stdinDecodeInput(value: ValueSchema, raw: unknown, input: ValueInput): unknown {
-	if (
-		input !== 'stdin' ||
-		(value.codec.name === 'string' && value.valueHint !== 'path') ||
-		typeof raw !== 'string'
-	) {
-		return raw;
-	}
+function stdinDecodeInput(codec: ValueCodec, raw: unknown, input: ValueInput): unknown {
+	if (input !== 'stdin' || keepsStdinTerminator(codec) || typeof raw !== 'string') return raw;
 	if (raw.endsWith('\r\n')) return raw.slice(0, -2);
 	if (raw.endsWith('\n') || raw.endsWith('\r')) return raw.slice(0, -1);
 	return raw;
+}
+
+/**
+ * Whether decoding leaves the line terminator a pipe appends on the value.
+ *
+ * @param codec - The codec about to read a stdin buffer.
+ * @returns `true` when the terminator survives decoding.
+ */
+function keepsStdinTerminator(codec: ValueCodec): boolean {
+	return codec.name === 'string';
 }
 
 /**
@@ -723,6 +727,7 @@ export {
 	enumValue,
 	flagAggregateStandard,
 	flagValueSchema,
+	keepsStdinTerminator,
 	numberValue,
 	passthroughValue,
 	pathValue,

--- a/src/core/testkit/testkit-source-model.test.ts
+++ b/src/core/testkit/testkit-source-model.test.ts
@@ -109,7 +109,7 @@ describe('runCommand() stdin contract', () => {
 		const result = await runCommand(cmd, ['a', '-', 'b'], { stdinData: 'x\ny\n' });
 
 		expect(result.exitCode).toBe(0);
-		expect(result.stdout.join('')).toContain('["a","x","y","b"]');
+		expect(result.stdout.join('')).toContain('["a","x","y","b"]\n');
 	});
 
 	it('reports a dash in the tail with nothing piped', async () => {
@@ -121,7 +121,7 @@ describe('runCommand() stdin contract', () => {
 
 		expect(result.exitCode).toBe(2);
 		expect(result.stderr.join('')).toContain(
-			"No piped stdin for the '-' occurrence of argument <files>",
+			"No piped stdin for the '-' occurrence of argument <files>\n",
 		);
 	});
 });

--- a/src/core/testkit/testkit-source-model.test.ts
+++ b/src/core/testkit/testkit-source-model.test.ts
@@ -98,4 +98,30 @@ describe('runCommand() stdin contract', () => {
 		expect(result.stdout).toEqual(['true\n']);
 		expect(result.exitCode).toBe(0);
 	});
+
+	it('splices the buffer into a variadic positional tail', async () => {
+		const cmd = command('build')
+			.arg('files', arg.string().variadic().stdin())
+			.action(({ args, out }) => {
+				out.log(JSON.stringify(args.files));
+			});
+
+		const result = await runCommand(cmd, ['a', '-', 'b'], { stdinData: 'x\ny\n' });
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.join('')).toContain('["a","x","y","b"]');
+	});
+
+	it('reports a dash in the tail with nothing piped', async () => {
+		const cmd = command('build')
+			.arg('files', arg.string().variadic().stdin())
+			.action(() => {});
+
+		const result = await runCommand(cmd, ['a', '-']);
+
+		expect(result.exitCode).toBe(2);
+		expect(result.stderr.join('')).toContain(
+			"No piped stdin for the '-' occurrence of argument <files>",
+		);
+	});
 });


### PR DESCRIPTION
Targets v4. Stacked on #115. L17 of the input-model unification, two commits by design (Decision 9's refactor-first gate).

**Commit 1, behavior-identical refactor**: the parser preserves one ordered occurrence list per input (value, entry, stdin sentinel, negated, increment, aggregated) until aggregation; duplicate policies, negation, clusters, count folding, and the splice all re-express over it, and the L16 dual-tolerance for pre-folded records is gone. An independent 595-line differential probe against the L16 tip diffs empty; zero existing test expectations modified; the reviewer reverted nothing because nothing was smuggled, and fixed a quadratic duplicate-tally regression (24ms to 956ms to 27ms on 20k occurrences).

**Commit 2, the additions**: a positional after a variadic arg or two variadics is a build-time error from both paths; collection args carry stdin bindings ('-' splices mid-tail, an empty tail under missing coverage takes the buffer); `ResolutionDiagnosticSource` gains cli so typed duplicate keys stop claiming "from stdin"; `StdinBinding.trim` implemented for real (one predicate owns the terminator condition after the review caught a double-strip); an explicit `-` beside typed occurrences with nothing piped errors instead of silently shortening the collection (breaking); `flag.count().stdin()` and inert collection-only arg modifiers throw at build.
