### PR TITLE
test!: axis matrices, six sweep rounds, and the builder/factory guard closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,7 +387,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   is already on the user's screen. Every coercion failure now also carries
   `source: 'env' | 'config' | 'stdin' | 'prompt'` in `details`, which is what
   labels an issue `[env API_TOKEN]` in an aggregate error and what now gives the
-  argument surface the same label the flag surface had.
+  argument surface the same label the flag surface had. The `flag.path()` and
+  `arg.path()` filesystem checks read the same rule, so a path a pipe, an
+  explicit `-`, the environment, a config file, a prompt, or a declared default
+  supplied reports `Path '<redacted>' for flag --key does not exist` and omits
+  `value` from `details`; a path typed on the command line is still quoted in
+  full. Every element of a collection of paths is checked and redacted
+  individually.
 
 - **Breaking: a positional declared after a variadic one is a build error.** A
   variadic argument consumes every remaining positional, so anything registered
@@ -500,6 +506,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   input is unaffected, since `Number()` already ignored the terminator. Stdin
   also stops borrowing the prompt widening table: it accepts exactly what an env
   value accepts, so the prompt-only `y` and `n` boolean spellings are rejected.
+
+- **Breaking: a number input rejects blank text instead of reading it as zero.**
+  `Number('')` and `Number('  ')` are both `0`, so `PORT= mycli serve`,
+  `printf '\n' | mycli serve`, and a config key holding `""` all resolved a
+  number input to `0` without a word. All three now fail with `TYPE_MISMATCH`
+  and the same `Invalid number value '<redacted>' from …` diagnostic any other
+  unreadable value gets, and `mycli serve --port ''` fails at the parse boundary
+  where it quotes the token. Whitespace around a real number is still ignored,
+  so `' 42 '` and `'42\n'` are unaffected. A `count` flag already guarded this;
+  the number codec now does too. Set the variable, or drop it and let the
+  default apply.
 
 - **Breaking: `CLISchema.commands` and `CLISchema.defaultCommand` hold
   `CommandSchema`** — both used to hold `ErasedCommand` wrappers carrying the
@@ -675,6 +692,161 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   already defaults to `['package.json']`.
 
 ### Fixed
+
+- **A variadic argument could not take the prompt its flag twin takes.** The
+  argument prompt gate read the kind discriminator alone, so
+  `arg.string().variadic().prompt({ kind: 'multiselect' })` was rejected with
+  `Prompt kind 'multiselect' is not compatible with string argument <files>`
+  while `flag.array(flag.string()).prompt({ kind: 'multiselect' })` resolved,
+  and the scalar `input` and `select` kinds the flag surface rejects were
+  accepted, resolving a one-element array. The gate now reads the cardinality:
+  an argument that collects several values takes `multiselect`, and names itself
+  `variadic string argument <files>` when it reports a mismatch.
+  `AllowedArgPromptConfig<C>` follows the same rule, so the compiler agrees.
+
+- **A collection given a config value of the wrong shape said less on the
+  argument surface.** `flag.array(...).config('p')` over `{ p: 5 }` reported
+  `Invalid array value from config p for flag --tags`; the positional twin
+  reported `Invalid value '<redacted>' from config p for argument <tags>`,
+  naming neither the shape nor a value it actually held. Both surfaces now word
+  it `Invalid array value` / `Invalid object value`, so the byte-for-byte
+  wording rule in [Diagnostics and redaction](https://dreamcli.kjanat.dev/guide/semantics#diagnostics-and-redaction)
+  holds for the collection faults too.
+
+- **A builder could produce a schema its own factory refuses.** Each modifier
+  states the kinds it belongs to through a `this` constraint, which the compiler
+  enforces and a JavaScript caller does not see, so `flag.string().separator(',')`
+  built a string flag carrying a CLI delimiter and emitted a definition document
+  `createFlagSchema()` then rejected with `INVALID_SCHEMA`. Twelve modifiers on
+  the flag surface and eleven on the argument surface behaved this way. Every
+  builder modifier now runs the same check `createFlagSchema()` /
+  `createArgSchema()` run, so what a builder produces is always a definition the
+  framework reads back. A test calling such a modifier through `@ts-expect-error`
+  and expecting it to build needs `expect(...).toThrow()`.
+
+- **The normalization factories accepted a kind they have no arm for.**
+  `createFlagSchema('nope')` and `createArgSchema('count')` built a schema whose
+  discriminator is outside `FLAG_KINDS` / `ARG_KINDS`, which every exhaustive
+  `switch (schema.kind)` downstream falls through. The types forbid the call,
+  but a JavaScript caller reached it, and the keyValue prompt gate showed such a
+  schema can reach a shipped diagnostic. Both factories now throw
+  `INVALID_SCHEMA` with `Unknown flag kind 'nope'` / `Unknown arg kind 'count'`,
+  listing the allowed kinds in `details.allowed`, on the two-argument path, the
+  definition path, and a nested `elementSchema`.
+
+- **`flag.array()` with no element threw a raw `TypeError`.** The factory read
+  `.schema` off the element it was handed, so a JavaScript caller omitting it
+  got `Cannot read properties of undefined` instead of a framework error. It now
+  throws `INVALID_SCHEMA` with `flag.array() requires an element builder`.
+  `flag.keyValue()` and `arg.keyValue()`, whose element is optional, apply the
+  same check to an element that is supplied.
+
+- **A positional cut a parse function's message at its last colon.** Off argv,
+  the argument surface rebuilt the reason for a failure by scanning the message
+  the flag surface had already written, keeping only the text after the final
+  `": "`. Anything a parse function put before a colon was lost, and a reason
+  whose own tail held a colon was dropped whole: `arg.url({ protocols: ['https'] })`
+  reported `Invalid value '<redacted>' from env ENDPOINT for argument <endpoint>: https`,
+  and `arg.date()` reported no reason at all. `arg.duration()`, `arg.bytes()`,
+  and every `arg.custom()` whose error text carries a colon were affected the
+  same way. Each surface now words its own diagnostic from the value layer's
+  verdict, so the reason reaches the argument surface whole.
+
+  A parse-function failure off argv is also worded the way the flag surface and
+  the command line already word it, so `Failed to parse env ENDPOINT for
+  argument <endpoint>: URL protocol 'http' is not allowed. Allowed: https`
+  replaces the `Invalid value '<redacted>' …` opening, which announced a
+  redaction in the same sentence that printed the parse function's own text.
+  A test asserting the old opening for a non-argv `arg.url()`, `arg.date()`,
+  `arg.duration()`, `arg.bytes()`, or `arg.custom()` message needs the new one.
+
+- **A positional withheld what a type mismatch expected.** For a value no
+  boolean codec could read, the flag surface reported
+  `Invalid boolean value '<redacted>' …` and suggested
+  `Set VAR to true/false, 1/0, or yes/no`, while the argument surface reported
+  `Invalid value '<redacted>' …` and suggested only `Set VAR to a valid boolean`,
+  which is the question rather than the answer. A string a config object could
+  not fill carried no `expected` field and no suggestion at all on the argument
+  surface. Both now match the flag surface: the message names the type, the
+  details carry `expected`, and the suggestion names what the codec reads.
+
+- **An argument kind with no compatible prompt was told to use `undefined`.**
+  `createArgSchema({ kind: 'keyValue', prompt: … })` reached the prompt gate,
+  which took the first allowed prompt kind from an empty list and reported
+  `Prompt kind 'input' is not compatible with keyValue argument <vars>. Use
+  'undefined' instead` with `Change the prompt to { kind: 'undefined' }`. The
+  flag surface already had a branch for a kind that is not promptable at all;
+  both surfaces now share it and report
+  `keyValue arguments are not promptable` with `Remove the prompt config for <vars>`.
+
+- **A key-value input told the user to write an array.** A config value of the
+  wrong shape for `flag.keyValue()` or `arg.keyValue()` reported
+  `Invalid array value from config c for flag --vars` with `expected: 'array'`
+  and `Set c to an array in your config`, which is not what an entries input
+  accepts and, for a config value that already was an array, not even a change.
+  The fault now carries the shape the cardinality wants: an entries input reads
+  `Invalid object value …` with `expected: 'object'` and
+  `Set c to an object in your config` on the flag surface and
+  `Use KEY=VALUE for <vars>` on the argument surface. A list input is unchanged.
+
+- **Five types the stability page classified as public were exported from
+  nowhere.** `NodeProcess`, `DenoNamespace`, and `GlobalForDetect` are the host
+  objects `createNodeAdapter()`, `createDenoAdapter()`, and `detectRuntime()`
+  accept, and the page attributes all three to `@kjanat/dreamcli/runtime`, which
+  exported none of them; a caller injecting a host could not name the parameter
+  type. `StringArgElementConfig` and `WithoutArgElementEligibility` sat in the
+  same sentence as `StringElementConfig`, which the root entrypoint does export.
+  All five are now exported, along with the flag-side
+  `WithoutElementEligibility` its argument twin mirrors.
+
+- **A definition document, its input schema, and help all dropped a default the
+  schema still resolved.** `generateSchema()`, `generateInputSchema()`, and
+  `formatHelp()` each reported a default only for `presence: 'defaulted'`, but
+  resolution uses any `defaultValue` a schema carries, and
+  `createFlagSchema({ kind: 'string', defaultValue: 'dist' })` keeps
+  `presence: 'optional'`. A document emitted from such a schema decoded back to
+  a flag with no default, so a round trip through the format changed behavior;
+  the input schema omitted `default`, and help omitted `(default: dist)` for a
+  flag that does resolve one. All three now report the default whenever the
+  schema carries one, on both surfaces, whatever the presence.
+  Builder-authored schemas are unaffected, since `.default()` sets the
+  defaulted presence.
+
+  Help no longer calls such an input required either. A default binding always
+  produces a value, so neither `REQUIRED_FLAG` nor `REQUIRED_ARG` can fire for a
+  schema carrying a `defaultValue`, yet `flag.string().default('dist').required()`
+  rendered `[required]` and hid its own default while the positional twin
+  rendered `(default: prod)` and still demanded a token as `<target>`. A
+  `defaultValue` now suppresses the `[required]` marker and the angle brackets on
+  both surfaces; an input without one is unchanged.
+
+- **A duplicate key leaked its text from every non-argv source.** Under
+  `.duplicateKeys('error')`, `Duplicate key 'DB_PASSWORD' from env VARS for flag
+  --vars` quoted the key in the message, in `details.key`, and in `suggest`,
+  whatever source carried it. A key is half of a `KEY=VALUE` pair, so it is
+  value text from that source, and the same pair reported `Invalid key-value
+  pair '<redacted>'` when it failed to split instead. The key is now quoted only
+  for occurrences the user typed on the command line; stdin, env, config, and
+  prompt read `Duplicate key '<redacted>'`, carry no `key` in `details`, and
+  suggest `Set the repeated key once`. Both surfaces follow the rule.
+
+- **A flag reported a JSON shape fault in the wrong order.** `Invalid JSON
+  value, expected an object from env VARS for flag --vars` put the expectation
+  between the fault and the source that carried it. The flag surface now words
+  it as the argument surface already did: `Invalid JSON value from env VARS for
+  flag --vars, expected an object`.
+
+- **`ArgElementFragmentV1` was documented as public but exported from nowhere.**
+  `stability.md` classifies it with the other version 1 fragment types and
+  `schema-export.md` names it as the shape of an arg `elementSchema`, but the
+  type never reached `@kjanat/dreamcli`. It is exported now, alongside its
+  siblings.
+
+- **A default rejected on a vowel-initial kind read `a array`.** The
+  construction-time `INVALID_DEFAULT` message built its subject with a fixed
+  article, so `createFlagSchema('array', …)` and `createFlagSchema('enum', …)`
+  produced `Default value for a array flag` and `Default value for a enum flag`.
+  Both now read `an`.
 
 - **A duplicate key the user typed said it came from stdin.** Under
   `.duplicateKeys('error')`, a repeat among CLI occurrences was worded

--- a/docs/guide/arguments.md
+++ b/docs/guide/arguments.md
@@ -376,7 +376,15 @@ deduplicates a variadic array, and `.duplicateKeys()` decides a repeated key:
 arg.string().variadic().split({ cli: ',', env: 'json' });
 // mycli build a,b c   →  ['a', 'b', 'c']
 // FILES='["a","b"]'   →  ['a', 'b']
+
+arg.keyValue().separator(',');
+// mycli run A=1,B=2   →  { A: '1', B: '2' }
 ```
+
+The CLI delimiter applies to each token whatever the arity, so a non-variadic
+`arg.keyValue()` splits its single token the same way the variadic form splits
+each token of its tail, and the same way `flag.keyValue()` splits each
+occurrence.
 
 These four modifiers are collection modifiers, so they are available on an
 argument that aggregates. Each states the shape it needs. `.separator()` and
@@ -498,13 +506,16 @@ mycli deploy             # asks "Target:"
 mycli deploy production  # skips the prompt
 ```
 
-The prompt kinds an argument accepts follow its kind, matching the flag table:
-`string` takes `input` or `select`, `number` takes `input`, `enum` takes
-`select` or `input`, and `custom` takes every kind. An incompatible pairing
-throws `CONSTRAINT_VIOLATED` naming the argument:
+The prompt kinds an argument accepts follow its value and cardinality, matching
+the flag table: `string` takes `input` or `select`, `number` takes `input`,
+`enum` takes `select` or `input`, `custom` takes every kind, and a variadic
+argument takes `multiselect`, the kind `flag.array()` takes. `arg.keyValue()` is
+not promptable, as `flag.keyValue()` is not. An incompatible pairing throws
+`CONSTRAINT_VIOLATED` naming the argument:
 
 ```
 Prompt kind 'confirm' is not compatible with number argument <n>. Use 'input' instead
+Prompt kind 'input' is not compatible with variadic string argument <files>. Use 'multiselect' instead
 ```
 
 Prompts run only when a prompter is available. Without one the argument falls

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -475,12 +475,12 @@ flag.keyValue().duplicateKeys('first').alias('e').env('VARS');
 // VARS='A=1,A=2'     →  { A: '1' }
 ```
 
-Under `'error'`, the message names the key and the source that carried it:
-`Duplicate key 'A' from env VARS for flag --env` for the environment, and
-`Duplicate key 'A' for flag --v` for occurrences the user typed, which name no
-source. A key spliced in from a pipe reads `from stdin`. A JSON object cannot
-preserve repeated member names through decoding, so `.duplicateKeys()` cannot
-reliably detect them for `.split({ env: 'json' })`.
+Under `'error'`, the message names the source that carried the repeat:
+`Duplicate key '<redacted>' from env VARS for flag --env` for the environment,
+and `Duplicate key 'A' for flag --v` for occurrences the user typed, which name
+no source and quote the key. A key spliced in from a pipe reads `from stdin`.
+JSON decoding does not preserve repeated object member names, so
+`.duplicateKeys()` cannot reliably detect them for `.split({ env: 'json' })`.
 
 ## Sources
 
@@ -1162,7 +1162,7 @@ flag.string({ minLength: 3 }).default('ab');
 // Default value for a string flag is invalid: must be at least 3 characters
 
 flag.array(flag.number({ min: 0 })).default([-1]);
-// Default value for a array flag at 0 is invalid: must be >= 0
+// Default value for an array flag at 0 is invalid: must be >= 0
 
 flag.count().default(-1);
 // Default value for a count flag is invalid: expected a non-negative integer

--- a/docs/guide/flags.md
+++ b/docs/guide/flags.md
@@ -470,13 +470,13 @@ than only across repeated CLI occurrences:
 | `'error'` | a repeat fails with `CONSTRAINT_VIOLATED`   |
 
 ```ts
-flag.keyValue().duplicateKeys('first').alias('e').env('VARS');
+command('deploy').flag('v', flag.keyValue().duplicateKeys('first').alias('e').env('VARS'));
 // -e A=1 -e A=2      →  { A: '1' }
 // VARS='A=1,A=2'     →  { A: '1' }
 ```
 
 Under `'error'`, the message names the source that carried the repeat:
-`Duplicate key '<redacted>' from env VARS for flag --env` for the environment,
+`Duplicate key '<redacted>' from env VARS for flag --v` for the environment,
 and `Duplicate key 'A' for flag --v` for occurrences the user typed, which name
 no source and quote the key. A key spliced in from a pipe reads `from stdin`.
 JSON decoding does not preserve repeated object member names, so

--- a/docs/guide/schema-export.md
+++ b/docs/guide/schema-export.md
@@ -220,6 +220,18 @@ adds `name` and `variadic`. An `elementSchema` on an arg is an
 `ArgElementFragmentV1`, which is the arg fragment without the `name` a position
 supplies.
 
+`defaultValue` is written whenever the schema carries one that survives JSON,
+whatever its `presence`. A definition may set a default without setting
+`presence: 'defaulted'`, and resolution uses it either way, so the document
+states it either way.
+
+An element fragment is the whole fragment shape, so it admits fields no element
+reader consumes: `stdin`, `envVar`, `configPath`, `prompt`, `defaultValue`, and
+`variadic` on an arg element. They are validated as any other field is, they
+survive the document, and they change nothing at resolution, which reads sources
+from the collection itself. Validation still applies in isolation, so
+`variadic: true` on an element makes that element's own default an array.
+
 ### What's Omitted
 
 Non-serializable runtime values are always excluded:

--- a/docs/guide/semantics.md
+++ b/docs/guide/semantics.md
@@ -133,25 +133,27 @@ and accepts `\n`, `\r\n`, and `\r`: `'a\nb\n'` gives `['a', 'b']` and
   `{ A: 'b=c' }`. A segment with no `=`, or an empty key, fails: `INVALID_VALUE`
   on a CLI token, `TYPE_MISMATCH` from every other source.
 - Entries fold under `.duplicateKeys()`: `'last'` (the default), `'first'`, or
-  `'error'`, which reports `CONSTRAINT_VIOLATED` naming the key and the source
-  that carried it. The policy applies to every source, not only to repeated CLI
+  `'error'`, which reports `CONSTRAINT_VIOLATED` naming the source that carried
+  the repeat. The policy applies to every source, not only to repeated CLI
   occurrences.
 - A count reads an explicit value (`--verbose=2`, env, config) as the count
   itself, and must be a non-negative integer.
 
 Under `'error'`, each occurrence keeps its own source through aggregation, so a
 collection filled from both the command line and a pipe names whichever one
-carried the repeat. Tokens the user typed name no source:
+carried the repeat. Tokens the user typed name no source. A key is half of a
+`KEY=VALUE` pair, so it takes the redaction rule below: quoted in full when the
+user typed it, `<redacted>` from every other source.
 
 ```bash
 $ mycli set --v A=1 --v A=2
 Duplicate key 'A' for flag --v
 
 $ printf 'A=2\n' | mycli set --v A=1 --v -
-Duplicate key 'A' from stdin for flag --v
+Duplicate key '<redacted>' from stdin for flag --v
 
 $ VARS='A=1,A=2' mycli set
-Duplicate key 'A' from env VARS for flag --env
+Duplicate key '<redacted>' from env VARS for flag --v
 ```
 
 The argument surface words it the same way, with `for argument <vars>` in place
@@ -254,6 +256,12 @@ The stream is read at most once per invocation, and only when a declared binding
 would fire. Declaring a second exclusive stdin input on one command, flag or
 argument, throws `DUPLICATE_STDIN_INPUT` at build time; every stdin input on a
 command that passes `{ consume: 'broadcast' }` receives the same buffer.
+
+That build-time rule covers one command's own inputs. Sibling commands may each
+declare their own exclusive consumer, and the invocation decides which one runs.
+A `.propagate()` stdin flag reaching a subcommand that also declares one is the
+one case where two exclusive consumers meet in a single invocation: the buffer
+is still read once and both receive it.
 
 For a scalar input, the whole buffer becomes the value. Codecs that preserve
 text terminators keep it byte for byte; this includes strings and paths. Other
@@ -472,16 +480,22 @@ is provisional;
 [#120](https://github.com/kjanat/dreamcli/issues/120) tracks replacing it with
 explicit sensitivity metadata.
 
-| Source | Message quotes             | `details.value` | Reason                                              |
-| ------ | -------------------------- | --------------- | --------------------------------------------------- |
-| argv   | the token, verbatim        | present         | it is already on the user's screen                  |
-| stdin  | `'<redacted>'`             | absent          | a pipe carries secrets                              |
-| env    | `'<redacted>'`             | absent          | an environment variable carries secrets             |
-| config | `'<redacted>'`             | absent          | a config file carries secrets                       |
-| prompt | `'<redacted>'`             | absent          | an answer may be a password                         |
+| Source  | Message quotes      | `details.value` | Reason                                  |
+| ------- | ------------------- | --------------- | --------------------------------------- |
+| argv    | the token, verbatim | present         | it is already on the user's screen      |
+| stdin   | `'<redacted>'`      | absent          | a pipe carries secrets                  |
+| env     | `'<redacted>'`      | absent          | an environment variable carries secrets |
+| config  | `'<redacted>'`      | absent          | a config file carries secrets           |
+| prompt  | `'<redacted>'`      | absent          | an answer may be a password             |
+| default | `'<redacted>'`      | absent          | a declared default may hold a secret    |
 
 An explicit `-` counts as a stdin value, not an argv one because the bytes came
 from the pipe rather than from the token.
+
+The rule reaches every diagnostic resolution produces, including the ones a
+later pass writes: a Standard Schema issue and a `flag.path()` / `arg.path()`
+filesystem check both quote `<redacted>` and omit `details.value` unless an
+argv token carried the value.
 
 ```bash
 $ mycli deploy --token sk-live-9f2

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -273,7 +273,9 @@ Cause:
   variable or a pipe routinely carries a secret, and a diagnostic is written to
   a terminal, a log, and a CI transcript.
 - an explicit `-` counts as a stdin value, since the bytes came from the pipe
-  rather than from the token.
+  rather than from the token;
+- a declared default is redacted too, and so is a `flag.path()` / `arg.path()`
+  filesystem check on a path no argv token carried.
 
 Check:
 

--- a/docs/guide/upgrading-v4.md
+++ b/docs/guide/upgrading-v4.md
@@ -696,6 +696,19 @@ rather than to interpolate the value.
 Argv is unaffected. A token the user typed is already on their screen, so parse
 errors keep quoting it.
 
+The `flag.path()` and `arg.path()` filesystem checks follow the same rule, one
+pass later. A path an argv token carried is quoted in full; a path from stdin,
+an explicit `-`, the environment, a config file, a prompt, or a declared default
+reports `Path '<redacted>' for flag --key does not exist` and omits `value`:
+
+```
+# 3.x
+Path '/home/u/.ssh/id_rsa' for flag --key does not exist
+
+# 4.0, with KEY=/home/u/.ssh/id_rsa in the environment
+Path '<redacted>' for flag --key does not exist
+```
+
 Two adjustments. Tests asserting a value inside a resolution error message
 assert `'<redacted>'` instead. Code reading `error.details.value` reads the
 value from its own source, since the framework no longer copies it into a

--- a/docs/reference/stability.md
+++ b/docs/reference/stability.md
@@ -643,7 +643,8 @@ Class constructors follow the same rule as functions, with one exception.
 `InferFlag`, `InferFlags`, `InferArg`, `InferArgs`, `InferStandardInput`,
 `InferStandardOutput`, `ResolvedValue`, `ResolvedArgValue`, `ArgDefaultValue`,
 `WithPresence`, `WithArgPresence`, `WithVariadic`,
-`WithoutArgElementEligibility`, the builder state types `FlagConfig`,
+`WithoutElementEligibility`, `WithoutArgElementEligibility`, the builder state
+types `FlagConfig`,
 `ArgConfig`, `StringElementConfig`, and `StringArgElementConfig`, the element
 configs a collection factory assumes when given no element builder, and
 `FlagMap`, the record of flag builders `readFlags()` evaluates.

--- a/src/core/cli/stdin-eligibility.test.ts
+++ b/src/core/cli/stdin-eligibility.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { arg } from '#internals/core/schema/arg.ts';
 import { command } from '#internals/core/schema/command.ts';
 import { flag } from '#internals/core/schema/flag.ts';
+import type { ResolutionProvenance } from '#internals/core/schema/provenance.ts';
 import { createTestAdapter, ExitError } from '#internals/runtime/adapter.ts';
 import { cli } from './index.ts';
 
@@ -197,6 +198,94 @@ describe('flag stdin eligibility', () => {
 		await runQuietly(() => app.run({ adapter: host.adapter }));
 
 		expect(host.reads()).toBe(0);
+	});
+});
+
+// === L19 — the build-time rule is per command, so the invocation decides at run time
+
+describe('several commands declaring stdin', () => {
+	/** Read a flag the subcommand inherited, which its own generics do not name. */
+	function propagatedBody(flags: { readonly body?: string }): string | undefined {
+		return flags.body;
+	}
+
+	/** Read the provenance of that inherited flag. */
+	function propagatedBodySource(sources: {
+		readonly body?: ResolutionProvenance;
+	}): ResolutionProvenance | undefined {
+		return sources.body;
+	}
+
+	/** Two sibling commands, each the only stdin consumer of its own schema. */
+	function siblings(seen: unknown[]) {
+		return cli('mycli')
+			.command(
+				command('send')
+					.flag('body', flag.string().stdin())
+					.action(({ flags }) => {
+						seen.push({ send: flags.body });
+					}),
+			)
+			.command(
+				command('load')
+					.arg('input', arg.string().stdin())
+					.action(({ args }) => {
+						seen.push({ load: args.input });
+					}),
+			);
+	}
+
+	it('reads the pipe once, for the command actually dispatched', async () => {
+		const seen: unknown[] = [];
+		const host = countingAdapter({ argv: ['send'], stdinData: 'piped' });
+
+		await runQuietly(() => siblings(seen).run({ adapter: host.adapter }));
+
+		expect(host.reads()).toBe(1);
+		expect(seen).toEqual([{ send: 'piped' }]);
+	});
+
+	it('reads the pipe once for the other sibling too', async () => {
+		const seen: unknown[] = [];
+		const host = countingAdapter({ argv: ['load'], stdinData: 'piped' });
+
+		await runQuietly(() => siblings(seen).run({ adapter: host.adapter }));
+
+		expect(host.reads()).toBe(1);
+		expect(seen).toEqual([{ load: 'piped' }]);
+	});
+
+	it('hands one buffer to a propagated stdin flag and the subcommand own stdin arg', async () => {
+		const seen: unknown[] = [];
+		const app = cli('mycli').command(
+			command('db')
+				.flag('body', flag.string().stdin({ consume: 'broadcast' }).propagate())
+				.command(
+					command('migrate')
+						.arg('input', arg.string().stdin({ consume: 'broadcast' }))
+						.action(({ args, flags, sources }) => {
+							seen.push({
+								input: args.input,
+								body: propagatedBody(flags),
+								inputSource: sources.args.input,
+								bodySource: propagatedBodySource(sources.flags),
+							});
+						}),
+				),
+		);
+		const host = countingAdapter({ argv: ['db', 'migrate'], stdinData: 'piped' });
+
+		await runQuietly(() => app.run({ adapter: host.adapter }));
+
+		expect(host.reads()).toBe(1);
+		expect(seen).toEqual([
+			{
+				input: 'piped',
+				body: 'piped',
+				inputSource: { stage: 'stdin', via: 'stdin', trigger: 'fallback' },
+				bodySource: { stage: 'stdin', via: 'stdin', trigger: 'fallback' },
+			},
+		]);
 	});
 });
 

--- a/src/core/help/help.test.ts
+++ b/src/core/help/help.test.ts
@@ -331,6 +331,44 @@ describe('formatHelp', () => {
 			expect(help).toContain('(default: 8080)');
 		});
 
+		it('shows a default a definition declared without the defaulted presence', () => {
+			const base = command('run');
+			const help = formatHelp({
+				...base.schema,
+				flags: { out: createFlagSchema('string', { defaultValue: 'dist' }) },
+				args: [{ name: 'target', schema: createArgSchema('string', { defaultValue: 'prod' }) }],
+			});
+
+			expect(help).toContain('(default: dist)');
+			expect(help).toContain('(default: prod)');
+		});
+
+		it('drops the required marker from an input a default always fills', () => {
+			const base = command('run');
+			const help = formatHelp({
+				...base.schema,
+				flags: {
+					out: createFlagSchema('string', { presence: 'required', defaultValue: 'dist' }),
+					mode: createFlagSchema('string', { presence: 'required' }),
+				},
+				args: [
+					{
+						name: 'target',
+						schema: createArgSchema('string', { presence: 'required', defaultValue: 'prod' }),
+					},
+					{ name: 'other', schema: createArgSchema('string', { presence: 'required' }) },
+				],
+			});
+
+			expect(help).toContain('(default: dist)');
+			expect(help).toContain('(default: prod)');
+			expect(help).toContain('[target]');
+			expect(help).toContain('<other>');
+			expect(help).not.toContain('<target>');
+			expect(help).toMatch(/--mode <string>\s+\[required\]/);
+			expect(help).not.toMatch(/--out <string>\s+\[required\]/);
+		});
+
 		it('renders nullish sentinels for defaulted flags', () => {
 			const base = command('run');
 			const nullHelp = formatHelp({

--- a/src/core/help/index.ts
+++ b/src/core/help/index.ts
@@ -293,10 +293,12 @@ function formatFlagDescription(schema: FlagSchema, theme: HelpTheme): string {
 		parts.push(theme.annotation('[prompt]'));
 	}
 
-	if (schema.presence === 'required') {
+	// A schema carrying a default resolves one whatever its presence says, so the
+	// required stage never reports it missing.
+	if (schema.presence === 'required' && schema.defaultValue === undefined) {
 		parts.push(theme.annotation('[required]'));
 	} else if (
-		schema.presence === 'defaulted' &&
+		(schema.presence === 'defaulted' || schema.defaultValue !== undefined) &&
 		schema.kind !== 'boolean' &&
 		schema.kind !== 'count'
 	) {
@@ -380,7 +382,9 @@ function formatArgUsage(entry: CommandArgEntry): string {
 	const label =
 		schema.kind === 'enum' && schema.enumValues !== undefined ? schema.enumValues.join('|') : name;
 	const variadicSuffix = schema.variadic ? '...' : '';
-	if (schema.presence === 'required') {
+	// A positional carrying a default resolves one whatever its presence says, so
+	// the usage line does not demand a token for it.
+	if (schema.presence === 'required' && schema.defaultValue === undefined) {
 		return `<${label}>${variadicSuffix}`;
 	}
 	return `[${label}]${variadicSuffix}`;
@@ -418,7 +422,7 @@ function formatArgDescription(schema: ArgSchema, theme: HelpTheme): string {
 		parts.push(theme.annotation('[prompt]'));
 	}
 
-	if (schema.presence === 'defaulted') {
+	if (schema.presence === 'defaulted' || schema.defaultValue !== undefined) {
 		parts.push(theme.defaultValue(`(default: ${formatHelpDefaultValue(schema.defaultValue)})`));
 	}
 

--- a/src/core/json-schema/definition-round-trip.test.ts
+++ b/src/core/json-schema/definition-round-trip.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Definition-document round trips: build, emit, rebuild, emit again, deep-equal.
+ *
+ * A V1 document is only worth freezing if the fields it writes are the fields a
+ * definition accepts. The maximal CLI below sets every field the emitter can
+ * write; the rebuild maps a fragment back to a definition and the two documents
+ * must match byte for byte.
+ *
+ * @module dreamcli/core/json-schema/definition-round-trip.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { CLIDefinition } from '#internals/core/cli/index.ts';
+import { createCLISchema } from '#internals/core/cli/index.ts';
+import { parse } from '#internals/core/parse/index.ts';
+import { resolve } from '#internals/core/resolve/index.ts';
+import type { ArgDefinition } from '#internals/core/schema/arg.ts';
+import type { SourceSplitBinding } from '#internals/core/schema/cardinality.ts';
+import type { CommandDefinition } from '#internals/core/schema/command.ts';
+import type { FlagDefinition, FlagNegation } from '#internals/core/schema/flag.ts';
+import type { PathChecks } from '#internals/core/schema/value-parsers.ts';
+import type {
+	ArgDefinitionFragmentV1,
+	CommandDefinitionFragmentV1,
+	DefinitionDocumentV1,
+	FlagDefinitionFragmentV1,
+	FlagNegationFragmentV1,
+	FlagPathChecksFragmentV1,
+	FlagStringConstraintsFragmentV1,
+	SourceSplitFragmentV1,
+} from './index.ts';
+import { generateSchema } from './index.ts';
+
+type ArgValueFragmentV1 = Omit<ArgDefinitionFragmentV1, 'name'>;
+
+// === the rebuild: one fragment shape, one definition shape
+
+/**
+ * Rebuild string constraints from a fragment.
+ *
+ * A JSON document cannot carry a `RegExp`, so the emitter writes its source and
+ * flags; this is the only field whose document shape differs from its
+ * definition shape.
+ */
+function stringConstraintsOf(fragment: FlagStringConstraintsFragmentV1): Record<string, unknown> {
+	const pattern = fragment.pattern;
+	return {
+		...(fragment.nonEmpty !== undefined ? { nonEmpty: fragment.nonEmpty } : {}),
+		...(fragment.minLength !== undefined ? { minLength: fragment.minLength } : {}),
+		...(fragment.maxLength !== undefined ? { maxLength: fragment.maxLength } : {}),
+		...(pattern !== undefined ? { pattern: new RegExp(pattern.source, pattern.flags) } : {}),
+	};
+}
+
+/**
+ * Rebuild filesystem checks from a fragment.
+ *
+ * A document omits a field it has nothing to say about; a definition declares
+ * every field and spells absence as `undefined`.
+ */
+function pathChecksOf(fragment: FlagPathChecksFragmentV1): PathChecks {
+	return {
+		mustExist: fragment.mustExist,
+		type: fragment.type,
+		create: fragment.create ?? false,
+	};
+}
+
+/** Rebuild the non-CLI split policies, whose fragment leaves an unset source out. */
+function splitOf(fragment: SourceSplitFragmentV1): SourceSplitBinding {
+	return { env: fragment.env, stdin: fragment.stdin };
+}
+
+/** Rebuild the negated-spelling settings, whose fragment leaves the defaults out. */
+function negationOf(fragment: FlagNegationFragmentV1): FlagNegation {
+	return { alias: fragment.alias, hidden: fragment.hidden ?? false };
+}
+
+/** Rebuild a flag definition from the fragment the document carries. */
+function flagDefinitionOf(fragment: FlagDefinitionFragmentV1): FlagDefinition {
+	const { kind, stringConstraints, pathChecks, split, negation, elementSchema, ...rest } = fragment;
+	const fields = {
+		...rest,
+		...(stringConstraints !== undefined
+			? { stringConstraints: stringConstraintsOf(stringConstraints) }
+			: {}),
+		...(pathChecks !== undefined ? { pathChecks: pathChecksOf(pathChecks) } : {}),
+		...(split !== undefined ? { split: splitOf(split) } : {}),
+		...(negation !== undefined ? { negation: negationOf(negation) } : {}),
+		...(elementSchema !== undefined ? { elementSchema: flagDefinitionOf(elementSchema) } : {}),
+	};
+
+	switch (kind) {
+		case 'string':
+			return { kind: 'string', ...fields };
+		case 'number':
+			return { kind: 'number', ...fields };
+		case 'boolean':
+			return { kind: 'boolean', ...fields };
+		case 'enum':
+			return { kind: 'enum', ...fields, enumValues: fragment.enumValues ?? [] };
+		case 'custom':
+			return { kind: 'custom', ...fields };
+		case 'array':
+			return { kind: 'array', ...fields };
+		case 'keyValue':
+			return { kind: 'keyValue', ...fields };
+		case 'count':
+			return { kind: 'count', ...fields };
+	}
+}
+
+/** Rebuild an arg definition from the value half of a fragment. */
+function argDefinitionOf(fragment: ArgValueFragmentV1): ArgDefinition {
+	const { kind, stringConstraints, pathChecks, split, elementSchema, ...rest } = fragment;
+	const fields = {
+		...rest,
+		...(stringConstraints !== undefined
+			? { stringConstraints: stringConstraintsOf(stringConstraints) }
+			: {}),
+		...(pathChecks !== undefined ? { pathChecks: pathChecksOf(pathChecks) } : {}),
+		...(split !== undefined ? { split: splitOf(split) } : {}),
+		...(elementSchema !== undefined ? { elementSchema: argDefinitionOf(elementSchema) } : {}),
+	};
+
+	switch (kind) {
+		case 'string':
+			return { kind: 'string', ...fields };
+		case 'number':
+			return { kind: 'number', ...fields };
+		case 'boolean':
+			return { kind: 'boolean', ...fields };
+		case 'enum':
+			return { kind: 'enum', ...fields, enumValues: fragment.enumValues ?? [] };
+		case 'custom':
+			return { kind: 'custom', ...fields };
+		case 'keyValue':
+			return { kind: 'keyValue', ...fields };
+	}
+}
+
+/** Rebuild one positional entry, whose name the array position no longer supplies. */
+function argEntryOf(fragment: ArgDefinitionFragmentV1): {
+	readonly name: string;
+	readonly schema: ArgDefinition;
+} {
+	const { name, ...value } = fragment;
+	return { name, schema: argDefinitionOf(value) };
+}
+
+/** Rebuild a command definition from the fragment the document carries. */
+function commandDefinitionOf(fragment: CommandDefinitionFragmentV1): CommandDefinition {
+	const flags: Record<string, FlagDefinition> = {};
+	for (const [name, flagFragment] of Object.entries(fragment.flags)) {
+		flags[name] = flagDefinitionOf(flagFragment);
+	}
+
+	return {
+		name: fragment.name,
+		...(fragment.description !== undefined ? { description: fragment.description } : {}),
+		...(fragment.aliases !== undefined ? { aliases: fragment.aliases } : {}),
+		...(fragment.hidden !== undefined ? { hidden: fragment.hidden } : {}),
+		...(fragment.examples !== undefined ? { examples: fragment.examples } : {}),
+		flags,
+		args: fragment.args.map(argEntryOf),
+		commands: fragment.commands.map(commandDefinitionOf),
+		hasAction: true,
+	};
+}
+
+/** Rebuild the whole CLI definition from the document. */
+function cliDefinitionOf(document: DefinitionDocumentV1): CLIDefinition {
+	return {
+		name: document.name,
+		...(document.version !== undefined ? { version: document.version } : {}),
+		...(document.description !== undefined ? { description: document.description } : {}),
+		...(document.defaultCommand !== undefined
+			? { defaultCommand: commandDefinitionOf(document.defaultCommand) }
+			: {}),
+		commands: document.commands.map(commandDefinitionOf),
+	};
+}
+
+// === the maximal schema
+
+/** A CLI that sets every field the definition emitter can write. */
+function maximalDefinition(): CLIDefinition {
+	return {
+		name: 'maximal',
+		version: '4.0.0',
+		description: 'Every field a V1 document carries',
+		defaultCommand: {
+			name: 'root',
+			description: 'The default command',
+			hasAction: true,
+			flags: { quietly: { kind: 'boolean', presence: 'defaulted', defaultValue: false } },
+		},
+		commands: [
+			{
+				name: 'deploy',
+				description: 'Ship the build',
+				aliases: ['ship'],
+				hidden: true,
+				hasAction: true,
+				examples: [
+					{ command: 'deploy prod', description: 'the usual' },
+					{ command: 'deploy staging' },
+				],
+				flags: {
+					region: {
+						kind: 'enum',
+						presence: 'defaulted',
+						defaultValue: 'us',
+						enumValues: ['us', 'eu', 'ap'],
+						aliases: ['r'],
+						envVar: 'REGION',
+						configPath: 'deploy.region',
+						description: 'Target region',
+						prompt: {
+							kind: 'select',
+							message: 'Where?',
+							choices: [{ value: 'us', label: 'United States', description: 'the default' }],
+						},
+						deprecated: 'use --location',
+						propagate: true,
+						duplicates: 'error',
+					},
+					force: {
+						kind: 'boolean',
+						presence: 'optional',
+						negation: { alias: 'no-force', hidden: true },
+					},
+					name: {
+						kind: 'string',
+						presence: 'required',
+						stringConstraints: {
+							nonEmpty: true,
+							minLength: 2,
+							maxLength: 32,
+							pattern: /^[a-z][a-z0-9-]*$/iu,
+						},
+						prompt: { kind: 'input', message: 'Name?', placeholder: 'svc-1' },
+					},
+					out: {
+						kind: 'string',
+						presence: 'optional',
+						pathChecks: { mustExist: true, type: 'directory', create: true },
+						valueHint: 'path',
+						stdin: { when: 'dash', consume: 'broadcast', trim: true },
+					},
+					retries: {
+						kind: 'number',
+						presence: 'defaulted',
+						defaultValue: 3,
+						numberConstraints: { min: 0, max: 10, int: true, finite: true },
+					},
+					tag: {
+						kind: 'array',
+						presence: 'optional',
+						elementSchema: { kind: 'string', stringConstraints: { nonEmpty: true } },
+						separator: ',',
+						split: { env: { format: 'json' }, stdin: { format: 'delimiter', delimiter: ';' } },
+						unique: true,
+						prompt: {
+							kind: 'multiselect',
+							message: 'Which tags?',
+							choices: [{ value: 'api' }, { value: 'web', label: 'Web' }],
+							min: 1,
+							max: 2,
+						},
+					},
+					define: {
+						kind: 'keyValue',
+						presence: 'optional',
+						elementSchema: { kind: 'number', numberConstraints: { min: 1 } },
+						duplicateKeys: 'error',
+					},
+					verbose: { kind: 'count', presence: 'optional', aliases: ['v'] },
+					confirmed: {
+						kind: 'boolean',
+						presence: 'optional',
+						prompt: { kind: 'confirm', message: 'Sure?' },
+					},
+				},
+				args: [
+					{
+						name: 'target',
+						schema: {
+							kind: 'enum',
+							presence: 'required',
+							enumValues: ['prod', 'staging'],
+							description: 'Where to ship',
+							envVar: 'TARGET',
+							configPath: 'deploy.target',
+							deprecated: true,
+							prompt: { kind: 'input', message: 'Vars?' },
+						},
+					},
+					{
+						name: 'vars',
+						schema: {
+							kind: 'keyValue',
+							presence: 'optional',
+							elementSchema: { kind: 'string', presence: 'required' },
+							duplicateKeys: 'first',
+							separator: ',',
+							split: { env: { format: 'lines' }, stdin: undefined },
+						},
+					},
+					{
+						name: 'files',
+						schema: {
+							kind: 'string',
+							presence: 'optional',
+							variadic: true,
+							defaultValue: ['a.txt'],
+							pathChecks: { mustExist: true, type: undefined, create: false },
+							valueHint: 'path',
+							unique: true,
+							stdin: { when: 'missing', consume: 'broadcast', trim: false },
+						},
+					},
+				],
+				commands: [
+					{
+						name: 'rollback',
+						hasAction: true,
+						flags: { steps: { kind: 'number', presence: 'defaulted', defaultValue: 1 } },
+						args: [{ name: 'release', schema: { kind: 'string', presence: 'optional' } }],
+						commands: [{ name: 'dry', hasAction: true }],
+					},
+				],
+			},
+		],
+	};
+}
+
+// === the round trip
+
+describe('a maximal definition document', () => {
+	const first = generateSchema(createCLISchema(maximalDefinition()));
+	const second = generateSchema(createCLISchema(cliDefinitionOf(first)));
+
+	it('emits the same document after a rebuild', () => {
+		expect(second).toEqual(first);
+	});
+
+	it('survives a JSON round trip on the way through', () => {
+		const parsed: unknown = JSON.parse(JSON.stringify(first));
+		expect(parsed).toEqual(first);
+	});
+
+	it('carries every field the emitter can write', () => {
+		const deploy = first.commands[0];
+		const flags = deploy?.flags ?? {};
+
+		expect(Object.keys(flags).sort()).toEqual([
+			'confirmed',
+			'define',
+			'force',
+			'name',
+			'out',
+			'region',
+			'retries',
+			'tag',
+			'verbose',
+		]);
+		expect(new Set(Object.keys(flags.region ?? {}))).toEqual(
+			new Set([
+				'kind',
+				'presence',
+				'defaultValue',
+				'aliases',
+				'envVar',
+				'configPath',
+				'description',
+				'enumValues',
+				'prompt',
+				'deprecated',
+				'propagate',
+				'duplicates',
+			]),
+		);
+		expect(new Set(Object.keys(flags.tag ?? {}))).toEqual(
+			new Set(['kind', 'presence', 'elementSchema', 'separator', 'split', 'unique', 'prompt']),
+		);
+		expect(new Set(Object.keys(deploy?.args[2] ?? {}))).toEqual(
+			new Set([
+				'name',
+				'kind',
+				'presence',
+				'variadic',
+				'stdin',
+				'defaultValue',
+				'pathChecks',
+				'valueHint',
+				'unique',
+			]),
+		);
+	});
+});
+
+// === the rebuilt schema resolves what the original resolved
+
+describe('a rebuilt command', () => {
+	/** Resolve one CLI's only command against an empty argv. */
+	async function resolvedValues(
+		definition: CLIDefinition,
+	): Promise<{ readonly flags: unknown; readonly args: unknown }> {
+		const schema = createCLISchema(definition).commands[0];
+		if (schema === undefined) throw new Error('the CLI declared no command');
+		const resolved = await resolve(schema, parse(schema, []), {});
+		return { flags: resolved.flags, args: resolved.args };
+	}
+
+	it('keeps a default a definition declared without the defaulted presence', async () => {
+		const original: CLIDefinition = {
+			name: 'defaults',
+			commands: [
+				{
+					name: 'build',
+					hasAction: true,
+					flags: { out: { kind: 'string', defaultValue: 'dist' } },
+					args: [
+						{ name: 'files', schema: { kind: 'string', variadic: true, defaultValue: ['a'] } },
+					],
+				},
+			],
+		};
+
+		const before = await resolvedValues(original);
+		const after = await resolvedValues(cliDefinitionOf(generateSchema(createCLISchema(original))));
+
+		expect(before).toEqual({ flags: { out: 'dist' }, args: { files: ['a'] } });
+		expect(after).toEqual(before);
+	});
+});
+
+// === what a document deliberately drops
+
+describe('the fields a document cannot carry', () => {
+	const document = generateSchema(
+		createCLISchema({
+			name: 'lossy',
+			commands: [
+				{
+					name: 'run',
+					hasAction: true,
+					flags: {
+						hex: {
+							kind: 'custom',
+							parseFn: (raw) => Number.parseInt(String(raw), 16),
+							standard: {
+								'~standard': { version: 1, vendor: 'test', validate: (value) => ({ value }) },
+							},
+						},
+						silent: { kind: 'boolean', aliases: [{ name: 's', hidden: true }] },
+						sink: { kind: 'custom', presence: 'defaulted', defaultValue: () => 42 },
+					},
+				},
+			],
+		}),
+	);
+
+	it('drops the runtime callables and the hidden alias', () => {
+		expect(document.commands[0]?.flags).toEqual({
+			hex: { kind: 'custom', presence: 'optional' },
+			silent: { kind: 'boolean', presence: 'optional' },
+			sink: { kind: 'custom', presence: 'defaulted' },
+		});
+	});
+
+	it('rebuilds into a schema that keeps everything the document did carry', () => {
+		const rebuilt = createCLISchema(cliDefinitionOf(document));
+
+		expect(generateSchema(rebuilt)).toEqual(document);
+	});
+});

--- a/src/core/json-schema/index.ts
+++ b/src/core/json-schema/index.ts
@@ -540,9 +540,7 @@ function serializeFlag(schema: FlagSchema, opts: ResolvedOptions): FlagDefinitio
 	return {
 		kind: schema.kind,
 		presence: schema.presence,
-		...(schema.presence === 'defaulted' && isJsonSerializable(schema.defaultValue)
-			? { defaultValue: schema.defaultValue }
-			: {}),
+		...(isJsonSerializable(schema.defaultValue) ? { defaultValue: schema.defaultValue } : {}),
 		...(visibleAliases.length > 0 ? { aliases: [...visibleAliases] } : {}),
 		...(schema.stdin !== undefined ? { stdin: serializeStdin(schema.stdin) } : {}),
 		...(schema.envVar !== undefined ? { envVar: schema.envVar } : {}),
@@ -643,9 +641,7 @@ function serializeArgValue(schema: ArgSchema, opts: ResolvedOptions): ArgValueFr
 		presence: schema.presence,
 		...(schema.variadic ? { variadic: true } : {}),
 		...(schema.stdin !== undefined ? { stdin: serializeStdin(schema.stdin) } : {}),
-		...(schema.presence === 'defaulted' && isJsonSerializable(schema.defaultValue)
-			? { defaultValue: schema.defaultValue }
-			: {}),
+		...(isJsonSerializable(schema.defaultValue) ? { defaultValue: schema.defaultValue } : {}),
 		...(schema.description !== undefined ? { description: schema.description } : {}),
 		...(schema.envVar !== undefined ? { envVar: schema.envVar } : {}),
 		...(schema.configPath !== undefined ? { configPath: schema.configPath } : {}),
@@ -1048,7 +1044,7 @@ function flagToJsonSchemaType(schema: FlagSchema): Record<string, unknown> {
 	if (schema.description !== undefined) {
 		result.description = schema.description;
 	}
-	if (schema.presence === 'defaulted' && isJsonSerializable(schema.defaultValue)) {
+	if (isJsonSerializable(schema.defaultValue)) {
 		result.default = schema.defaultValue;
 	}
 	if (schema.deprecated !== undefined) {
@@ -1068,7 +1064,7 @@ function argToJsonSchemaType(schema: ArgSchema): Record<string, unknown> {
 	if (schema.description !== undefined) {
 		result.description = schema.description;
 	}
-	if (schema.presence === 'defaulted' && isJsonSerializable(schema.defaultValue)) {
+	if (isJsonSerializable(schema.defaultValue)) {
 		result.default = schema.defaultValue;
 	}
 	if (schema.deprecated !== undefined) {

--- a/src/core/json-schema/json-schema.test.ts
+++ b/src/core/json-schema/json-schema.test.ts
@@ -416,6 +416,27 @@ describe('generateSchema — definition metadata', () => {
 		expect(result).toHaveProperty(['commands', 0, 'flags', 'region', 'defaultValue'], 'us');
 	});
 
+	it('includes a defaultValue a definition declared without the defaulted presence', () => {
+		const cmd = commandDef({
+			name: 'test',
+			flags: { region: flagDef({ kind: 'string', defaultValue: 'us' }) },
+			args: [argEntry('target', { kind: 'string', defaultValue: 'prod' })],
+		});
+		const result = generateSchema(minimalCLI({ commands: [cmd] }));
+
+		expect(result).toHaveProperty(['commands', 0, 'flags', 'region'], {
+			kind: 'string',
+			presence: 'optional',
+			defaultValue: 'us',
+		});
+		expect(result).toHaveProperty(['commands', 0, 'args', 0], {
+			name: 'target',
+			kind: 'string',
+			presence: 'required',
+			defaultValue: 'prod',
+		});
+	});
+
 	it('omits flag defaultValue when not serializable', () => {
 		const cmd = commandDef({
 			name: 'test',
@@ -1365,6 +1386,18 @@ describe('generateInputSchema — input validation', () => {
 		});
 		const result = generateInputSchema(cmd);
 		expect(result).toHaveProperty(['properties', 'target', 'description'], 'Deploy target');
+		expect(result).toHaveProperty(['properties', 'target', 'default'], 'prod');
+	});
+
+	it('includes a default a definition declared without the defaulted presence', () => {
+		const cmd = commandDef({
+			name: 'test',
+			flags: { region: flagDef({ kind: 'string', defaultValue: 'us' }) },
+			args: [argEntry('target', { kind: 'string', defaultValue: 'prod' })],
+		});
+		const result = generateInputSchema(cmd);
+
+		expect(result).toHaveProperty(['properties', 'region', 'default'], 'us');
 		expect(result).toHaveProperty(['properties', 'target', 'default'], 'prod');
 	});
 

--- a/src/core/parse/AGENTS.md
+++ b/src/core/parse/AGENTS.md
@@ -10,7 +10,7 @@ those two phases meet in.
 
 | File                        | Lines | Purpose                                                         |
 | --------------------------- | ----: | --------------------------------------------------------------- |
-| `index.ts`                  |  1272 | `tokenize()`, `parse()`, flag/arg token reading, lookup helpers |
+| `index.ts`                  |  1286 | `tokenize()`, `parse()`, flag/arg token reading, lookup helpers |
 | `occurrences.ts`            |   186 | `Occurrence`, `projectOccurrences()`, `liftOccurrences()`       |
 | `parse.test.ts`             |  1045 | parser contract, edge cases, regressions                        |
 | `parse-case-parity.test.ts` |   118 | kebab↔camel counterpart spellings                               |

--- a/src/core/parse/index.ts
+++ b/src/core/parse/index.ts
@@ -14,7 +14,7 @@
  */
 
 import { ParseError } from '#internals/core/errors/index.ts';
-import type { SplitPolicy } from '#internals/core/schema/cardinality.ts';
+import type { Cardinality, SplitPolicy } from '#internals/core/schema/cardinality.ts';
 import {
 	argCardinality,
 	flagCardinality,
@@ -1007,6 +1007,21 @@ function splitCliToken(
 /** The CLI policy a single-value positional splits under: none at all. */
 const WHOLE_TOKEN: SplitPolicy = { format: 'whole' };
 
+/**
+ * The CLI split policy a cardinality carries.
+ *
+ * A scalar and a count have no elements to split into, so their tokens stay
+ * whole.
+ *
+ * @param cardinality - How the input's values combine.
+ * @returns The policy each of its CLI tokens splits under.
+ */
+function cliSplitOf(cardinality: Cardinality): SplitPolicy {
+	return cardinality.kind === 'many' || cardinality.kind === 'entries'
+		? cardinality.cliSplit
+		: WHOLE_TOKEN;
+}
+
 // --- Positional arg mapping
 
 /**
@@ -1026,13 +1041,10 @@ function mapPositionals(
 
 	for (const entry of argEntries) {
 		const cardinality = argCardinality(entry.schema);
+		const policy = cliSplitOf(cardinality);
 		if (entry.schema.variadic) {
 			// Variadic arg consumes all remaining positionals
 			const remaining = positionals.slice(posIdx);
-			const policy =
-				cardinality.kind === 'many' || cardinality.kind === 'entries'
-					? cardinality.cliSplit
-					: WHOLE_TOKEN;
 			const occurrences = remaining.flatMap((raw) =>
 				splitCliToken(policy, raw, { stdin: entry.schema.stdin }).map((part) =>
 					argTokenOccurrence(entry.name, part, entry.schema),
@@ -1045,10 +1057,6 @@ function mapPositionals(
 
 		const rawPositional = positionals[posIdx];
 		if (rawPositional !== undefined) {
-			const policy =
-				cardinality.kind === 'many' || cardinality.kind === 'entries'
-					? cardinality.cliSplit
-					: WHOLE_TOKEN;
 			const occurrences = splitCliToken(policy, rawPositional, {
 				stdin: entry.schema.stdin,
 			}).map((part) => argTokenOccurrence(entry.name, part, entry.schema));

--- a/src/core/read-flags/read-flags-parity.test.ts
+++ b/src/core/read-flags/read-flags-parity.test.ts
@@ -1,0 +1,317 @@
+/**
+ * readFlags() against a command action, capability by capability.
+ *
+ * The argv-shaped parity table lives in read-flags.test.ts. This one walks the
+ * rest of the surface: every source, the stdin contract, aggregation, element
+ * and aggregate validation, path checks, deprecation notices, and provenance.
+ *
+ * @module dreamcli/core/read-flags/read-flags-parity.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { CLIError } from '#internals/core/errors/index.ts';
+import { createTestPrompter } from '#internals/core/prompt/index.ts';
+import type { DeprecationWarning } from '#internals/core/resolve/index.ts';
+import { command } from '#internals/core/schema/command.ts';
+import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import type { ResolutionProvenance } from '#internals/core/schema/provenance.ts';
+import type { RunOptions } from '#internals/core/schema/run.ts';
+import type { StandardSchemaV1 } from '#internals/core/schema/standard.ts';
+import { runCommand } from '#internals/core/testkit/index.ts';
+import { createTestAdapter } from '#internals/runtime/adapter.ts';
+import { readFlags } from './index.ts';
+
+// === helpers
+
+/** Everything one invocation produced, on either entry point. */
+interface Outcome {
+	readonly value: unknown;
+	readonly code: string | undefined;
+	readonly source: ResolutionProvenance | undefined;
+	readonly deprecations: readonly string[];
+}
+
+/** One capability: the flag under test, the argv, and the injected state. */
+interface Capability {
+	readonly label: string;
+	readonly builder: FlagBuilder<FlagConfig>;
+	readonly argv: readonly string[];
+	readonly options?: RunOptions;
+}
+
+/** The wording the command surface writes to stderr for one notice. */
+function formatDeprecation(warning: DeprecationWarning): string {
+	const entity = warning.kind === 'flag' ? `flag --${warning.name}` : `argument <${warning.name}>`;
+	return typeof warning.message === 'string'
+		? `Warning: ${entity} is deprecated: ${warning.message}`
+		: `Warning: ${entity} is deprecated`;
+}
+
+/** Minimal hand-rolled Standard Schema validator. */
+function standard<Output>(
+	validate: StandardSchemaV1<unknown, Output>['~standard']['validate'],
+): StandardSchemaV1<unknown, Output> {
+	return { '~standard': { version: 1, vendor: 'test', validate } };
+}
+
+/** Accepts only lower-case text, synchronously. */
+const lowerOnly = standard<string>((value) =>
+	typeof value === 'string' && value === value.toLowerCase()
+		? { value }
+		: { issues: [{ message: 'must be lower case' }] },
+);
+
+/** Accepts a list of at most two elements, asynchronously. */
+const atMostTwo = standard<readonly unknown[]>(async (value) =>
+	Array.isArray(value) && value.length <= 2 ? { value } : { issues: [{ message: 'too many' }] },
+);
+
+/** Run the capability through a command action. */
+async function viaCommand(capability: Capability): Promise<Outcome> {
+	let value: unknown;
+	let source: ResolutionProvenance | undefined;
+	const deprecations: string[] = [];
+	const cmd = command('parity')
+		.flag('value', capability.builder)
+		.action(({ flags, sources }) => {
+			value = flags.value;
+			source = sources.flags.value;
+		});
+
+	const result = await runCommand(cmd, [...capability.argv], {
+		env: {},
+		...capability.options,
+	});
+	for (const line of result.stderr) {
+		if (line.startsWith('Warning:')) deprecations.push(line.trim());
+	}
+
+	return { value, code: result.error?.code, source, deprecations };
+}
+
+/** Run the same capability through readFlags. */
+async function viaReadFlags(capability: Capability): Promise<Outcome> {
+	let source: ResolutionProvenance | undefined;
+	const deprecations: string[] = [];
+	const options = capability.options ?? {};
+	const prompter =
+		options.prompter ??
+		(options.answers !== undefined ? createTestPrompter(options.answers) : undefined);
+
+	try {
+		const values = await readFlags(
+			{ value: capability.builder },
+			{
+				argv: [...capability.argv],
+				env: options.env ?? {},
+				adapter: createTestAdapter(),
+				...(options.config !== undefined ? { config: options.config } : {}),
+				...(options.stdinData !== undefined ? { stdinData: options.stdinData } : {}),
+				...(prompter !== undefined ? { prompter } : {}),
+				...(options.stat !== undefined ? { stat: options.stat } : {}),
+				...(options.mkdir !== undefined ? { mkdir: options.mkdir } : {}),
+				onSources: (sources) => {
+					source = sources.value;
+				},
+				onDeprecation: (warning: DeprecationWarning) => {
+					deprecations.push(formatDeprecation(warning));
+				},
+			},
+		);
+		return { value: values.value, code: undefined, source, deprecations };
+	} catch (error: unknown) {
+		if (!(error instanceof CLIError)) throw error;
+		return {
+			value: undefined,
+			code: error.code,
+			source,
+			deprecations,
+		};
+	}
+}
+
+// === the capability matrix
+
+const CAPABILITIES: readonly Capability[] = [
+	{ label: 'a typed value', builder: flag.string(), argv: ['--value', 'typed'] },
+	{
+		label: 'an environment value',
+		builder: flag.string().env('VALUE'),
+		argv: [],
+		options: { env: { VALUE: 'from-env' } },
+	},
+	{
+		label: 'a config value',
+		builder: flag.string().config('deploy.value'),
+		argv: [],
+		options: { config: { deploy: { value: 'from-config' } } },
+	},
+	{
+		label: 'a prompt answer',
+		builder: flag.string().prompt({ kind: 'input', message: 'Value?' }),
+		argv: [],
+		options: { answers: ['answered'] },
+	},
+	{ label: 'a declared default', builder: flag.string().default('fallback'), argv: [] },
+	{
+		label: 'a prompt with no prompter falling through',
+		builder: flag.string().prompt({ kind: 'input', message: 'Value?' }).default('fallback'),
+		argv: [],
+	},
+	{
+		label: 'the stdin fallback',
+		builder: flag.string().stdin(),
+		argv: [],
+		options: { stdinData: 'piped\n' },
+	},
+	{
+		label: 'an explicit dash',
+		builder: flag.string().stdin(),
+		argv: ['--value', '-'],
+		options: { stdinData: 'piped\n' },
+	},
+	{
+		label: 'a trimmed pipe',
+		builder: flag.string().stdin({ trim: true }),
+		argv: [],
+		options: { stdinData: '  piped  \n' },
+	},
+	{
+		label: 'a dash with nothing piped',
+		builder: flag.array(flag.string()).stdin(),
+		argv: ['--value', 'a', '--value', '-'],
+	},
+	{
+		label: 'stdin outranking the environment',
+		builder: flag.string().stdin().env('VALUE'),
+		argv: [],
+		options: { stdinData: 'piped', env: { VALUE: 'from-env' } },
+	},
+	{
+		label: 'a piped number, terminator dropped',
+		builder: flag.number().stdin(),
+		argv: [],
+		options: { stdinData: '42\n' },
+	},
+	{
+		label: 'an env delimiter split',
+		builder: flag.array(flag.string()).env('VALUE'),
+		argv: [],
+		options: { env: { VALUE: 'a,b' } },
+	},
+	{
+		label: 'an env JSON split',
+		builder: flag
+			.array(flag.number())
+			.env('VALUE')
+			.split({ env: { format: 'json' } }),
+		argv: [],
+		options: { env: { VALUE: '[80,443]' } },
+	},
+	{
+		label: 'a stdin splice into occurrence order',
+		builder: flag.array(flag.string()).stdin(),
+		argv: ['--value', 'before', '--value', '-', '--value', 'after'],
+		options: { stdinData: 'a\nb\n' },
+	},
+	{
+		label: 'a native config array',
+		builder: flag.array(flag.string()).config('deploy.tags'),
+		argv: [],
+		options: { config: { deploy: { tags: ['a,b'] } } },
+	},
+	{
+		label: 'deduplication',
+		builder: flag.array(flag.string()).separator(',').unique(),
+		argv: ['--value', 'a,a,b'],
+	},
+	{
+		label: 'the last duplicate key',
+		builder: flag.keyValue(),
+		argv: ['--value', 'A=1', '--value', 'A=2'],
+	},
+	{
+		label: 'the first duplicate key',
+		builder: flag.keyValue().duplicateKeys('first'),
+		argv: ['--value', 'A=1', '--value', 'A=2'],
+	},
+	{
+		label: 'a rejected duplicate key',
+		builder: flag.keyValue().duplicateKeys('error'),
+		argv: ['--value', 'A=1', '--value', 'A=2'],
+	},
+	{
+		label: 'an element validator',
+		builder: flag.array(flag.string().standard(lowerOnly)),
+		argv: ['--value', 'a', '--value', 'B'],
+	},
+	{
+		label: 'an aggregate validator',
+		builder: flag.array(flag.string()).standard(atMostTwo),
+		argv: ['--value', 'a', '--value', 'b', '--value', 'c'],
+	},
+	{
+		label: 'an async validator on a scalar',
+		builder: flag.custom(atMostTwo),
+		argv: ['--value', 'x'],
+	},
+	{
+		label: 'a default validated through the pipeline',
+		builder: flag.string({ minLength: 2 }).default('ok'),
+		argv: [],
+	},
+	{
+		label: 'an env value against string constraints',
+		builder: flag.string({ minLength: 5 }).env('VALUE'),
+		argv: [],
+		options: { env: { VALUE: 'no' } },
+	},
+	{
+		label: 'a missing required flag',
+		builder: flag.string().required(),
+		argv: [],
+	},
+	{
+		label: 'a path check that passes',
+		builder: flag.path({ mustExist: true }),
+		argv: ['--value', '/tmp/here'],
+		options: { stat: async () => 'file' },
+	},
+	{
+		label: 'a path check that fails',
+		builder: flag.path({ mustExist: true }),
+		argv: ['--value', '/tmp/gone'],
+		options: { stat: async () => null },
+	},
+	{
+		label: 'an array of paths, checked per element',
+		builder: flag.array(flag.path({ mustExist: true })),
+		argv: ['--value', '/tmp/a', '--value', '/tmp/b'],
+		options: { stat: async (path: string) => (path === '/tmp/b' ? null : 'file') },
+	},
+	{
+		label: 'a deprecation notice',
+		builder: flag.string().deprecated('use --other'),
+		argv: ['--value', 'typed'],
+	},
+	{
+		label: 'an Object.prototype member as the value',
+		builder: flag.keyValue(),
+		argv: ['--value', '__proto__=x', '--value', 'A=1'],
+	},
+];
+
+describe('readFlags() capability parity', () => {
+	for (const capability of CAPABILITIES) {
+		it(`matches the command path for ${capability.label}`, async () => {
+			const fromCommand = await viaCommand(capability);
+			const fromReadFlags = await viaReadFlags(capability);
+
+			expect(fromReadFlags.code).toBe(fromCommand.code);
+			expect(fromReadFlags.value).toEqual(fromCommand.value);
+			expect(fromReadFlags.source).toEqual(fromCommand.source);
+			expect(fromReadFlags.deprecations).toEqual(fromCommand.deprecations);
+		});
+	}
+});

--- a/src/core/read-flags/read-flags.test.ts
+++ b/src/core/read-flags/read-flags.test.ts
@@ -428,6 +428,10 @@ describe('readFlags() prototype keys', () => {
 		const error = await thrownBy(() => readFlags(definitions, { argv: [], env: {} }));
 
 		expect(error instanceof CLIError && error.code).toBe('INVALID_SCHEMA');
+		expect(error instanceof CLIError && error.details).toEqual({ flag: '__proto__' });
+		expect(error instanceof CLIError && error.suggest).toBe(
+			'Rename the definition key, for example to "proto"',
+		);
 	});
 
 	it('rejects symbol and non-enumerable definition keys instead of dropping them', async () => {

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -1,6 +1,6 @@
 # resolve — Flag/arg value resolution chain
 
-Multi-file module (split from monolithic index). 10 source files, ~2870 source lines.
+Multi-file module (split from monolithic index). 11 source files, ~3240 source lines.
 
 ## RESOLUTION ORDER
 
@@ -20,16 +20,16 @@ a source the projection omits is a source no stage can produce.
 | File             | Lines | Purpose                                                                       |
 | ---------------- | ----: | ----------------------------------------------------------------------------- |
 | `index.ts`       |   153 | `resolve()` — orchestrates the chain, then the Standard Schema pass           |
-| `stages.ts`      |   263 | `runStages()` — one `SourceBinding` per stage, shared by both surfaces        |
+| `stages.ts`      |   265 | `runStages()` — one `SourceBinding` per stage, shared by both surfaces        |
 | `flags.ts`       |   433 | `resolveFlags()` — two-pass walk over each flag's source bindings             |
 | `args.ts`        |   299 | `resolveArgs()` — single-pass walk over each arg's bindings, then path checks |
-| `coerce.ts`      |  1175 | `coerceValue()` — unified raw value -> flag's declared kind                   |
-| `path-checks.ts` |   134 | `validatePathChecks()` — shared `flag.path()` / `arg.path()` filesystem pass  |
+| `coerce.ts`      |  1206 | `coerceValue()` — unified raw value -> flag's declared kind                   |
+| `path-checks.ts` |   136 | `validatePathChecks()` — shared `flag.path()` / `arg.path()` filesystem pass  |
 | `redaction.ts`   |    29 | `echoesValue()` / `REDACTED` — the one rule for value text in diagnostics     |
 | `config.ts`      |    26 | `resolveConfigPath()` — dotted path lookup in config object                   |
 | `errors.ts`      |   226 | Error aggregation + `throwAggregatedErrors()`                                 |
 | `contracts.ts`   |   182 | `ResolveOptions`, `ResolutionProvenanceRecord`, `resolverContract`            |
-| `standard.ts`    |   283 | Standard Schema v1 validation pass over resolved values                       |
+| `standard.ts`    |   284 | Standard Schema v1 validation pass over resolved values                       |
 
 ## KEY FUNCTIONS
 
@@ -177,7 +177,7 @@ rather than naming a first allowed kind there is none of. This mirrors the compi
 
 ## GOTCHAS
 
-- Split from ~940-line monolithic index — `coerce.ts` (1177 lines) is the largest piece
+- Split from ~940-line monolithic index — `coerce.ts` (1206 lines) is the largest piece
 - `ResolveOptions` injects everything: env, config, prompter, answers — never touches `process`
 - Imports `schema/prompt.ts` directly (not through barrel) — circular dep avoidance
 - `DeprecationWarning` structs collected during resolution for deprecated flag/arg usage

--- a/src/core/resolve/AGENTS.md
+++ b/src/core/resolve/AGENTS.md
@@ -21,14 +21,15 @@ a source the projection omits is a source no stage can produce.
 | ---------------- | ----: | ----------------------------------------------------------------------------- |
 | `index.ts`       |   153 | `resolve()` — orchestrates the chain, then the Standard Schema pass           |
 | `stages.ts`      |   263 | `runStages()` — one `SourceBinding` per stage, shared by both surfaces        |
-| `flags.ts`       |   386 | `resolveFlags()` — two-pass walk over each flag's source bindings             |
-| `args.ts`        |   276 | `resolveArgs()` — single-pass walk over each arg's bindings, then path checks |
-| `coerce.ts`      |  1191 | `coerceValue()` — unified raw value -> flag's declared kind                   |
-| `path-checks.ts` |   127 | `validatePathChecks()` — shared `flag.path()` / `arg.path()` filesystem pass  |
+| `flags.ts`       |   433 | `resolveFlags()` — two-pass walk over each flag's source bindings             |
+| `args.ts`        |   299 | `resolveArgs()` — single-pass walk over each arg's bindings, then path checks |
+| `coerce.ts`      |  1175 | `coerceValue()` — unified raw value -> flag's declared kind                   |
+| `path-checks.ts` |   134 | `validatePathChecks()` — shared `flag.path()` / `arg.path()` filesystem pass  |
+| `redaction.ts`   |    29 | `echoesValue()` / `REDACTED` — the one rule for value text in diagnostics     |
 | `config.ts`      |    26 | `resolveConfigPath()` — dotted path lookup in config object                   |
 | `errors.ts`      |   226 | Error aggregation + `throwAggregatedErrors()`                                 |
 | `contracts.ts`   |   182 | `ResolveOptions`, `ResolutionProvenanceRecord`, `resolverContract`            |
-| `standard.ts`    |   297 | Standard Schema v1 validation pass over resolved values                       |
+| `standard.ts`    |   283 | Standard Schema v1 validation pass over resolved values                       |
 
 ## KEY FUNCTIONS
 
@@ -39,10 +40,14 @@ a source the projection omits is a source no stage can produce.
 | `resolveFlags()`                    | `flags.ts`       | All flags: the shared stage walk, in two passes                     |
 | `resolveArgs()`                     | `args.ts`        | All args: the shared stage walk, then path checks                   |
 | `coerceValue()`                     | `coerce.ts`      | Unified raw value -> flag's declared kind (stdin/env/config/prompt) |
-| `coerceValueSchema()`               | `coerce.ts`      | Runs `decodeValue()` and names the subject on failure               |
+| `coerceValueSchema()`               | `coerce.ts`      | Runs `decodeValue()` and names the flag on failure                  |
+| `argValueCoercionError()`           | `coerce.ts`      | Words the same `ValueFailure` for the positional surface            |
 | `resolveConfigPath()`               | `config.ts`      | Dotted path lookup in config object                                 |
 | `validatePromptFlagCompatibility()` | `flags.ts`       | Prompt kind ↔ flag kind gate (before prompter invocation)           |
+| `argPromptCompatibility()`          | `args.ts`        | The same gate read through the arg's value and cardinality axes     |
+| `promptCompatibilityError()`        | `flags.ts`       | Words that gate's failure for whichever surface declared the prompt |
 | `validatePathChecks()`              | `path-checks.ts` | Post-resolution filesystem pass, flags and args alike               |
+| `echoesValue()`                     | `redaction.ts`   | Whether a recorded provenance permits quoting the value             |
 
 ## TWO-PASS ARCHITECTURE
 
@@ -73,6 +78,12 @@ quoting the token the user typed, which is already on their screen. `sourceDetai
 `source` on every coercion failure, which is what tells `errors.ts` a stage produced a value, as
 against a required input that merely declares an env var.
 
+`redaction.ts` owns the rule for the passes that run after coercion, where the raw source is gone
+and only the recorded `ResolutionProvenance` says where a value came from. `echoesValue(provenance)`
+is true for `{ stage: 'cli' }` alone, so an explicit `-` (`{ stage: 'cli', via: 'stdin' }`) and a
+declared default both redact. `standard.ts` and `path-checks.ts` read it; `coerce.ts` takes the
+`REDACTED` constant from the same module so one spelling reaches every surface.
+
 Returns `CoerceResult` (`{ ok: true; value } | { ok: false; error: ValidationError }`).
 
 What a value _means_ is not decided here. `coerceValue()` projects the flag through
@@ -96,7 +107,9 @@ it lifts to a single `aggregated` occurrence and reaches the resolved value unto
 Each spliced occurrence keeps the source it came from, `{ kind: 'cli' }` for a typed token and
 `{ kind: 'stdin' }` for one the buffer supplied. `AggregationErrors` takes that source, so a
 duplicate-key message names `from stdin` only for a key the pipe carried and names nothing for a key
-the user typed. `foldEntries()` reports the index of the repeating pair, which is how the source is
+the user typed. The same source decides how the key is quoted: `duplicateKeyReport()` prints it for
+a typed token and `'<redacted>'` for every other source, since a key is half of a `KEY=VALUE` pair
+and therefore value text. `foldEntries()` reports the index of the repeating pair, which is how the source is
 found without re-parsing. A `-` occurrence with no buffer is `dash-without-stdin`: a `MISSING_STDIN`
 error when it sits beside typed occurrences, and absence when every occurrence is `-`, which keeps
 the later stages reachable. A scalar `-` takes the second branch on its own, which is why a bare
@@ -136,9 +149,13 @@ once.
 | `resolve-redaction.test.ts`       | Redaction per source, argv literal, `MISSING_STDIN`          |
 | `contracts.test.ts`               | Contract verification                                        |
 
-## PROMPT — FLAG KIND COMPATIBILITY
+## PROMPT — INPUT KIND COMPATIBILITY
 
-`COMPATIBLE_PROMPT_KINDS` in `flags.ts` maps each `FlagKind` to allowed `PromptKind[]`:
+`COMPATIBLE_PROMPT_KINDS` in `flags.ts` maps each `FlagKind` to allowed `PromptKind[]`. Every
+`ArgKind` is also a `FlagKind`, so `argPromptCompatibility()` in `args.ts` reads the same map,
+through the cardinality: an arg whose `argCardinality()` is `many` takes the `array` row, since a
+variadic positional and a `flag.array()` aggregate the same way, and names itself `variadic <kind>`
+in the diagnostic. Every other arg takes its kind's row:
 
 | Flag kind | Allowed prompt kinds                      |
 | --------- | ----------------------------------------- |
@@ -152,12 +169,15 @@ once.
 | custom    | input, select, confirm, multiselect (all) |
 
 `validatePromptFlagCompatibility()` checks this map before `prompter.promptOne()` runs. Mismatches
-produce a `CONSTRAINT_VIOLATED` `ValidationError` with `details.flagKind`, `details.promptKind`, and
-an actionable `suggest`. This mirrors the compile-time `AllowedPromptConfig<C>` in `schema/flag.ts`.
+produce a `CONSTRAINT_VIOLATED` `ValidationError` with `details.flagKind` (`details.argKind` on the
+positional surface), `details.promptKind`, and an actionable `suggest`. Both surfaces word it through
+`promptCompatibilityError()`, which reports a kind with an empty allowed list as not promptable
+rather than naming a first allowed kind there is none of. This mirrors the compile-time
+`AllowedPromptConfig<C>` in `schema/flag.ts` and `AllowedArgPromptConfig<C>` in `schema/arg.ts`.
 
 ## GOTCHAS
 
-- Split from ~940-line monolithic index — `coerce.ts` (1179 lines) is the largest piece
+- Split from ~940-line monolithic index — `coerce.ts` (1177 lines) is the largest piece
 - `ResolveOptions` injects everything: env, config, prompter, answers — never touches `process`
 - Imports `schema/prompt.ts` directly (not through barrel) — circular dep avoidance
 - `DeprecationWarning` structs collected during resolution for deprecated flag/arg usage

--- a/src/core/resolve/args.ts
+++ b/src/core/resolve/args.ts
@@ -9,16 +9,17 @@ import { ValidationError } from '#internals/core/errors/index.ts';
 import type { PromptEngine } from '#internals/core/prompt/index.ts';
 import { resolvePromptConfig } from '#internals/core/prompt/index.ts';
 import { argCardinality, dedupe } from '#internals/core/schema/cardinality.ts';
-import type { ArgSchema, CommandArgEntry } from '#internals/core/schema/index.ts';
+import type { ArgSchema, CommandArgEntry, PromptKind } from '#internals/core/schema/index.ts';
 import type { PromptSourceBinding, SourceBinding } from '#internals/core/schema/source.ts';
 import { argCollectedNothing, sourceBindings } from '#internals/core/schema/source.ts';
 import { argValueSchema, valueEnumValues } from '#internals/core/schema/value.ts';
 import { coerceArgValue, finishCliArgValue } from './coerce.ts';
 import type { DeprecationWarning, ResolutionProvenance } from './contracts.ts';
 import { isNonEmpty, throwAggregatedErrors } from './errors.ts';
-import { COMPATIBLE_PROMPT_KINDS } from './flags.ts';
+import { COMPATIBLE_PROMPT_KINDS, promptCompatibilityError } from './flags.ts';
 import type { MkdirFn, StatFn } from './path-checks.ts';
 import { pathValuesOf, validatePathChecks } from './path-checks.ts';
+import { echoesValue } from './redaction.ts';
 import type { PromptOutcome, StageInput, StageState } from './stages.ts';
 import { readCliValue, runStages } from './stages.ts';
 
@@ -130,6 +131,9 @@ async function resolveArgs(
 			const checks = argValueSchema(schema).pathChecks;
 			if (checks === undefined) continue;
 
+			const echo = echoesValue(
+				Object.hasOwn(options.provenance, name) ? options.provenance[name] : undefined,
+			);
 			for (const value of pathValuesOf(
 				Object.hasOwn(resolved, name) ? resolved[name] : undefined,
 			)) {
@@ -139,6 +143,7 @@ async function resolveArgs(
 					checks,
 					options.stat,
 					options.mkdir,
+					echo,
 				);
 				if (violation !== undefined) {
 					errors.push(violation);
@@ -182,10 +187,31 @@ function stageInput(
 }
 
 /**
+ * The prompt kinds an arg accepts, read off its value and cardinality axes.
+ *
+ * An arg that collects several values takes the prompt a `flag.array()` takes,
+ * since the two aggregate the same way; every other arg takes what its kind
+ * takes on the flag surface.
+ *
+ * @param schema - The arg schema to read.
+ * @returns The compatible prompt kinds, and the word a diagnostic names the arg by.
+ */
+function argPromptCompatibility(schema: ArgSchema): {
+	readonly allowed: readonly PromptKind[];
+	readonly kindWord: string;
+} {
+	if (argCardinality(schema).kind === 'many') {
+		return { allowed: COMPATIBLE_PROMPT_KINDS.array, kindWord: `variadic ${schema.kind}` };
+	}
+	return { allowed: COMPATIBLE_PROMPT_KINDS[schema.kind], kindWord: schema.kind };
+}
+
+/**
  * Validate prompt/arg compatibility, run the prompt engine, and coerce the result.
  *
- * The compatibility table is the one flags use; every arg kind is also a flag
- * kind, so the two surfaces accept the same prompt kinds for the same value.
+ * The compatibility table is the one flags use, read through the value and
+ * cardinality axes, so the two surfaces accept the same prompt kinds for the
+ * same value.
  * @internal
  */
 async function resolveArgPromptValue(
@@ -195,23 +221,20 @@ async function resolveArgPromptValue(
 	prompter: PromptEngine,
 ): Promise<PromptOutcome> {
 	const promptConfig = binding.prompt;
-	const allowed = COMPATIBLE_PROMPT_KINDS[schema.kind];
+	const { allowed, kindWord } = argPromptCompatibility(schema);
 	if (!allowed.includes(promptConfig.kind)) {
-		const first = allowed[0];
 		return {
 			ok: false,
-			error: new ValidationError(
-				`Prompt kind '${promptConfig.kind}' is not compatible with ${schema.kind} argument <${argName}>. Use '${String(first)}' instead`,
+			error: promptCompatibilityError(
 				{
-					code: 'CONSTRAINT_VIOLATED',
-					details: {
-						arg: argName,
-						argKind: schema.kind,
-						promptKind: promptConfig.kind,
-						allowed,
-					},
-					suggest: `Change the prompt to { kind: '${String(first)}' } for <${argName}>`,
+					reference: `<${argName}>`,
+					singular: 'argument',
+					plural: 'arguments',
+					details: { arg: argName, argKind: schema.kind },
 				},
+				kindWord,
+				promptConfig.kind,
+				allowed,
 			),
 		};
 	}

--- a/src/core/resolve/coerce.ts
+++ b/src/core/resolve/coerce.ts
@@ -27,7 +27,6 @@ import type { ArgSchema, FlagSchema } from '#internals/core/schema/index.ts';
 import { describeNumberConstraintViolation } from '#internals/core/schema/number-constraints.ts';
 import type { DecodedSourceBinding, StdinSourceBinding } from '#internals/core/schema/source.ts';
 import { stdinReadsOnDash } from '#internals/core/schema/stdin.ts';
-import type { StringConstraintViolation } from '#internals/core/schema/string-constraints.ts';
 import {
 	describeStringConstraintViolation,
 	stringConstraintDetails,
@@ -50,6 +49,7 @@ import type {
 	FlagDiagnosticSource,
 	ResolutionDiagnosticSource,
 } from './contracts.ts';
+import { REDACTED } from './redaction.ts';
 
 type CoerceSource = FlagDiagnosticSource;
 
@@ -128,15 +128,6 @@ function coercionError(
 		suggest,
 	});
 }
-
-/**
- * The placeholder every non-literal-CLI source's value is reported as.
- *
- * Stdin, the environment, a config file, and a prompt answer all carry values a
- * user may consider secret, and a diagnostic is written to a terminal, a log,
- * and a CI transcript alike.
- */
-const REDACTED = '<redacted>';
 
 /**
  * Which source a binding's diagnostics name.
@@ -280,6 +271,32 @@ function sourceClause(source: ResolutionDiagnosticSource): string {
 /** The identification fields a source contributes to an aggregation error. */
 function aggregationSourceDetails(source: ResolutionDiagnosticSource): Record<string, unknown> {
 	return source.kind === 'cli' ? {} : sourceDetails(source);
+}
+
+/**
+ * How a duplicate key is quoted, and whether `details` carries it.
+ *
+ * A key is half of a `KEY=VALUE` pair, so it is value text from whatever source
+ * carried it. A token the user typed is quoted like every other argv value; a
+ * key that arrived from stdin, the environment, a config file, or a prompt takes
+ * the same redaction the pair itself takes when it fails to split.
+ *
+ * @param source - The source that carried the repeating pair.
+ * @param key - The key that repeated.
+ * @returns The quoted key for the message, and the detail fields it contributes.
+ */
+function duplicateKeyReport(
+	source: ResolutionDiagnosticSource,
+	key: string,
+): { readonly quoted: string; readonly details: Record<string, unknown> } {
+	return source.kind === 'cli'
+		? { quoted: `'${key}'`, details: { key } }
+		: { quoted: `'${REDACTED}'`, details: {} };
+}
+
+/** What a duplicate-key suggestion asks the caller to change. */
+function duplicateKeySubject(source: ResolutionDiagnosticSource, key: string): string {
+	return source.kind === 'cli' ? `'${key}'` : 'the repeated key';
 }
 
 /**
@@ -440,13 +457,13 @@ function flagCollectionErrors(flagName: string, source: CoerceSource): Collectio
 					`Provide valid JSON for --${flagName}`,
 				);
 			case 'json-shape':
-				return coercionError(
-					flagName,
-					source,
-					'TYPE_MISMATCH',
-					fault.expected,
-					`Invalid JSON value, expected an ${fault.expected}`,
-					`Provide a JSON ${fault.expected} for --${flagName}`,
+				return new ValidationError(
+					`Invalid JSON value ${sourceLabel(source)} for flag --${flagName}, expected an ${fault.expected}`,
+					{
+						code: 'TYPE_MISMATCH',
+						details: { flag: flagName, ...sourceDetails(source), expected: fault.expected },
+						suggest: `Provide a JSON ${fault.expected} for --${flagName}`,
+					},
 				);
 		}
 	};
@@ -477,12 +494,13 @@ function flagAggregationErrors(flagName: string): AggregationErrors {
 				},
 			);
 		}
+		const report = duplicateKeyReport(source, fault.key);
 		return new ValidationError(
-			`Duplicate key '${fault.key}' ${sourceClause(source)}for flag --${flagName}`,
+			`Duplicate key ${report.quoted} ${sourceClause(source)}for flag --${flagName}`,
 			{
 				code: 'CONSTRAINT_VIOLATED',
-				details: { flag: flagName, ...aggregationSourceDetails(source), key: fault.key },
-				suggest: `Set '${fault.key}' once for --${flagName}`,
+				details: { flag: flagName, ...aggregationSourceDetails(source), ...report.details },
+				suggest: `Set ${duplicateKeySubject(source, fault.key)} once for --${flagName}`,
 			},
 		);
 	};
@@ -494,11 +512,14 @@ function argCollectionErrors(argName: string, source: ArgStringSource): Collecti
 		switch (fault.kind) {
 			case 'shape':
 				return new ValidationError(
-					`Invalid value '${REDACTED}' ${argSourceLabel(source)} for argument <${argName}>`,
+					`Invalid ${fault.expected} value ${argSourceLabel(source)} for argument <${argName}>`,
 					{
 						code: 'TYPE_MISMATCH',
 						details: { arg: argName, ...argSourceDetails(source), expected: fault.expected },
-						suggest: `Provide values for <${argName}>`,
+						suggest:
+							fault.expected === 'object'
+								? `Use KEY=VALUE for <${argName}>`
+								: `Provide values for <${argName}>`,
 					},
 				);
 			case 'pair':
@@ -556,12 +577,13 @@ function argAggregationErrors(argName: string): AggregationErrors {
 				},
 			);
 		}
+		const report = duplicateKeyReport(source, fault.key);
 		return new ValidationError(
-			`Duplicate key '${fault.key}' ${sourceClause(source)}for argument <${argName}>`,
+			`Duplicate key ${report.quoted} ${sourceClause(source)}for argument <${argName}>`,
 			{
 				code: 'CONSTRAINT_VIOLATED',
-				details: { arg: argName, ...aggregationSourceDetails(source), key: fault.key },
-				suggest: `Set '${fault.key}' once for <${argName}>`,
+				details: { arg: argName, ...aggregationSourceDetails(source), ...report.details },
+				suggest: `Set ${duplicateKeySubject(source, fault.key)} once for <${argName}>`,
 			},
 		);
 	};
@@ -754,7 +776,7 @@ function argSourceDetails(source: ArgStringSource): Record<string, unknown> {
 function buildArgCoercionSuggest(
 	argName: string,
 	source: ArgStringSource,
-	expected: 'number' | 'string' | 'custom' | 'boolean',
+	expected: 'number' | 'string' | 'custom',
 ): string {
 	const subject = expected === 'custom' ? 'value' : expected;
 	return suggestBySource(source, {
@@ -768,143 +790,139 @@ function buildArgCoercionSuggest(
 	});
 }
 
+/** The spellings the boolean codec reads, named for the source that carried one. */
+function argBooleanSuggest(argName: string, source: ArgStringSource): string {
+	return suggestBySource(source, {
+		stdin: `Pipe true/false, 1/0, or yes/no to stdin for <${argName}>`,
+		env: (envVar) => `Set ${envVar} to true/false, 1/0, or yes/no`,
+		config: (configPath) => `Set ${configPath} to true or false in your config`,
+		prompt: `Answer yes or no for <${argName}>`,
+	});
+}
+
 /**
- * Rebuild the human-readable reason for a string-constraint failure from the
- * error's own details.
+ * Turn a value-layer failure into the positional surface's validation error.
  *
- * @param error - The coercion failure produced by {@link finalizeString}.
- * @returns The reason, or `undefined` when the failure was not a constraint
- *   violation.
+ * The failure states the reason, so this surface words its own diagnostic from
+ * it. Reading a reason back out of the message another surface wrote loses the
+ * part of it that follows a colon.
+ *
+ * @param argName - Name of the positional the value belongs to.
+ * @param source - The stage that carried the value.
+ * @param failure - What the value layer rejected.
+ * @returns The redacted error for this surface.
  */
-function stringConstraintReason(error: ValidationError): string | undefined {
-	const violation = toStringConstraintViolation(error);
-	return violation === undefined ? undefined : describeStringConstraintViolation(violation);
-}
-
-/** Narrow an error's details back into the violation {@link finalizeString} reported. */
-function toStringConstraintViolation(
-	error: ValidationError,
-): StringConstraintViolation | undefined {
-	if (error.code !== 'CONSTRAINT_VIOLATED') return undefined;
-	const constraint = error.details?.constraint;
-	if (constraint === 'nonEmpty') return { kind: 'nonEmpty' };
-	const bound = error.details?.bound;
-	if ((constraint === 'minLength' || constraint === 'maxLength') && typeof bound === 'number') {
-		return { kind: constraint, bound };
-	}
-	const pattern = error.details?.pattern;
-	if (constraint === 'pattern' && typeof pattern === 'string') {
-		return { kind: 'pattern', pattern };
-	}
-	return undefined;
-}
-
-function redactArgCoercionMessage(
+function argValueCoercionError(
 	argName: string,
 	source: ArgStringSource,
-	schema: ArgSchema,
-	error: ValidationError,
-): string {
-	switch (schema.kind) {
-		case 'number': {
-			const base = `Invalid number value '${REDACTED}' ${argSourceLabel(source)} for argument <${argName}>`;
-			// Only a constraint violation carries a schema-derived reason suffix
-			// (e.g. `: must be >= 0`), which is safe to keep. Any other failure
-			// (e.g. TYPE_MISMATCH) embeds the raw value in `error.message`, so
-			// extracting a trailing suffix there could leak user input.
-			if (error.code !== 'CONSTRAINT_VIOLATED') {
-				return base;
-			}
-			const match = /: ([^:]+)$/.exec(error.message);
-			const suffix = match?.[1];
-			return suffix !== undefined ? `${base}: ${suffix}` : base;
-		}
+	failure: ValueFailure,
+): ValidationError {
+	const subject = `${argSourceLabel(source)} for argument <${argName}>`;
+
+	switch (failure.kind) {
+		case 'type':
+			return argTypeCoercionError(argName, source, failure.expected);
+
 		case 'enum': {
-			const allowed = Array.isArray(error.details?.allowed)
-				? error.details.allowed.filter((value): value is string => typeof value === 'string')
-				: [];
-			return `Invalid value '${REDACTED}' ${argSourceLabel(source)} for argument <${argName}>. Allowed: ${allowed.join(', ')}`;
+			const allowed = failure.enumValues ?? [];
+			const allowedList = allowed.join(', ');
+			return new ValidationError(
+				`Invalid value '${REDACTED}' ${subject}. Allowed: ${allowedList}`,
+				{
+					code: 'INVALID_ENUM',
+					details: { arg: argName, ...argSourceDetails(source), allowed },
+					suggest: suggestBySource(source, {
+						stdin: `Provide one of: ${allowedList}`,
+						env: (envVar) => `Set ${envVar} to one of: ${allowedList}`,
+						config: (configPath) => `Set ${configPath} to one of: ${allowedList}`,
+						prompt: `Provide one of: ${allowedList}`,
+					}),
+				},
+			);
 		}
-		case 'custom': {
-			const match = /: ([^:]+)$/.exec(error.message);
-			const suffix = match?.[1];
-			return suffix !== undefined
-				? `Invalid value '${REDACTED}' ${argSourceLabel(source)} for argument <${argName}>: ${suffix}`
-				: `Invalid value '${REDACTED}' ${argSourceLabel(source)} for argument <${argName}>`;
-		}
-		case 'string':
-		case 'boolean':
-		case 'keyValue': {
-			const base = `Invalid value '${REDACTED}' ${argSourceLabel(source)} for argument <${argName}>`;
-			const reason = schema.kind === 'string' ? stringConstraintReason(error) : undefined;
-			return reason === undefined ? base : `${base}: ${reason}`;
+
+		case 'string-constraint':
+			return new ValidationError(
+				`Invalid value '${REDACTED}' ${subject}: ${describeStringConstraintViolation(failure.violation)}`,
+				{
+					code: 'CONSTRAINT_VIOLATED',
+					details: {
+						arg: argName,
+						...argSourceDetails(source),
+						expected: 'string',
+						...stringConstraintDetails(failure.violation),
+					},
+					suggest: buildArgCoercionSuggest(argName, source, 'string'),
+				},
+			);
+
+		case 'number-constraint':
+			return new ValidationError(
+				`Invalid number value '${REDACTED}' ${subject}: ${describeNumberConstraintViolation(failure.violation)}`,
+				{
+					code: 'CONSTRAINT_VIOLATED',
+					details: {
+						arg: argName,
+						...argSourceDetails(source),
+						expected: 'number',
+						constraint: failure.violation.kind,
+						...('bound' in failure.violation ? { bound: failure.violation.bound } : {}),
+					},
+					suggest: buildArgCoercionSuggest(argName, source, 'number'),
+				},
+			);
+
+		case 'thrown': {
+			const message =
+				failure.error instanceof Error ? failure.error.message : String(failure.error);
+			const sourceRef = suggestBySource(source, {
+				stdin: 'stdin value',
+				env: (envVar) => `env ${envVar}`,
+				config: (configPath) => `config ${configPath}`,
+				prompt: 'prompt value',
+			});
+			return new ValidationError(
+				`Failed to parse ${sourceRef} for argument <${argName}>: ${message}`,
+				{
+					code: 'TYPE_MISMATCH',
+					details: { arg: argName, ...argSourceDetails(source), expected: 'custom' },
+					suggest: buildArgCoercionSuggest(argName, source, 'custom'),
+				},
+			);
 		}
 	}
 }
 
-function redactArgCoercionDetails(
+/** Build the error for a raw value the codec could not read as its primitive. */
+function argTypeCoercionError(
 	argName: string,
 	source: ArgStringSource,
-	schema: ArgSchema,
-	error: ValidationError,
-): Readonly<Record<string, unknown>> {
-	const stringViolation = schema.kind === 'string' ? toStringConstraintViolation(error) : undefined;
+	expected: ValueTypeName,
+): ValidationError {
+	const subject = `${argSourceLabel(source)} for argument <${argName}>`;
+	const details = { arg: argName, ...argSourceDetails(source), expected };
 
-	return {
-		arg: argName,
-		...argSourceDetails(source),
-		...(schema.kind === 'number' || schema.kind === 'custom' || schema.kind === 'boolean'
-			? { expected: schema.kind }
-			: {}),
-		...(stringViolation !== undefined
-			? { expected: 'string', ...stringConstraintDetails(stringViolation) }
-			: {}),
-		...(schema.kind === 'number' && typeof error.details?.constraint === 'string'
-			? { constraint: error.details.constraint }
-			: {}),
-		...(schema.kind === 'number' && typeof error.details?.bound === 'number'
-			? { bound: error.details.bound }
-			: {}),
-		...(schema.kind === 'enum' && Array.isArray(error.details?.allowed)
-			? {
-					allowed: error.details.allowed.filter(
-						(value): value is string => typeof value === 'string',
-					),
-				}
-			: {}),
-	};
-}
-
-function redactArgCoercionSuggest(
-	argName: string,
-	source: ArgStringSource,
-	schema: ArgSchema,
-	error: ValidationError,
-): string | undefined {
-	if (schema.kind === 'number' || schema.kind === 'custom' || schema.kind === 'boolean') {
-		return buildArgCoercionSuggest(argName, source, schema.kind);
-	}
-
-	if (schema.kind === 'string') {
-		return toStringConstraintViolation(error) === undefined
-			? undefined
-			: buildArgCoercionSuggest(argName, source, 'string');
-	}
-
-	if (schema.kind === 'enum') {
-		const allowed = Array.isArray(error.details?.allowed)
-			? error.details.allowed.filter((value): value is string => typeof value === 'string')
-			: [];
-		const allowedList = allowed.join(', ');
-		return suggestBySource(source, {
-			stdin: `Provide one of: ${allowedList}`,
-			env: (envVar) => `Set ${envVar} to one of: ${allowedList}`,
-			config: (configPath) => `Set ${configPath} to one of: ${allowedList}`,
-			prompt: `Provide one of: ${allowedList}`,
+	if (expected === 'string') {
+		return new ValidationError(`Invalid string value ${subject}`, {
+			code: 'TYPE_MISMATCH',
+			details,
+			suggest: buildArgCoercionSuggest(argName, source, 'string'),
 		});
 	}
 
-	return undefined;
+	if (expected === 'number') {
+		return new ValidationError(`Invalid number value '${REDACTED}' ${subject}`, {
+			code: 'TYPE_MISMATCH',
+			details,
+			suggest: buildArgCoercionSuggest(argName, source, 'number'),
+		});
+	}
+
+	return new ValidationError(`Invalid boolean value '${REDACTED}' ${subject}`, {
+		code: 'TYPE_MISMATCH',
+		details,
+		suggest: argBooleanSuggest(argName, source),
+	});
 }
 
 /**
@@ -950,6 +968,9 @@ function coerceArgValue(
 /**
  * Decode one arg value through the value layer, redacting the raw value in
  * diagnostics.
+ *
+ * An entries arg projects onto the value of one entry, so the failure a decode
+ * reports already describes the element rather than the record.
  */
 function coerceArgElement(
 	argName: string,
@@ -957,47 +978,10 @@ function coerceArgElement(
 	raw: unknown,
 	schema: ArgSchema,
 ): CoerceResult {
-	const coerced = coerceValueSchema(argName, source, raw, argValueSchema(schema));
-	if (coerced.ok) {
-		return coerced;
-	}
-
-	const element = redactionSubject(schema);
-	const suggest = redactArgCoercionSuggest(argName, source, element, coerced.error);
-	const options =
-		suggest === undefined
-			? {
-					code: coerced.error.code,
-					details: redactArgCoercionDetails(argName, source, element, coerced.error),
-				}
-			: {
-					code: coerced.error.code,
-					details: redactArgCoercionDetails(argName, source, element, coerced.error),
-					suggest,
-				};
-
-	return {
-		ok: false,
-		error: new ValidationError(
-			redactArgCoercionMessage(argName, source, element, coerced.error),
-			options,
-		),
-	};
-}
-
-/**
- * The schema whose kind words a redacted failure.
- *
- * An entries arg fails on one entry value, so its element schema is what the
- * message and details describe.
- *
- * @param schema - The arg being resolved.
- * @returns The element schema for an entries arg, or the schema itself.
- */
-function redactionSubject(schema: ArgSchema): ArgSchema {
-	return schema.kind === 'keyValue' && schema.elementSchema !== undefined
-		? schema.elementSchema
-		: schema;
+	const decoded = decodeValue(argValueSchema(schema), raw, valueInputOf(source));
+	return decoded.ok
+		? { ok: true, value: decoded.value }
+		: { ok: false, error: argValueCoercionError(argName, source, decoded.failure) };
 }
 
 // --- CLI occurrence finishing

--- a/src/core/resolve/flags.ts
+++ b/src/core/resolve/flags.ts
@@ -28,6 +28,7 @@ import type { DeprecationWarning, ResolutionProvenance } from './contracts.ts';
 import { isNonEmpty, throwAggregatedErrors } from './errors.ts';
 import type { MkdirFn, StatFn } from './path-checks.ts';
 import { pathValuesOf, validatePathChecks } from './path-checks.ts';
+import { echoesValue } from './redaction.ts';
 import type { PromptOutcome, StageInput, StageOutcome, StageState } from './stages.ts';
 import { readCliValue, runStages } from './stages.ts';
 
@@ -159,6 +160,9 @@ async function resolveFlags(
 
 		if (checks === undefined || options.stat === undefined) continue;
 
+		const echo = echoesValue(
+			Object.hasOwn(options.provenance, name) ? options.provenance[name] : undefined,
+		);
 		for (const path of pathValuesOf(Object.hasOwn(resolved, name) ? resolved[name] : undefined)) {
 			const violation = await validatePathChecks(
 				{ kind: 'flag', name },
@@ -166,6 +170,7 @@ async function resolveFlags(
 				checks,
 				options.stat,
 				options.mkdir,
+				echo,
 			);
 			if (violation !== undefined) {
 				errors.push(violation);
@@ -264,6 +269,57 @@ const COMPATIBLE_PROMPT_KINDS: Record<FlagKind, readonly PromptKind[]> = {
 	keyValue: [],
 };
 
+/** How one surface spells the input a prompt-compatibility failure names. */
+interface PromptSubject {
+	/** How the input is written on the command line: `--out` or `<out>`. */
+	readonly reference: string;
+	/** What a diagnostic calls one of them: `flag` or `argument`. */
+	readonly singular: string;
+	/** What a diagnostic calls several: `flags` or `arguments`. */
+	readonly plural: string;
+	/** Identification fields the surface contributes to `details`. */
+	readonly details: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Word an incompatible prompt config for the surface that declared it.
+ *
+ * A kind with no compatible prompt at all is a different diagnostic from one
+ * whose prompt is merely the wrong sort, so the empty list gets its own message
+ * on both surfaces.
+ *
+ * @param subject - How the surface spells the input.
+ * @param kind - The input's declared kind.
+ * @param promptKind - The prompt kind the config asked for.
+ * @param allowed - The prompt kinds that kind accepts.
+ * @returns The error to report.
+ * @internal
+ */
+function promptCompatibilityError(
+	subject: PromptSubject,
+	kind: string,
+	promptKind: PromptKind,
+	allowed: readonly PromptKind[],
+): ValidationError {
+	const details = { ...subject.details, promptKind, allowed };
+	const headline = `Prompt kind '${promptKind}' is not compatible with ${kind} ${subject.singular} ${subject.reference}.`;
+	const first = allowed[0];
+
+	if (first === undefined) {
+		return new ValidationError(`${headline} ${kind} ${subject.plural} are not promptable`, {
+			code: 'CONSTRAINT_VIOLATED',
+			details,
+			suggest: `Remove the prompt config for ${subject.reference}`,
+		});
+	}
+
+	return new ValidationError(`${headline} Use '${first}' instead`, {
+		code: 'CONSTRAINT_VIOLATED',
+		details,
+		suggest: `Change the prompt to { kind: '${first}' } for ${subject.reference}`,
+	});
+}
+
 /**
  * Check whether a prompt kind is compatible with the flag's declared kind.
  *
@@ -279,25 +335,16 @@ function validatePromptFlagCompatibility(
 	const allowed = COMPATIBLE_PROMPT_KINDS[flagKind];
 	if (allowed.includes(promptKind)) return undefined;
 
-	const first = allowed[0];
-	if (first === undefined) {
-		return new ValidationError(
-			`Prompt kind '${promptKind}' is not compatible with ${flagKind} flag --${flagName}. ${flagKind} flags are not promptable`,
-			{
-				code: 'CONSTRAINT_VIOLATED',
-				details: { flag: flagName, flagKind, promptKind, allowed },
-				suggest: `Remove the prompt config for --${flagName}`,
-			},
-		);
-	}
-
-	return new ValidationError(
-		`Prompt kind '${promptKind}' is not compatible with ${flagKind} flag --${flagName}. Use '${first}' instead`,
+	return promptCompatibilityError(
 		{
-			code: 'CONSTRAINT_VIOLATED',
-			details: { flag: flagName, flagKind, promptKind, allowed },
-			suggest: `Change the prompt to { kind: '${first}' } for --${flagName}`,
+			reference: `--${flagName}`,
+			singular: 'flag',
+			plural: 'flags',
+			details: { flag: flagName, flagKind },
 		},
+		flagKind,
+		promptKind,
+		allowed,
 	);
 }
 
@@ -383,4 +430,4 @@ function buildRequiredFlagSuggest(name: string, schema: FlagSchema): string {
 }
 
 export type { FlagResolutionOptions };
-export { COMPATIBLE_PROMPT_KINDS, resolveFlags };
+export { COMPATIBLE_PROMPT_KINDS, promptCompatibilityError, resolveFlags };

--- a/src/core/resolve/path-checks.ts
+++ b/src/core/resolve/path-checks.ts
@@ -12,6 +12,7 @@
 
 import { ValidationError } from '#internals/core/errors/index.ts';
 import type { PathChecks } from '#internals/core/schema/index.ts';
+import { REDACTED } from './redaction.ts';
 
 /**
  * Filesystem probe injected by the caller for path checks.
@@ -51,6 +52,9 @@ function subjectDetails(subject: PathCheckSubject): Readonly<Record<string, stri
  * @param checks - Expectations declared by `flag.path()` / `arg.path()`.
  * @param stat - Filesystem probe.
  * @param mkdir - Recursive directory creation, when the caller supplies one.
+ * @param echo - Whether the source permits quoting the path, per
+ *   `redaction.ts`. A path from stdin, env, config, prompt, or a default is
+ *   quoted as `<redacted>` and omitted from `details`.
  * @returns `undefined` when the path satisfies the checks, or a
  *   {@link ValidationError} with code `'CONSTRAINT_VIOLATED'` otherwise.
  */
@@ -60,10 +64,13 @@ async function validatePathChecks(
 	checks: PathChecks,
 	stat: StatFn,
 	mkdir: MkdirFn | undefined,
+	echo: boolean,
 ): Promise<ValidationError | undefined> {
 	const label = subjectLabel(subject);
 	const reference = subjectReference(subject);
 	const details = subjectDetails(subject);
+	const quoted = echo ? value : REDACTED;
+	const reported = echo ? { value } : {};
 
 	const found = await stat(value);
 	if (found === null) {
@@ -73,30 +80,30 @@ async function validatePathChecks(
 				return undefined;
 			} catch (error) {
 				return new ValidationError(
-					`Failed to create directory '${value}' for ${label}: ${
+					`Failed to create directory '${quoted}' for ${label}: ${
 						error instanceof Error ? error.message : String(error)
 					}`,
 					{
 						code: 'CONSTRAINT_VIOLATED',
-						details: { ...details, value, constraint: 'create' },
+						details: { ...details, ...reported, constraint: 'create' },
 						suggest: `Provide a creatable or existing directory path for ${reference}`,
 					},
 				);
 			}
 		}
 		if (!checks.mustExist) return undefined;
-		return new ValidationError(`Path '${value}' for ${label} does not exist`, {
+		return new ValidationError(`Path '${quoted}' for ${label} does not exist`, {
 			code: 'CONSTRAINT_VIOLATED',
-			details: { ...details, value, constraint: 'mustExist' },
+			details: { ...details, ...reported, constraint: 'mustExist' },
 			suggest: `Provide an existing path for ${reference}`,
 		});
 	}
 	if (checks.type !== undefined && found !== checks.type) {
 		return new ValidationError(
-			`Path '${value}' for ${label} is a ${found}, expected a ${checks.type}`,
+			`Path '${quoted}' for ${label} is a ${found}, expected a ${checks.type}`,
 			{
 				code: 'CONSTRAINT_VIOLATED',
-				details: { ...details, value, constraint: 'pathType', expected: checks.type },
+				details: { ...details, ...reported, constraint: 'pathType', expected: checks.type },
 				suggest: `Provide a ${checks.type} path for ${reference}`,
 			},
 		);

--- a/src/core/resolve/redaction.ts
+++ b/src/core/resolve/redaction.ts
@@ -1,0 +1,29 @@
+/**
+ * The one rule every resolution diagnostic applies to the value it reports on.
+ *
+ * A token typed on the command line is already on the user's screen, so a
+ * message quotes it and `details.value` carries it. Every other stage, an
+ * explicit `-` included, delivers bytes a user may consider secret, so the
+ * message quotes {@link REDACTED} and `details` omits the value. Coercion
+ * failures, Standard Schema issues, and filesystem checks all read this.
+ *
+ * @module dreamcli/core/resolve/redaction
+ * @internal
+ */
+
+import type { ResolutionProvenance } from '#internals/core/schema/provenance.ts';
+
+/** What a diagnostic prints in place of a value it may not echo. */
+const REDACTED = '<redacted>';
+
+/**
+ * Whether a diagnostic may quote the value a stage produced.
+ *
+ * @param source - Where the value came from, or `undefined` when unrecorded.
+ * @returns `true` when the value is safe to echo.
+ */
+function echoesValue(source: ResolutionProvenance | undefined): boolean {
+	return source !== undefined && source.stage === 'cli' && !('via' in source);
+}
+
+export { echoesValue, REDACTED };

--- a/src/core/resolve/resolve-arg-tail.test.ts
+++ b/src/core/resolve/resolve-arg-tail.test.ts
@@ -219,7 +219,7 @@ describe('a duplicate key names the source that carried it', () => {
 					},
 				),
 			),
-		).toBe("Duplicate key 'A' from stdin for flag --value");
+		).toBe("Duplicate key '<redacted>' from stdin for flag --value");
 	});
 
 	it('names stdin for a spliced key in a positional tail', async () => {
@@ -229,7 +229,7 @@ describe('a duplicate key names the source that carried it', () => {
 					stdinData: 'A=2\n',
 				}),
 			),
-		).toBe("Duplicate key 'A' from stdin for argument <files>");
+		).toBe("Duplicate key '<redacted>' from stdin for argument <files>");
 	});
 
 	it('names the typed token when it is the one that repeats', async () => {
@@ -253,6 +253,6 @@ describe('a duplicate key names the source that carried it', () => {
 					env: { VARS: 'A=1,A=2' },
 				}),
 			),
-		).toBe("Duplicate key 'A' from env VARS for flag --value");
+		).toBe("Duplicate key '<redacted>' from env VARS for flag --value");
 	});
 });

--- a/src/core/resolve/resolve-cardinality.test.ts
+++ b/src/core/resolve/resolve-cardinality.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import type { ValidationError } from '#internals/core/errors/index.ts';
 import { isValidationError } from '#internals/core/errors/index.ts';
 import { parse } from '#internals/core/parse/index.ts';
 import { createTestPrompter } from '#internals/core/prompt/index.ts';
@@ -181,6 +182,27 @@ describe('many, config, prompt, and defaults', () => {
 		).toEqual([80, 443]);
 	});
 
+	it('takes a native config array past the split policy, delimiters and all', async () => {
+		expect(
+			await resolveFlag(flag.array(flag.string()).config('deploy.tags').split({ env: ',' }), [], {
+				config: { deploy: { tags: ['a,b', 'c'] } },
+			}),
+		).toEqual(['a,b', 'c']);
+	});
+
+	it('takes a native config array past a JSON policy too', async () => {
+		expect(
+			await resolveFlag(
+				flag
+					.array(flag.string())
+					.config('deploy.tags')
+					.split({ env: { format: 'json' } }),
+				[],
+				{ config: { deploy: { tags: ['[not json]'] } } },
+			),
+		).toEqual(['[not json]']);
+	});
+
 	it('splits a config string under the env policy', async () => {
 		expect(
 			await resolveFlag(flag.array(flag.string()).config('deploy.tags'), [], {
@@ -280,6 +302,33 @@ describe('entries, every source', () => {
 		expect(await resolveArg(arg.keyValue(), ['A=1'])).toEqual({ A: '1' });
 	});
 
+	it('splits one CLI token on the separator a non-variadic arg declares', async () => {
+		expect(await resolveArg(arg.keyValue().separator(','), ['A=1,B=2'])).toEqual({
+			A: '1',
+			B: '2',
+		});
+		expect(await resolveArg(arg.keyValue().split({ cli: ';' }), ['A=1;B=2'])).toEqual({
+			A: '1',
+			B: '2',
+		});
+	});
+
+	it('splits a CLI token the same way whichever surface and arity declares it', async () => {
+		const expected = { A: '1', B: '2' };
+
+		expect(await resolveFlag(flag.keyValue().separator(','), ['--value', 'A=1,B=2'])).toEqual(
+			expected,
+		);
+		expect(await resolveArg(arg.keyValue().separator(','), ['A=1,B=2'])).toEqual(expected);
+		expect(await resolveArg(arg.keyValue().variadic().separator(','), ['A=1,B=2'])).toEqual(
+			expected,
+		);
+	});
+
+	it('leaves a CLI token whole when the arg declares no separator', async () => {
+		expect(await resolveArg(arg.keyValue(), ['A=1,B=2'])).toEqual({ A: '1,B=2' });
+	});
+
 	it('splits env pairs on commas and at the first =', async () => {
 		expect(
 			await resolveFlag(flag.keyValue().env('VARS'), [], { env: { VARS: 'A=1,B=b=c' } }),
@@ -316,6 +365,14 @@ describe('entries, every source', () => {
 			}),
 		);
 		expect(message).toContain('Invalid object value');
+	});
+
+	it('takes a native config object past the split policy, separators and all', async () => {
+		expect(
+			await resolveFlag(flag.keyValue().config('deploy.vars').split({ env: ',' }), [], {
+				config: { deploy: { vars: { A: '1,2', B: 'x=y' } } },
+			}),
+		).toEqual({ A: '1,2', B: 'x=y' });
 	});
 
 	it('reads piped lines as pairs', async () => {
@@ -361,7 +418,7 @@ describe('entries, duplicate keys', () => {
 				env: { VARS: 'A=1,A=2' },
 			}),
 		);
-		expect(message).toContain("Duplicate key 'A'");
+		expect(message).toBe("Duplicate key '<redacted>' from env VARS for flag --value");
 	});
 });
 
@@ -423,7 +480,7 @@ describe('stdin splices into occurrence order', () => {
 				{ stdinData: 'A=2\n' },
 			),
 		);
-		expect(message).toContain("Duplicate key 'A'");
+		expect(message).toBe("Duplicate key '<redacted>' from stdin for flag --value");
 	});
 
 	it('decodes each spliced element through the element value axis', async () => {
@@ -821,6 +878,87 @@ describe('two `-` occurrences on one collection', () => {
 					},
 				),
 			),
-		).toMatch(/Duplicate key 'A'/);
+		).toBe("Duplicate key '<redacted>' from stdin for flag --value");
+	});
+});
+
+// === the shape a source value must have to fill a collection
+
+describe('a source value of the wrong shape names the shape the collection wants', () => {
+	/** Run a resolution expected to fail, returning the failure it reported. */
+	async function failure(run: () => Promise<unknown>): Promise<ValidationError> {
+		try {
+			await run();
+		} catch (error) {
+			if (isValidationError(error)) return error;
+			throw error;
+		}
+		throw new Error('expected resolution to fail');
+	}
+
+	it('asks a key-value flag for an object', async () => {
+		for (const raw of [5, [1, 2], true]) {
+			const error = await failure(() =>
+				resolveFlag(flag.keyValue().config('deploy.value'), [], {
+					config: { deploy: { value: raw } },
+				}),
+			);
+			expect(error.message).toBe('Invalid object value from config deploy.value for flag --value');
+			expect(error.details).toEqual({
+				flag: 'value',
+				source: 'config',
+				configPath: 'deploy.value',
+				expected: 'object',
+			});
+			expect(error.suggest).toBe('Set deploy.value to an object in your config');
+		}
+	});
+
+	it('asks a key-value arg for an object', async () => {
+		const error = await failure(() =>
+			resolveArg(arg.keyValue().config('deploy.value'), [], { config: { deploy: { value: 5 } } }),
+		);
+		expect(error.message).toBe(
+			'Invalid object value from config deploy.value for argument <value>',
+		);
+		expect(error.details).toEqual({
+			arg: 'value',
+			source: 'config',
+			configPath: 'deploy.value',
+			expected: 'object',
+		});
+		expect(error.suggest).toBe('Use KEY=VALUE for <value>');
+	});
+
+	it('still asks a list flag for an array', async () => {
+		const error = await failure(() =>
+			resolveFlag(flag.array(flag.string()).config('deploy.value'), [], {
+				config: { deploy: { value: 5 } },
+			}),
+		);
+		expect(error.message).toBe('Invalid array value from config deploy.value for flag --value');
+		expect(error.details).toEqual({
+			flag: 'value',
+			source: 'config',
+			configPath: 'deploy.value',
+			expected: 'array',
+		});
+		expect(error.suggest).toBe('Set deploy.value to an array in your config');
+	});
+
+	it('still asks a list arg for an array', async () => {
+		const error = await failure(() =>
+			resolveArg(arg.string().variadic().config('deploy.value'), [], {
+				config: { deploy: { value: 5 } },
+			}),
+		);
+		expect(error.message).toBe('Invalid array value from config deploy.value for argument <value>');
+		expect(error.details).toEqual({
+			arg: 'value',
+			source: 'config',
+			configPath: 'deploy.value',
+			expected: 'array',
+		});
+		expect(error.suggest).toBe('Provide values for <value>');
 	});
 });

--- a/src/core/resolve/resolve-config.test.ts
+++ b/src/core/resolve/resolve-config.test.ts
@@ -107,6 +107,54 @@ describe('resolve', () => {
 			expect(result.flags).toEqual({});
 		});
 
+		it('reads a config path named after an Object.prototype member', async () => {
+			const schema = makeSchema({
+				flags: {
+					own: createFlagSchema('string', { configPath: 'toString' }),
+					nested: createFlagSchema('string', { configPath: 'constructor.valueOf' }),
+				},
+			});
+			const options: ResolveOptions = {
+				config: JSON.parse('{"toString":"own","constructor":{"valueOf":"nested"}}'),
+			};
+
+			const result = await resolve(schema, makeParsed(), options);
+			expect(result.flags).toEqual({ own: 'own', nested: 'nested' });
+			expect(result.provenance.flags.own).toEqual({ stage: 'config', configPath: 'toString' });
+		});
+
+		it('answers nothing for a prototype member the config never set', async () => {
+			const schema = makeSchema({
+				flags: {
+					method: createFlagSchema('string', { configPath: 'toString', defaultValue: 'fallback' }),
+					deep: createFlagSchema('string', {
+						configPath: 'server.hasOwnProperty',
+						defaultValue: 'fallback',
+					}),
+				},
+			});
+			const options: ResolveOptions = { config: { server: {} } };
+
+			const result = await resolve(schema, makeParsed(), options);
+			expect(result.flags).toEqual({ method: 'fallback', deep: 'fallback' });
+		});
+
+		it('reads a __proto__ config key only as an own entry', async () => {
+			const schema = makeSchema({
+				flags: {
+					own: createFlagSchema('string', { configPath: '__proto__', defaultValue: 'fallback' }),
+				},
+			});
+
+			const inherited = await resolve(schema, makeParsed(), { config: { plain: 'value' } });
+			const carried = await resolve(schema, makeParsed(), {
+				config: JSON.parse('{"__proto__":"own"}'),
+			});
+
+			expect(inherited.flags).toEqual({ own: 'fallback' });
+			expect(carried.flags).toEqual({ own: 'own' });
+		});
+
 		it('coerces number to string from config', async () => {
 			const schema = makeSchema({
 				flags: {

--- a/src/core/resolve/resolve-path-checks.test.ts
+++ b/src/core/resolve/resolve-path-checks.test.ts
@@ -629,7 +629,9 @@ describe('runCommand — flag.path() end to end', () => {
 		});
 		expect(result.exitCode).toBe(2);
 		expect(result.error?.code).toBe('CONSTRAINT_VIOLATED');
-		expect(result.error?.message).toBe("Path '/env-missing.txt' for flag --file does not exist");
+		expect(result.error?.message).toBe("Path '<redacted>' for flag --file does not exist");
+		expect(result.error?.details).toEqual({ flag: 'file', constraint: 'mustExist' });
+		expect(result.error?.suggest).toBe('Provide an existing path for --file');
 		expect(probe.calls).toEqual(['/env-missing.txt']);
 	});
 
@@ -781,9 +783,8 @@ describe('runCommand — arg.path() end to end', () => {
 		});
 		expect(result.exitCode).toBe(2);
 		expect(result.error?.code).toBe('CONSTRAINT_VIOLATED');
-		expect(result.error?.message).toBe(
-			"Path '/env-missing.txt' for argument <file> does not exist",
-		);
+		expect(result.error?.message).toBe("Path '<redacted>' for argument <file> does not exist");
+		expect(result.error?.details).toEqual({ arg: 'file', constraint: 'mustExist' });
 		expect(probe.calls).toEqual(['/env-missing.txt']);
 	});
 
@@ -794,8 +795,13 @@ describe('runCommand — arg.path() end to end', () => {
 		const result = await runCommand(cmd, [], { stdinData: '/piped.txt', stat: probe.stat });
 		expect(result.exitCode).toBe(2);
 		expect(result.error?.message).toBe(
-			"Path '/piped.txt' for argument <file> is a directory, expected a file",
+			"Path '<redacted>' for argument <file> is a directory, expected a file",
 		);
+		expect(result.error?.details).toEqual({
+			arg: 'file',
+			constraint: 'pathType',
+			expected: 'file',
+		});
 		expect(probe.calls).toEqual(['/piped.txt']);
 	});
 
@@ -805,7 +811,8 @@ describe('runCommand — arg.path() end to end', () => {
 
 		const result = await runCommand(cmd, [], { stat: probe.stat });
 		expect(result.exitCode).toBe(2);
-		expect(result.error?.message).toBe("Path '/fallback.txt' for argument <file> does not exist");
+		expect(result.error?.message).toBe("Path '<redacted>' for argument <file> does not exist");
+		expect(result.error?.details).toEqual({ arg: 'file', constraint: 'mustExist' });
 	});
 
 	// --- variadic

--- a/src/core/resolve/resolve-redaction.test.ts
+++ b/src/core/resolve/resolve-redaction.test.ts
@@ -128,6 +128,132 @@ describe('flag diagnostics', () => {
 	});
 });
 
+describe('a duplicate key is value text and takes the same rule', () => {
+	/** An entries input reachable from stdin, env, and config under `'error'`. */
+	function entriesCommand(surface: 'flag' | 'arg'): CommandSchema {
+		const entries = { stdin: {}, env: 'VARS', config: 'run.vars', duplicateKeys: 'error' } as const;
+		return surface === 'flag'
+			? createCommandSchema({
+					name: 'test',
+					flags: {
+						vars: flag
+							.keyValue()
+							.stdin()
+							.env(entries.env)
+							.config(entries.config)
+							.duplicateKeys(entries.duplicateKeys).schema,
+					},
+				})
+			: createCommandSchema({
+					name: 'test',
+					args: [
+						{
+							name: 'vars',
+							schema: arg
+								.keyValue()
+								.variadic()
+								.stdin()
+								.env(entries.env)
+								.config(entries.config)
+								.duplicateKeys(entries.duplicateKeys).schema,
+						},
+					],
+				});
+	}
+
+	it('redacts a key the environment carried', async () => {
+		const error = await failure(entriesCommand('flag'), [], {
+			env: { VARS: `${SECRET}=1,${SECRET}=2` },
+		});
+
+		expect(error.message).toBe("Duplicate key '<redacted>' from env VARS for flag --vars");
+		expect(error.details).toEqual({ flag: 'vars', source: 'env', envVar: 'VARS' });
+		expect(error.suggest).toBe('Set the repeated key once for --vars');
+	});
+
+	it('redacts a key a pipe carried', async () => {
+		const error = await failure(entriesCommand('flag'), [], {
+			stdinData: `${SECRET}=1\n${SECRET}=2\n`,
+		});
+
+		expect(error.message).toBe("Duplicate key '<redacted>' from stdin for flag --vars");
+		expect(error.details).toEqual({ flag: 'vars', source: 'stdin' });
+	});
+
+	it('redacts a key a config file carried', async () => {
+		const error = await failure(entriesCommand('flag'), [], {
+			config: { run: { vars: `${SECRET}=1,${SECRET}=2` } },
+		});
+
+		expect(error.message).toBe("Duplicate key '<redacted>' from config run.vars for flag --vars");
+		expect(error.details).toEqual({
+			flag: 'vars',
+			source: 'config',
+			configPath: 'run.vars',
+		});
+	});
+
+	it('redacts a key a pipe carried into a positional tail', async () => {
+		const error = await failure(entriesCommand('arg'), [], {
+			stdinData: `${SECRET}=1\n${SECRET}=2\n`,
+		});
+
+		expect(error.message).toBe("Duplicate key '<redacted>' from stdin for argument <vars>");
+		expect(error.details).toEqual({ arg: 'vars', source: 'stdin' });
+		expect(error.suggest).toBe('Set the repeated key once for <vars>');
+	});
+
+	it('keeps a key the user typed', async () => {
+		const error = await failure(entriesCommand('flag'), [
+			'--vars',
+			`${SECRET}=1`,
+			'--vars',
+			`${SECRET}=2`,
+		]);
+
+		expect(error.message).toBe(`Duplicate key '${SECRET}' for flag --vars`);
+		expect(error.details).toEqual({ flag: 'vars', key: SECRET });
+		expect(error.suggest).toBe(`Set '${SECRET}' once for --vars`);
+	});
+});
+
+describe('a JSON shape fault words the source the same way on both surfaces', () => {
+	it('names the source before the expectation on a flag', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			flags: { vars: flag.keyValue().split({ env: 'json' }).env('VARS').schema },
+		});
+		const error = await failure(schema, [], { env: { VARS: '["a"]' } });
+
+		expect(error.message).toBe(
+			'Invalid JSON value from env VARS for flag --vars, expected an object',
+		);
+		expect(error.details).toEqual({
+			flag: 'vars',
+			source: 'env',
+			envVar: 'VARS',
+			expected: 'object',
+		});
+	});
+
+	it('names the source before the expectation on an arg', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			args: [
+				{
+					name: 'vars',
+					schema: arg.keyValue().variadic().split({ env: 'json' }).env('VARS').schema,
+				},
+			],
+		});
+		const error = await failure(schema, [], { env: { VARS: '["a"]' } });
+
+		expect(error.message).toBe(
+			'Invalid JSON value from env VARS for argument <vars>, expected an object',
+		);
+	});
+});
+
 describe('Standard Schema failures follow the same rule', () => {
 	/** A validator that always fails, so only the diagnostic shape is under test. */
 	const rejects = {
@@ -172,6 +298,70 @@ describe('Standard Schema failures follow the same rule', () => {
 		const error = await failure(schema, [], { env: { TOKEN: SECRET } });
 
 		expect(error.details).toEqual({ issues: ['rejected'] });
+	});
+});
+
+// === L19 — the one channel redaction does not reach
+
+describe('caller-authored text passes through verbatim', () => {
+	it('keeps a parse function message intact while every framework field redacts', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			flags: {
+				token: flag
+					.custom((raw) => {
+						throw new Error(`bad input ${String(raw)}`);
+					})
+					.env('TOKEN').schema,
+			},
+		});
+		const error = await failure(schema, [], { env: { TOKEN: SECRET } });
+
+		expect(error.message).toBe(`Failed to parse env TOKEN for flag --token: bad input ${SECRET}`);
+		expect(error.details).toEqual({
+			flag: 'token',
+			source: 'env',
+			envVar: 'TOKEN',
+			expected: 'custom',
+		});
+	});
+
+	it('keeps the same message intact for a positional', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			args: [
+				{
+					name: 'token',
+					schema: arg
+						.custom((raw) => {
+							throw new Error(`bad input ${String(raw)}`);
+						})
+						.env('TOKEN').schema,
+				},
+			],
+		});
+		const error = await failure(schema, [], { env: { TOKEN: SECRET } });
+
+		expect(error.message).toContain(`bad input ${SECRET}`);
+		expect(error.details).not.toHaveProperty('value');
+	});
+
+	it('keeps a Standard Schema issue message intact', async () => {
+		const echoes = {
+			'~standard': {
+				version: 1 as const,
+				vendor: 'test',
+				validate: (value: unknown) => ({ issues: [{ message: `rejected ${String(value)}` }] }),
+			},
+		};
+		const schema = createCommandSchema({
+			name: 'test',
+			flags: { token: flag.custom(echoes).env('TOKEN').schema },
+		});
+		const error = await failure(schema, [], { env: { TOKEN: SECRET } });
+
+		expect(error.message).toContain(`rejected ${SECRET}`);
+		expect(error.details).toEqual({ issues: [`rejected ${SECRET}`] });
 	});
 });
 
@@ -258,5 +448,237 @@ describe('MISSING_STDIN', () => {
 		const resolved = await resolve(schema, parse(schema, ['-']), { env: { BODY: 'from-env' } });
 
 		expect(resolved.args).toEqual({ body: 'from-env' });
+	});
+});
+
+// === L19 — a positional words its diagnostic from the value layer's verdict
+
+describe('a positional keeps the whole reason a parse function threw', () => {
+	/** A command whose one input rejects everything with `message`. */
+	function throwing(surface: 'flag' | 'arg', message: string): CommandSchema {
+		const parseFn = () => {
+			throw new Error(message);
+		};
+		return surface === 'flag'
+			? createCommandSchema({
+					name: 'test',
+					flags: { token: flag.custom(parseFn).env('TOKEN').schema },
+				})
+			: createCommandSchema({
+					name: 'test',
+					args: [{ name: 'token', schema: arg.custom(parseFn).env('TOKEN').schema }],
+				});
+	}
+
+	for (const message of ['plain', 'bad input: really bad', 'a: b: c']) {
+		it(`carries '${message}' through on both surfaces`, async () => {
+			const forFlag = await failure(throwing('flag', message), [], { env: { TOKEN: 'v' } });
+			const forArg = await failure(throwing('arg', message), [], { env: { TOKEN: 'v' } });
+
+			expect(forFlag.message).toBe(`Failed to parse env TOKEN for flag --token: ${message}`);
+			expect(forArg.message).toBe(`Failed to parse env TOKEN for argument <token>: ${message}`);
+		});
+	}
+
+	it('carries a URL protocol reason a positional would otherwise cut to one word', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			args: [
+				{ name: 'endpoint', schema: arg.url({ protocols: ['https'] }).env('ENDPOINT').schema },
+			],
+		});
+		const error = await failure(schema, [], { env: { ENDPOINT: 'http://example.com' } });
+
+		expect(error.message).toBe(
+			"Failed to parse env ENDPOINT for argument <endpoint>: URL protocol 'http' is not allowed. Allowed: https",
+		);
+	});
+
+	it('carries a date reason whose own text holds colons', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			args: [{ name: 'since', schema: arg.date().env('SINCE').schema }],
+		});
+		const error = await failure(schema, [], { env: { SINCE: 'nope' } });
+
+		expect(error.message).toBe(
+			"Failed to parse env SINCE for argument <since>: Invalid date 'nope': expected ISO-8601 (e.g. 2026-07-10 or 2026-07-10T14:30:00Z)",
+		);
+	});
+});
+
+describe('a type mismatch says the same thing on both surfaces', () => {
+	it('names the boolean spellings a positional accepts', async () => {
+		const forFlag = await failure(
+			createCommandSchema({ name: 'test', flags: { yes: flag.boolean().env('YES').schema } }),
+			[],
+			{ env: { YES: SECRET } },
+		);
+		const forArg = await failure(
+			createCommandSchema({
+				name: 'test',
+				args: [{ name: 'yes', schema: arg.boolean().env('YES').schema }],
+			}),
+			[],
+			{ env: { YES: SECRET } },
+		);
+
+		expect(forFlag.message).toBe("Invalid boolean value '<redacted>' from env YES for flag --yes");
+		expect(forArg.message).toBe(
+			"Invalid boolean value '<redacted>' from env YES for argument <yes>",
+		);
+		expect(forFlag.suggest).toBe('Set YES to true/false, 1/0, or yes/no');
+		expect(forArg.suggest).toBe('Set YES to true/false, 1/0, or yes/no');
+		expect(forArg.details).toEqual({
+			arg: 'yes',
+			source: 'env',
+			envVar: 'YES',
+			expected: 'boolean',
+		});
+	});
+
+	it('names the expected type for a positional a config object could not fill', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			args: [{ name: 'target', schema: arg.string().config('deploy.target').schema }],
+		});
+		const error = await failure(schema, [], { config: { deploy: { target: {} } } });
+
+		expect(error.message).toBe(
+			'Invalid string value from config deploy.target for argument <target>',
+		);
+		expect(error.details).toEqual({
+			arg: 'target',
+			source: 'config',
+			configPath: 'deploy.target',
+			expected: 'string',
+		});
+		expect(error.suggest).toBe('Set deploy.target to a valid string for <target>');
+	});
+});
+
+// === a filesystem check reads the same rule as every other diagnostic
+
+describe('path checks redact a path no argv token carried', () => {
+	const MISSING = '/home/u/.ssh/id_rsa';
+	const nothingExists = (): Promise<'file' | 'directory' | null> => Promise.resolve(null);
+
+	function pathFlagCommand(): CommandSchema {
+		return createCommandSchema({
+			name: 'test',
+			flags: {
+				key: flag.path({ mustExist: true }).stdin().env('KEY').config('auth.key').default(MISSING)
+					.schema,
+			},
+		});
+	}
+
+	function pathArgCommand(): CommandSchema {
+		return createCommandSchema({
+			name: 'test',
+			args: [
+				{
+					name: 'key',
+					schema: arg
+						.path({ mustExist: true })
+						.stdin()
+						.env('KEY')
+						.config('auth.key')
+						.default(MISSING).schema,
+				},
+			],
+		});
+	}
+
+	const cases: ReadonlyArray<readonly [string, ResolveOptions]> = [
+		['stdin', { stdinData: MISSING }],
+		['env', { env: { KEY: MISSING } }],
+		['config', { config: { auth: { key: MISSING } } }],
+		['default', {}],
+	];
+
+	for (const [source, options] of cases) {
+		it(`hides a ${source} path from a flag's message and details`, async () => {
+			const error = await failure(pathFlagCommand(), [], { ...options, stat: nothingExists });
+
+			expect(error.message).toBe("Path '<redacted>' for flag --key does not exist");
+			expect(error.details).toEqual({ flag: 'key', constraint: 'mustExist' });
+			expect(error.suggest).toBe('Provide an existing path for --key');
+		});
+
+		it(`hides a ${source} path from a positional's message and details`, async () => {
+			const error = await failure(pathArgCommand(), [], { ...options, stat: nothingExists });
+
+			expect(error.message).toBe("Path '<redacted>' for argument <key> does not exist");
+			expect(error.details).toEqual({ arg: 'key', constraint: 'mustExist' });
+			expect(error.suggest).toBe('Provide an existing path for <key>');
+		});
+	}
+
+	it('quotes a path the user typed on the command line', async () => {
+		const forFlag = await failure(pathFlagCommand(), ['--key', MISSING], {
+			stat: nothingExists,
+		});
+		const forArg = await failure(pathArgCommand(), [MISSING], { stat: nothingExists });
+
+		expect(forFlag.message).toBe(`Path '${MISSING}' for flag --key does not exist`);
+		expect(forFlag.details).toEqual({ flag: 'key', value: MISSING, constraint: 'mustExist' });
+		expect(forArg.message).toBe(`Path '${MISSING}' for argument <key> does not exist`);
+		expect(forArg.details).toEqual({ arg: 'key', value: MISSING, constraint: 'mustExist' });
+	});
+
+	it('hides a path an explicit dash piped in', async () => {
+		const error = await failure(pathFlagCommand(), ['--key', '-'], {
+			stdinData: MISSING,
+			stat: nothingExists,
+		});
+
+		expect(error.message).toBe("Path '<redacted>' for flag --key does not exist");
+		expect(error.details).toEqual({ flag: 'key', constraint: 'mustExist' });
+	});
+
+	it('hides a non-argv path from a wrong-type report', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			flags: { key: flag.path({ type: 'file' }).env('KEY').schema },
+		});
+		const error = await failure(schema, [], {
+			env: { KEY: MISSING },
+			stat: () => Promise.resolve('directory'),
+		});
+
+		expect(error.message).toBe("Path '<redacted>' for flag --key is a directory, expected a file");
+		expect(error.details).toEqual({ flag: 'key', constraint: 'pathType', expected: 'file' });
+	});
+
+	it('hides a non-argv path from a failed directory creation', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			flags: { out: flag.path({ type: 'directory', create: true }).env('OUT').schema },
+		});
+		const error = await failure(schema, [], {
+			env: { OUT: MISSING },
+			stat: nothingExists,
+			mkdir: () => Promise.reject(new Error('EACCES')),
+		});
+
+		expect(error.message).toBe("Failed to create directory '<redacted>' for flag --out: EACCES");
+		expect(error.details).toEqual({ flag: 'out', constraint: 'create' });
+	});
+
+	it('checks every element of a collection an env value split', async () => {
+		const schema = createCommandSchema({
+			name: 'test',
+			flags: { keys: flag.array(flag.path({ mustExist: true })).env('KEYS').schema },
+		});
+		const error = await failure(schema, [], {
+			env: { KEYS: `${MISSING},/other/secret` },
+			stat: nothingExists,
+		});
+
+		expect(error.message).toContain("Path '<redacted>' for flag --keys does not exist");
+		expect(error.message).not.toContain(MISSING);
+		expect(error.message).not.toContain('/other/secret');
+		expect(JSON.stringify(error.details)).not.toContain('secret');
 	});
 });

--- a/src/core/resolve/resolve-source-model.test.ts
+++ b/src/core/resolve/resolve-source-model.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import type { ValidationError } from '#internals/core/errors/index.ts';
 import { isValidationError } from '#internals/core/errors/index.ts';
+import type { ParseResult } from '#internals/core/parse/index.ts';
 import { parse } from '#internals/core/parse/index.ts';
 import { createTestPrompter } from '#internals/core/prompt/index.ts';
 import type { ArgConfig } from '#internals/core/schema/arg.ts';
@@ -7,7 +9,23 @@ import { ArgBuilder, arg, createArgSchema } from '#internals/core/schema/arg.ts'
 import { command } from '#internals/core/schema/command.ts';
 import type { FlagBuilder, FlagConfig } from '#internals/core/schema/flag.ts';
 import { flag } from '#internals/core/schema/flag.ts';
+import type { ResolveOptions } from './index.ts';
 import { resolve } from './index.ts';
+
+/** Resolve a case that must fail, and hand back the failure. */
+async function failure(
+	schema: Parameters<typeof resolve>[0],
+	parsed: ParseResult,
+	options: ResolveOptions,
+): Promise<ValidationError> {
+	try {
+		await resolve(schema, parsed, options);
+	} catch (error) {
+		if (isValidationError(error)) return error;
+		throw error;
+	}
+	throw new Error('expected resolution to fail');
+}
 
 // === L15 — the unified source model
 
@@ -560,5 +578,66 @@ describe('provenance record', () => {
 		expect(result.provenance.flags.tags).toEqual({ stage: 'default' });
 		expect(result.provenance.flags.vars).toEqual({ stage: 'default' });
 		expect(result.provenance.args.rest).toEqual({ stage: 'default' });
+	});
+});
+
+// === blank text is not the number zero
+
+describe('a number input rejects blank text from every source', () => {
+	const blanks = ['', ' ', '\n', '\r\n', '\t'];
+
+	const sources: ReadonlyArray<readonly [string, (raw: string) => ResolveOptions]> = [
+		['stdin', (raw) => ({ stdinData: raw })],
+		['env', (raw) => ({ env: { VALUE: raw } })],
+		['config', (raw) => ({ config: { deploy: { value: raw } } })],
+		['prompt', (raw) => ({ prompter: createTestPrompter([raw]) })],
+	];
+
+	function numberFlag() {
+		return flag
+			.number()
+			.stdin()
+			.env('VALUE')
+			.config('deploy.value')
+			.prompt({ kind: 'input', message: 'Value' });
+	}
+
+	function numberArg() {
+		return arg.number().stdin().env('VALUE').config('deploy.value').optional();
+	}
+
+	for (const [name, options] of sources) {
+		// A blank `input` prompt answer falls through to the next stage rather than
+		// coercing, so the prompt source is covered by the flag surface alone.
+		if (name === 'prompt') continue;
+
+		it(`fails a flag on ${name}`, async () => {
+			for (const raw of blanks) {
+				const built = flagCase(numberFlag(), []);
+				const error = await failure(built.schema, built.parsed, options(raw));
+				expect(error.code).toBe('TYPE_MISMATCH');
+				expect(error.details?.expected).toBe('number');
+				expect(error.message).toContain("'<redacted>'");
+			}
+		});
+
+		it(`fails an arg on ${name}`, async () => {
+			for (const raw of blanks) {
+				const built = argCase(numberArg(), []);
+				const error = await failure(built.schema, built.parsed, options(raw));
+				expect(error.code).toBe('TYPE_MISMATCH');
+				expect(error.details?.expected).toBe('number');
+				expect(error.message).toContain("'<redacted>'");
+			}
+		});
+	}
+
+	it('still reads a number framed by whitespace', async () => {
+		const spaced = flagCase(numberFlag(), []);
+		expect(
+			(await resolve(spaced.schema, spaced.parsed, { env: { VALUE: ' 42 ' } })).flags.value,
+		).toBe(42);
+		const piped = flagCase(numberFlag(), []);
+		expect((await resolve(piped.schema, piped.parsed, { stdinData: '42\n' })).flags.value).toBe(42);
 	});
 });

--- a/src/core/resolve/resolve-standard-schema.test.ts
+++ b/src/core/resolve/resolve-standard-schema.test.ts
@@ -30,6 +30,15 @@ const evenInt = standard<number>((value) => {
 	return { value: n };
 });
 
+/** Sync validator: accepts an odd integer, so the count factory's own default of 0 fails it. */
+const oddInt = standard<number>((value) => {
+	const n = Number(value);
+	if (!Number.isInteger(n) || n % 2 === 0) {
+		return { issues: [{ message: 'must be an odd integer' }] };
+	}
+	return { value: n };
+});
+
 /** Async validator: accepts a string longer than two chars. */
 const asyncName = standard<string>(async (value) => {
 	if (typeof value !== 'string' || value.length <= 2) {
@@ -139,6 +148,43 @@ describe('Standard Schema v1 interop — flags', () => {
 		const bad = await runCommand(cmd, ['--count', '2', '--count', '3']);
 		expect(bad.exitCode).toBe(2);
 		expect(bad.error?.message).toContain('--count[1] failed validation');
+	});
+
+	it('validates a count flag, whose scalar value carries the element validator', async () => {
+		const cmd = command('run')
+			.flag('verbose', flag.count().alias('v').standard(evenInt))
+			.action(({ flags, out }) => out.log(`verbose=${String(flags.verbose)}`));
+
+		const ok = await runCommand(cmd, ['-v', '-v']);
+		expect(ok.exitCode).toBe(0);
+		expect(ok.stdout[0]).toBe('verbose=2\n');
+
+		const bad = await runCommand(cmd, ['-v']);
+		expect(bad.exitCode).toBe(2);
+		expect(bad.error?.code).toBe('CONSTRAINT_VIOLATED');
+		expect(bad.error?.message).toBe('--verbose failed validation: must be an even integer');
+	});
+
+	it('validates a count flag resolved from env', async () => {
+		const cmd = command('run')
+			.flag('verbose', flag.count().env('VERBOSE').standard(evenInt))
+			.action(({ out }) => out.log('unreachable'));
+
+		const result = await runCommand(cmd, [], { env: { VERBOSE: '3' } });
+
+		expect(result.exitCode).toBe(2);
+		expect(result.error?.message).toBe('--verbose failed validation: must be an even integer');
+	});
+
+	it('validates a count flag left at the factory default', async () => {
+		const cmd = command('run')
+			.flag('verbose', flag.count().standard(oddInt))
+			.action(({ out }) => out.log('unreachable'));
+
+		const result = await runCommand(cmd, []);
+
+		expect(result.exitCode).toBe(2);
+		expect(result.error?.message).toBe('--verbose failed validation: must be an odd integer');
 	});
 });
 

--- a/src/core/resolve/standard.ts
+++ b/src/core/resolve/standard.ts
@@ -30,6 +30,7 @@ import {
 	flagValueSchema,
 } from '#internals/core/schema/value.ts';
 import type { ResolutionProvenanceRecord } from './contracts.ts';
+import { echoesValue } from './redaction.ts';
 
 /** Resolved values after the Standard Schema pass, plus any issues found. */
 interface StandardValidationResult {
@@ -60,21 +61,6 @@ function issuesMessage(label: string, issues: ReadonlyArray<StandardSchemaV1Issu
 		return path === undefined ? issue.message : `${path}: ${issue.message}`;
 	});
 	return `${label} failed validation: ${rendered.join('; ')}`;
-}
-
-/**
- * Whether a diagnostic may quote the value the user supplied.
- *
- * Only a token typed on the command line is already on the user's screen. Every
- * other stage, an explicit `-` included, carries bytes a user may consider
- * secret, so the same rule `coerce.ts` applies to its messages governs the
- * `value` this pass records.
- *
- * @param source - Where the value came from, or `undefined` when unrecorded.
- * @returns `true` when the value is safe to echo.
- */
-function echoesValue(source: ResolutionProvenance | undefined): boolean {
-	return source !== undefined && source.stage === 'cli' && !('via' in source);
 }
 
 /**

--- a/src/core/schema/AGENTS.md
+++ b/src/core/schema/AGENTS.md
@@ -7,23 +7,23 @@ Multi-file module in `core/`. All others (except resolve, output, completion) us
 | File                    | Lines | Purpose                                                                                                                     |
 | ----------------------- | ----: | --------------------------------------------------------------------------------------------------------------------------- |
 | `command.ts`            |  1946 | `CommandBuilder<F, A, C>` — fluent builder + `Out` interface + schema + `createCommandSchema()`                             |
-| `flag.ts`               |  2410 | `FlagBuilder` — `flag.string/number/boolean/enum/array/custom/url/path/date/duration/bytes/count/keyValue()`                |
-| `arg.ts`                |  2187 | `ArgBuilder` — `arg.string/number/boolean/enum/custom/keyValue/url/path/date/duration/bytes()`                              |
+| `flag.ts`               |  2473 | `FlagBuilder` — `flag.string/number/boolean/enum/array/custom/url/path/date/duration/bytes/count/keyValue()`                |
+| `arg.ts`                |  2240 | `ArgBuilder` — `arg.string/number/boolean/enum/custom/keyValue/url/path/date/duration/bytes()`                              |
 | `brand.ts`              |    19 | `schemaBrand` — type-only `unique symbol` sealing flag, arg, command, CLI, and config-settings schemas                      |
 | `activity.ts`           |   240 | Activity types — `SpinnerHandle`, `ProgressHandle`, `ActivityEvent`, etc.                                                   |
 | `middleware.ts`         |   180 | `middleware<Output>(handler)` factory — phantom-branded `Middleware<Output>`                                                |
 | `prompt.ts`             |   171 | Prompt config types — `PromptConfig` discriminated union (4 kinds)                                                          |
 | `stdin.ts`              |   156 | `StdinBinding` / `StdinOptions` — the stdin axis both factories carry, plus its normalizer                                  |
-| `cardinality.ts`        |   669 | Internal cardinality axis: `Cardinality`, split policies, aggregation rules, declared-default validation                    |
+| `cardinality.ts`        |   684 | Internal cardinality axis: `Cardinality`, split policies, aggregation rules, declared-default validation                    |
 | `source.ts`             |   321 | Internal source axis — `RESOLUTION_ORDER`, `sourceBindings()`, stdin eligibility and exclusivity helpers                    |
 | `provenance.ts`         |    92 | Public provenance surface — `ResolutionProvenance`, `InputSources`, `SourcesOf`, `wasExplicit()`                            |
 | `number-constraints.ts` |   153 | `NumberConstraints` + shared `validateNumberConstraints()` (parse & resolve both import it)                                 |
 | `string-constraints.ts` |   172 | `StringConstraints` + shared `validateStringConstraints()` / `stringConstraintDetails()` (parse & resolve both import them) |
 | `standard.ts`           |   143 | Vendored Standard Schema v1 types (no runtime dep) + `isStandardSchemaV1()` guard                                           |
-| `value.ts`              |   777 | Internal value layer (`ValueSchema`, `ValueCodec`, `decodeValue()`, `stripTerminator()`, both schema projections)           |
+| `value.ts`              |   778 | Internal value layer (`ValueSchema`, `ValueCodec`, `decodeValue()`, `stripTerminator()`, both schema projections)           |
 | `value-parsers.ts`      |   329 | Value machinery behind the sugar factories on both `flag` and `arg` — parsers, path option types, `buildPathChecks()`       |
 | `run.ts`                |   243 | `RunOptions` / `RunResult` — execution options + structured result (re-exported by testkit)                                 |
-| `index.ts`              |   173 | Barrel — re-exports all public symbols                                                                                      |
+| `index.ts`              |   176 | Barrel — re-exports all public symbols                                                                                      |
 
 ## TYPE SYSTEM PATTERNS
 
@@ -133,6 +133,15 @@ promise is left to the resolution-time pass, as are filesystem checks.
 from `.default()`, and from every modifier that could invalidate an existing
 default (`nextFlag()` / `nextArg()`), so the verdict does not depend on the order
 the chain was written in.
+
+`nextFlag()` / `nextArg()` also run `assertValidFlagDefinition()` /
+`assertValidArgDefinition()`, the same check `createFlagSchema()` /
+`createArgSchema()` run. A modifier states its kinds to the compiler through a
+`this` constraint, which a JavaScript caller does not see, so without the runtime
+check a builder could produce a schema whose emitted definition document its own
+factory refuses. Every kind-sensitive modifier routes through these two helpers;
+a modifier that calls `new FlagBuilder(...)` or `new ArgBuilder(...)` directly is
+one whose field every kind carries.
 
 ## PROVENANCE (`provenance.ts`)
 
@@ -262,7 +271,9 @@ collapse two path args into the same placeholder.
 - `custom` → `PromptConfig` (all kinds — the `parseFn` is responsible for handling any prompt result)
 - `count` / `keyValue` → `never` (not promptable; `.prompt()` uncallable at compile time)
 
-Runtime enforcement lives in `resolve/flags.ts` (`COMPATIBLE_PROMPT_KINDS` + `validatePromptFlagCompatibility()`).
+Runtime enforcement lives in `resolve/flags.ts` (`COMPATIBLE_PROMPT_KINDS` +
+`validatePromptFlagCompatibility()`), and `resolve/args.ts` reads the same map for the positional
+surface through the shared `promptCompatibilityError()`.
 
 ## GOTCHAS
 

--- a/src/core/schema/arg-value-factories.test.ts
+++ b/src/core/schema/arg-value-factories.test.ts
@@ -143,18 +143,18 @@ describe('arg sugar factories — type inference', () => {
 
 	it('gates string constraint methods to string-kind args', () => {
 		// @ts-expect-error — .nonEmpty() is not available on number args
-		arg.number().nonEmpty();
+		expect(() => arg.number().nonEmpty()).toThrow(/requires kind 'string'/);
 		// @ts-expect-error — .minLength() is not available on enum args
-		arg.enum(['a', 'b']).minLength(1);
+		expect(() => arg.enum(['a', 'b']).minLength(1)).toThrow(/requires kind 'string'/);
 		// @ts-expect-error — .maxLength() is not available on custom args
-		arg.url().maxLength(2);
+		expect(() => arg.url().maxLength(2)).toThrow(/requires kind 'string'/);
 		// @ts-expect-error — .pattern() is not available on date args
-		arg.date().pattern(/^a/);
+		expect(() => arg.date().pattern(/^a/)).toThrow(/requires kind 'string'/);
 	});
 
 	it('gates numeric constraint methods away from the new string kinds', () => {
 		// @ts-expect-error — .min() is not available on path args
-		arg.path().min(1);
+		expect(() => arg.path().min(1)).toThrow(/requires kind 'number'/);
 	});
 });
 
@@ -341,10 +341,11 @@ describe('arg constraints from stdin', () => {
 	it('rejects a malformed piped url', async () => {
 		const { schema, parsed } = parseCommandArg(arg.url().stdin(), []);
 
-		// A parse-function failure outside argv is TYPE_MISMATCH on both surfaces.
+		// A parse-function failure outside argv is TYPE_MISMATCH on both surfaces,
+		// and its message is the flag one with the subject swapped.
 		await expect(resolve(schema, parsed, { stdinData: 'nope' })).rejects.toMatchObject({
 			code: 'TYPE_MISMATCH',
-			message: "Invalid value '<redacted>' from stdin for argument <x>: Invalid URL 'nope'",
+			message: "Failed to parse stdin value for argument <x>: Invalid URL 'nope'",
 		});
 	});
 

--- a/src/core/schema/arg.test.ts
+++ b/src/core/schema/arg.test.ts
@@ -76,12 +76,11 @@ describe('arg.number() chained constraint methods', () => {
 		expectTypeOf<InferArg<typeof a>>().toEqualTypeOf<number | undefined>();
 	});
 
-	it('constraint methods are number-kind only at compile time', () => {
+	it('constraint methods are number-kind only, at compile time and construction time', () => {
 		// @ts-expect-error — .min() is not available on string args
-		arg.string().min(0);
+		expect(() => arg.string().min(0)).toThrow(/requires kind 'number'/);
 		// @ts-expect-error — .int() is not available on enum args
-		arg.enum(['a', 'b']).int();
-		expect(true).toBe(true);
+		expect(() => arg.enum(['a', 'b']).int()).toThrow(/requires kind 'number'/);
 	});
 });
 

--- a/src/core/schema/arg.ts
+++ b/src/core/schema/arg.ts
@@ -16,6 +16,7 @@ import {
 	argCardinality,
 	DUPLICATE_KEYS,
 	defaultViolationError,
+	indefiniteArticle,
 	isCollection,
 	normalizeSplitOptions,
 	normalizeSplitPolicy,
@@ -25,6 +26,7 @@ import { assertNumberConstraints, type NumberConstraints } from './number-constr
 import type {
 	ConfirmPromptConfig,
 	InputPromptConfig,
+	MultiselectPromptConfig,
 	PromptConfig,
 	SelectPromptConfig,
 } from './prompt.ts';
@@ -198,8 +200,17 @@ type PromptConfigByArgKind = {
 	readonly keyValue: never;
 };
 
-/** Prompt configuration compatible with the kind carried by an {@link ArgConfig}. */
-type AllowedArgPromptConfig<C extends ArgConfig> = PromptConfigByArgKind[C['argKind']];
+/**
+ * Prompt configuration compatible with an {@link ArgConfig}.
+ *
+ * A variadic arg collects several values, so it takes the multiselect a
+ * `flag.array()` takes; every other arg takes what its kind takes.
+ */
+type AllowedArgPromptConfig<C extends ArgConfig> = C['argKind'] extends 'keyValue'
+	? never
+	: C['variadic'] extends true
+		? MultiselectPromptConfig
+		: PromptConfigByArgKind[C['argKind']];
 
 /** Extract the resolved value type from an {@linkcode ArgBuilder}. */
 type InferArg<B> = B extends ArgBuilder<infer C extends ArgConfig> ? ResolvedArgValue<C> : never;
@@ -717,9 +728,12 @@ function normalizeArgDefinitionFields(fields: ArgDefinitionFields): ArgSchemaFie
  *
  * @param kind - Declared kind of the definition.
  * @param fields - Definition fields excluding the kind discriminator.
- * @throws {CLIError} With code `'INVALID_SCHEMA'` on a kind mismatch.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` on an unknown kind or a kind
+ *   mismatch.
  */
 function assertValidArgDefinition(kind: ArgKind, fields: ArgDefinitionFields): void {
+	assertKnownArgKind(kind);
+
 	for (const [field, requiredKind] of KIND_SPECIFIC_ARG_FIELDS) {
 		if (kind === requiredKind) continue;
 		if (fields[field] === undefined) continue;
@@ -790,6 +804,26 @@ function assertValidArgDefinition(kind: ArgKind, fields: ArgDefinitionFields): v
 			suggest: "Add 'variadic: true' on a list kind, or drop 'unique'",
 		});
 	}
+}
+
+/**
+ * Reject a discriminator outside {@link ARG_KINDS}.
+ *
+ * The types admit only a declared kind, so this catches an untyped JavaScript
+ * caller before an unknown discriminator reaches an exhaustive `switch` that
+ * has no arm for it.
+ *
+ * @param kind - Declared kind of the definition.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` on an unknown kind.
+ */
+function assertKnownArgKind(kind: ArgKind): void {
+	if (ARG_KINDS.includes(kind)) return;
+
+	throw new CLIError(`Unknown arg kind '${String(kind)}'`, {
+		code: 'INVALID_SCHEMA',
+		details: { kind, allowed: [...ARG_KINDS] },
+		suggest: `Use one of: ${ARG_KINDS.join(', ')}`,
+	});
 }
 
 /**
@@ -867,7 +901,9 @@ function assertValidArgDefault(name: string | undefined, schema: ArgSchema): voi
 	);
 	if (violation === undefined) return;
 	throw defaultViolationError(
-		name === undefined ? `a ${schema.kind} argument` : `argument <${name}>`,
+		name === undefined
+			? `${indefiniteArticle(schema.kind)} ${schema.kind} argument`
+			: `argument <${name}>`,
 		{ kind: schema.kind, ...(name === undefined ? {} : { arg: name }) },
 		violation,
 	);
@@ -1157,7 +1193,7 @@ class ArgBuilder<C extends ArgConfig> {
 		value: string,
 	): ArgBuilder<C> {
 		normalizeSplitPolicy('cli', value);
-		return nextCollectionArg({ ...this.schema, separator: value });
+		return nextArg({ ...this.schema, separator: value });
 	}
 
 	/**
@@ -1192,7 +1228,7 @@ class ArgBuilder<C extends ArgConfig> {
 		options: SplitOptions,
 	): ArgBuilder<C> {
 		const normalized = normalizeSplitOptions(options, this.schema.split);
-		return nextCollectionArg({
+		return nextArg({
 			...this.schema,
 			...(normalized.setsSeparator ? { separator: normalized.separator } : {}),
 			split: normalized.split,
@@ -1218,7 +1254,7 @@ class ArgBuilder<C extends ArgConfig> {
 		if (this.schema.kind === 'keyValue' || this.schema.variadic !== true) {
 			assertValidArgDefinition(this.schema.kind, { ...this.schema, unique: true });
 		}
-		return nextCollectionArg({ ...this.schema, unique: value });
+		return nextArg({ ...this.schema, unique: value });
 	}
 
 	/**
@@ -1233,14 +1269,14 @@ class ArgBuilder<C extends ArgConfig> {
 	 * ```ts
 	 * arg.keyValue().variadic().duplicateKeys('error').env('VARS')
 	 * // $ VARS='A=1,A=2' mycli run
-	 * // #   → Duplicate key 'A' from env VARS for argument <vars>  (CONSTRAINT_VIOLATED)
+	 * // #   → Duplicate key '<redacted>' from env VARS for argument <vars>  (CONSTRAINT_VIOLATED)
 	 * ```
 	 */
 	duplicateKeys(
 		this: ArgBuilder<C & { readonly argKind: 'keyValue' }>,
 		policy: DuplicateKeys,
 	): ArgBuilder<C> {
-		return nextCollectionArg({ ...this.schema, duplicateKeys: policy });
+		return nextArg({ ...this.schema, duplicateKeys: policy });
 	}
 
 	/**
@@ -1387,6 +1423,10 @@ class ArgBuilder<C extends ArgConfig> {
 	 * is skipped and resolution falls through to the default or the missing-arg
 	 * error.
 	 *
+	 * The compatible kinds follow the value and the cardinality: a variadic arg
+	 * takes the `multiselect` a `flag.array()` takes, and every other arg takes
+	 * what its kind takes on the flag surface.
+	 *
 	 * @param config - {@link PromptConfig} describing the interactive prompt.
 	 * @returns The builder (for chaining).
 	 *
@@ -1395,6 +1435,8 @@ class ArgBuilder<C extends ArgConfig> {
 	 * arg.string().prompt({ kind: 'input', message: 'Target:' })
 	 * // $ mycli deploy             → prompts "Target:"
 	 * // $ mycli deploy production  → skips the prompt
+	 *
+	 * arg.string().variadic().prompt({ kind: 'multiselect', message: 'Targets:' })
 	 * ```
 	 */
 	prompt(config: AllowedArgPromptConfig<C>): ArgBuilder<WithoutArgElementEligibility<C>> {
@@ -1623,26 +1665,16 @@ class ArgBuilder<C extends ArgConfig> {
 }
 
 /**
- * Continue a builder chain, rejecting a default the change just invalidated.
+ * Continue a builder chain, rejecting a schema the change just invalidated.
+ *
+ * The `this` constraint on each modifier states to the compiler which kinds
+ * carry the field it sets; this states the same rule to a caller who reaches
+ * the builder from JavaScript, with the error {@link createArgSchema} already
+ * gives, so what a builder produces is always a definition the framework can
+ * read back.
  *
  * A constraint added after `.default()` still governs the default, so the
  * verdict is the same whichever order the chain was written in.
- *
- * @param schema - The schema the modifier produced.
- * @returns A builder over that schema.
- * @throws {CLIError} With code `'INVALID_DEFAULT'` when the default no longer holds.
- */
-function nextArg<C extends ArgConfig>(schema: ArgSchema): ArgBuilder<C> {
-	assertValidArgDefault(undefined, schema);
-	return new ArgBuilder(schema);
-}
-
-/**
- * Continue a builder chain past a modifier only an arg that aggregates carries.
- *
- * The `this` constraints on those modifiers state the rule to the compiler; this
- * states it to a caller who reaches the builder from JavaScript, with the error
- * the definition path already gives.
  *
  * @param schema - The schema the modifier produced.
  * @returns A builder over that schema.
@@ -1650,9 +1682,10 @@ function nextArg<C extends ArgConfig>(schema: ArgSchema): ArgBuilder<C> {
  *   on the arg, or `'INVALID_DEFAULT'` when the default no longer holds.
  * @internal
  */
-function nextCollectionArg<C extends ArgConfig>(schema: ArgSchema): ArgBuilder<C> {
+function nextArg<C extends ArgConfig>(schema: ArgSchema): ArgBuilder<C> {
 	assertValidArgDefinition(schema.kind, schema);
-	return nextArg(schema);
+	assertValidArgDefault(undefined, schema);
+	return new ArgBuilder(schema);
 }
 
 // --- Factory namespace
@@ -2138,6 +2171,7 @@ const arg: ArgFactory = {
 		readonly argKind: 'keyValue';
 		readonly elementEligible: false;
 	}> {
+		if (element !== undefined) assertArgElementBuilder('keyValue', element);
 		return new ArgBuilder(
 			createArgSchema('keyValue', {
 				valueHint: 'key=value',
@@ -2227,6 +2261,27 @@ const arg: ArgFactory = {
 		return new ArgBuilder(createArgSchema('custom', valueDefinitionFields(bytesValue())));
 	},
 };
+
+/**
+ * Reject a collection factory handed something other than an arg builder.
+ *
+ * The types demand one, so this catches an untyped JavaScript caller before the
+ * factory reads `.schema` off a value that has none.
+ *
+ * @param factory - Name of the factory being called.
+ * @param element - What the caller passed as the element.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` when it is not an
+ *   {@link ArgBuilder}.
+ */
+function assertArgElementBuilder(factory: 'keyValue', element: unknown): void {
+	if (element instanceof ArgBuilder) return;
+
+	throw new CLIError(`arg.${factory}() requires an element builder`, {
+		code: 'INVALID_SCHEMA',
+		details: { factory, field: 'element', received: typeof element },
+		suggest: `Pass an element builder, as in arg.${factory}(arg.string())`,
+	});
+}
 
 // --- Exports
 

--- a/src/core/schema/cardinality.test.ts
+++ b/src/core/schema/cardinality.test.ts
@@ -7,6 +7,8 @@
 
 import { describe, expect, it, test } from 'vitest';
 import { isCLIError } from '#internals/core/errors/index.ts';
+import { parse } from '#internals/core/parse/index.ts';
+import { resolve } from '#internals/core/resolve/index.ts';
 import { arg, createArgSchema } from './arg.ts';
 import {
 	argCardinality,
@@ -18,7 +20,8 @@ import {
 	splitLines,
 	splitManyText,
 } from './cardinality.ts';
-import { createFlagSchema, flag } from './flag.ts';
+import { createCommandSchema } from './command.ts';
+import { createFlagSchema, type FlagSchema, flag } from './flag.ts';
 import type { StandardSchemaV1 } from './standard.ts';
 import { argValueSchema, flagValueSchema } from './value.ts';
 
@@ -350,6 +353,32 @@ describe('validated defaults, flags', () => {
 		expect(schemaError(() => createFlagSchema('count', { defaultValue: -1 })).message).toBe(
 			'Default value for a count flag is invalid: expected a non-negative integer',
 		);
+	});
+
+	it('leaves a count validator to resolution, since the factory declares the default', async () => {
+		const verbose = flag.count().standard({
+			'~standard': {
+				version: 1,
+				vendor: 'test',
+				validate: (value: unknown) =>
+					value === 2 ? { value } : { issues: [{ message: 'must be two' }] },
+			},
+		});
+		expect(verbose.schema.defaultValue).toBe(0);
+		expect(verbose.default(1).schema.defaultValue).toBe(1);
+
+		const resolveDefault = (flagSchema: FlagSchema) => {
+			const command = createCommandSchema({ name: 'test', flags: { verbose: flagSchema } });
+			return resolve(command, parse(command, []));
+		};
+		await expect(resolveDefault(verbose.schema)).rejects.toMatchObject({
+			code: 'CONSTRAINT_VIOLATED',
+			details: { issues: ['must be two'] },
+		});
+		await expect(resolveDefault(verbose.default(1).schema)).rejects.toMatchObject({
+			code: 'CONSTRAINT_VIOLATED',
+			details: { issues: ['must be two'] },
+		});
 	});
 
 	it('runs a synchronous element validator over a default', () => {

--- a/src/core/schema/cardinality.ts
+++ b/src/core/schema/cardinality.ts
@@ -581,6 +581,7 @@ function validateDefault(
 		case 'one':
 			return validateDefaultElement(element, undefined, value);
 		case 'count':
+			// `flag.count()` supplies its own default of 0.
 			return typeof value === 'number' && Number.isInteger(value) && value >= 0
 				? undefined
 				: { kind: 'shape', expected: 'count' };
@@ -627,6 +628,19 @@ function validateDefaultStandard(
 	if (result instanceof Promise) return undefined;
 	if (result.issues === undefined) return undefined;
 	return { kind: 'standard', at, value, issues: result.issues.map((issue) => issue.message) };
+}
+
+/** Vowel-initial kind names, for the article a message puts before one. */
+const VOWEL_INITIAL = /^[aeiou]/i;
+
+/**
+ * The English article that precedes a kind name.
+ *
+ * @param word - The kind name a message names an input by.
+ * @returns `'an'` before a vowel, `'a'` otherwise.
+ */
+function indefiniteArticle(word: string): string {
+	return VOWEL_INITIAL.test(word) ? 'an' : 'a';
 }
 
 /**
@@ -691,6 +705,7 @@ export {
 	defaultViolationError,
 	flagCardinality,
 	foldEntries,
+	indefiniteArticle,
 	isCollection,
 	normalizeSplitOptions,
 	normalizeSplitPolicy,

--- a/src/core/schema/element-fragment-fields.test.ts
+++ b/src/core/schema/element-fragment-fields.test.ts
@@ -1,0 +1,266 @@
+/**
+ * The fields supported by collection element schemas.
+ *
+ * Array flag elements retain the full flag fragment. Key-value arg elements
+ * retain only value fields; positional sources and allocation settings are
+ * rejected instead of being accepted and ignored.
+ *
+ * @module dreamcli/core/schema/element-fragment-fields.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { CLIError } from '#internals/core/errors/index.ts';
+import { generateCommandSchema } from '#internals/core/json-schema/index.ts';
+import { parse } from '#internals/core/parse/index.ts';
+import { resolve } from '#internals/core/resolve/index.ts';
+import { arg, createArgSchema } from './arg.ts';
+import { createCommandSchema } from './command.ts';
+import { createFlagSchema, flag } from './flag.ts';
+
+// === the fields an element definition admits
+
+/** Every source field a flag element definition may carry. */
+const FLAG_ELEMENT_SOURCES = {
+	presence: 'required',
+	defaultValue: 'element-default',
+	envVar: 'ELEMENT_ENV',
+	configPath: 'element.path',
+	stdin: {},
+	prompt: { kind: 'input', message: 'Element?' },
+	description: 'an element',
+	deprecated: 'element deprecation',
+} as const;
+
+describe('a flag element definition', () => {
+	it('builds with every source field set', () => {
+		const schema = createFlagSchema('array', {
+			elementSchema: { kind: 'string', ...FLAG_ELEMENT_SOURCES },
+		});
+
+		expect(schema.elementSchema).toMatchObject({
+			kind: 'string',
+			presence: 'required',
+			defaultValue: 'element-default',
+			envVar: 'ELEMENT_ENV',
+			configPath: 'element.path',
+			stdin: { when: 'dash-or-missing', consume: 'exclusive', trim: false },
+			prompt: { kind: 'input', message: 'Element?' },
+		});
+	});
+
+	it('leaves resolution reading the collection own sources alone', async () => {
+		const schema = createCommandSchema({
+			name: 'deploy',
+			flags: {
+				tags: {
+					kind: 'array',
+					envVar: 'TAGS',
+					elementSchema: { kind: 'string', ...FLAG_ELEMENT_SOURCES },
+				},
+			},
+		});
+
+		const resolved = await resolve(schema, parse(schema, []), {
+			env: { TAGS: 'a,b', ELEMENT_ENV: 'from-the-element' },
+			config: { element: { path: 'from-the-element' } },
+		});
+
+		expect(resolved.flags.tags).toEqual(['a', 'b']);
+		expect(resolved.provenance.flags.tags).toEqual({ stage: 'env', envVar: 'TAGS' });
+	});
+
+	it('leaves an absent collection at its own default, not the element one', async () => {
+		const schema = createCommandSchema({
+			name: 'deploy',
+			flags: {
+				tags: {
+					kind: 'array',
+					defaultValue: ['collection-default'],
+					elementSchema: { kind: 'string', ...FLAG_ELEMENT_SOURCES },
+				},
+			},
+		});
+
+		const resolved = await resolve(schema, parse(schema, []), {});
+
+		expect(resolved.flags.tags).toEqual(['collection-default']);
+	});
+
+	it('keeps an element stdin binding out of the exclusivity rule and out of the pipe', async () => {
+		const schema = createCommandSchema({
+			name: 'deploy',
+			flags: {
+				tags: { kind: 'array', elementSchema: { kind: 'string', stdin: {} } },
+				body: { kind: 'string', stdin: {} },
+			},
+		});
+
+		const resolved = await resolve(schema, parse(schema, []), { stdinData: 'piped' });
+
+		expect(resolved.flags).toEqual({ body: 'piped', tags: [] });
+		expect(resolved.provenance.flags.tags).toEqual({ stage: 'default' });
+	});
+});
+
+describe('an arg element definition', () => {
+	it('builds with value fields set', () => {
+		const schema = createArgSchema('keyValue', {
+			elementSchema: {
+				kind: 'string',
+				stringConstraints: { nonEmpty: true },
+				valueHint: 'entry-value',
+			},
+		});
+
+		expect(schema.elementSchema).toMatchObject({
+			kind: 'string',
+			presence: 'required',
+			variadic: false,
+			stringConstraints: { nonEmpty: true },
+			valueHint: 'entry-value',
+		});
+	});
+
+	describe('positional-only fields', () => {
+		it.each([
+			['presence', { presence: 'optional' }],
+			['variadic', { variadic: true }],
+			['stdin', { stdin: {} }],
+			['defaultValue', { defaultValue: 'element-default' }],
+			['description', { description: 'an element' }],
+			['envVar', { envVar: 'ELEMENT_ENV' }],
+			['configPath', { configPath: 'element.path' }],
+			['prompt', { prompt: { kind: 'input', message: 'Element?' } }],
+			['deprecated', { deprecated: 'element deprecation' }],
+		] as const)('rejects %s', (field, fields) => {
+			expect(() =>
+				createArgSchema('keyValue', { elementSchema: { kind: 'string', ...fields } }),
+			).toThrow(
+				expect.objectContaining<Partial<CLIError>>({
+					code: 'INVALID_SCHEMA',
+					details: { kind: 'string', field },
+				}),
+			);
+		});
+	});
+
+	it('applies value fields while reading the positional own source', async () => {
+		const schema = createCommandSchema({
+			name: 'deploy',
+			args: [
+				{
+					name: 'vars',
+					schema: {
+						kind: 'keyValue',
+						envVar: 'VARS',
+						elementSchema: {
+							kind: 'string',
+							stringConstraints: { pattern: /^\d+$/ },
+						},
+					},
+				},
+			],
+		});
+
+		const resolved = await resolve(schema, parse(schema, []), {
+			env: { VARS: 'A=1' },
+		});
+
+		expect(resolved.args.vars).toEqual({ A: '1' });
+		expect(resolved.provenance.args.vars).toEqual({ stage: 'env', envVar: 'VARS' });
+	});
+
+	it('keeps the element value schema out of positional allocation', async () => {
+		const schema = createCommandSchema({
+			name: 'deploy',
+			args: [
+				{
+					name: 'vars',
+					schema: { kind: 'keyValue', elementSchema: { kind: 'string' } },
+				},
+				{ name: 'target', schema: { kind: 'string' } },
+			],
+		});
+
+		const resolved = await resolve(schema, parse(schema, ['A=1', 'prod']), {});
+
+		expect(resolved.args).toEqual({ vars: { A: '1' }, target: 'prod' });
+	});
+});
+
+// === the definition document carries the supported fragment
+
+describe('the definition document', () => {
+	it('emits the element source fields a flag definition declared', () => {
+		const schema = createCommandSchema({
+			name: 'deploy',
+			flags: {
+				tags: { kind: 'array', elementSchema: { kind: 'string', ...FLAG_ELEMENT_SOURCES } },
+			},
+		});
+
+		expect(generateCommandSchema(schema).flags.tags?.elementSchema).toEqual({
+			kind: 'string',
+			presence: 'required',
+			defaultValue: 'element-default',
+			envVar: 'ELEMENT_ENV',
+			configPath: 'element.path',
+			stdin: { when: 'dash-or-missing', consume: 'exclusive', trim: false },
+			prompt: { kind: 'input', message: 'Element?' },
+			description: 'an element',
+			deprecated: 'element deprecation',
+		});
+	});
+
+	it('rebuilds the same element from what it emitted', () => {
+		const built = createFlagSchema('array', {
+			elementSchema: { kind: 'string', ...FLAG_ELEMENT_SOURCES },
+		});
+		const document = generateCommandSchema(
+			createCommandSchema({ name: 'deploy', flags: { tags: built } }),
+		);
+		const fragment = document.flags.tags?.elementSchema;
+		if (fragment === undefined) throw new Error('the document emitted no element');
+
+		expect(fragment.prompt).toEqual(FLAG_ELEMENT_SOURCES.prompt);
+		const rebuilt = createFlagSchema('array', {
+			elementSchema: {
+				kind: 'string',
+				presence: fragment.presence,
+				defaultValue: fragment.defaultValue,
+				envVar: fragment.envVar,
+				configPath: fragment.configPath,
+				stdin: fragment.stdin,
+				description: fragment.description,
+				deprecated: fragment.deprecated,
+				prompt: FLAG_ELEMENT_SOURCES.prompt,
+			},
+		});
+
+		expect(rebuilt).toEqual(built);
+	});
+
+	it('emits kind and presence alone for an element a builder produced, which carries no sources', () => {
+		const schema = createCommandSchema({
+			name: 'deploy',
+			flags: { tags: flag.array(flag.string()).schema },
+		});
+
+		expect(generateCommandSchema(schema).flags.tags?.elementSchema).toEqual({
+			kind: 'string',
+			presence: 'optional',
+		});
+	});
+
+	it('emits kind and presence alone for an arg element a builder produced too', () => {
+		const schema = createCommandSchema({
+			name: 'deploy',
+			args: [{ name: 'vars', schema: arg.keyValue(arg.number()).schema }],
+		});
+
+		expect(generateCommandSchema(schema).args[0]?.elementSchema).toEqual({
+			kind: 'number',
+			presence: 'required',
+		});
+	});
+});

--- a/src/core/schema/factory-parity.test.ts
+++ b/src/core/schema/factory-parity.test.ts
@@ -330,7 +330,10 @@ function withoutReference(text: string | undefined): string | undefined {
 async function sourcedVerdict(schema: CommandSchema, options: ResolveOptions): Promise<Verdict> {
 	const error = await resolve(schema, parse(schema, []), options).then(
 		() => undefined,
-		(thrown: unknown) => (isValidationError(thrown) ? thrown : undefined),
+		(thrown: unknown) => {
+			if (!isValidationError(thrown)) throw thrown;
+			return thrown;
+		},
 	);
 	return {
 		accepted: error === undefined,

--- a/src/core/schema/factory-parity.test.ts
+++ b/src/core/schema/factory-parity.test.ts
@@ -8,12 +8,18 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { isValidationError } from '#internals/core/errors/index.ts';
+import { parse } from '#internals/core/parse/index.ts';
+import type { ResolveOptions } from '#internals/core/resolve/index.ts';
+import { resolve } from '#internals/core/resolve/index.ts';
 import { runCommand } from '#internals/core/testkit/index.ts';
 import type { ArgBuilder, ArgConfig } from './arg.ts';
-import { arg } from './arg.ts';
-import { command } from './command.ts';
+import { arg, createArgSchema } from './arg.ts';
+import type { CommandSchema } from './command.ts';
+import { command, createCommandSchema } from './command.ts';
 import type { FlagBuilder, FlagConfig } from './flag.ts';
-import { flag } from './flag.ts';
+import { createFlagSchema, flag } from './flag.ts';
+import type { PromptConfig } from './prompt.ts';
 import type { StandardSchemaV1 } from './standard.ts';
 import type { ValueInput, ValueSchema } from './value.ts';
 import { argValueSchema, decodeValue, flagValueSchema, valueEnumValues } from './value.ts';
@@ -301,6 +307,290 @@ describe('flag.string() / arg.string() constraint parity', () => {
 			constraint: 'minLength',
 			bound: 5,
 		});
+	});
+});
+
+// === the same failures, read off a source the user did not type
+
+/**
+ * Normalize the subject out of an off-argv diagnostic.
+ *
+ * The reference appears in the message and in the suggestion alike, and the two
+ * surfaces spell it differently, so both spellings collapse onto one token.
+ */
+function withoutReference(text: string | undefined): string | undefined {
+	return text
+		?.replaceAll('flag --x', '<subject>')
+		.replaceAll('argument <x>', '<subject>')
+		.replaceAll('--x', '<subject>')
+		.replaceAll('<x>', '<subject>');
+}
+
+/** Report what resolving one schema did, with the subject normalized away. */
+async function sourcedVerdict(schema: CommandSchema, options: ResolveOptions): Promise<Verdict> {
+	const error = await resolve(schema, parse(schema, []), options).then(
+		() => undefined,
+		(thrown: unknown) => (isValidationError(thrown) ? thrown : undefined),
+	);
+	return {
+		accepted: error === undefined,
+		code: error?.code,
+		reason: withoutReference(error?.message),
+		value: undefined,
+	};
+}
+
+/** Resolve one flag from the environment and report the verdict. */
+async function flagEnvVerdict<C extends FlagConfig>(
+	builder: FlagBuilder<C>,
+	raw: string,
+): Promise<Verdict> {
+	const schema = createCommandSchema({ name: 'subject', flags: { x: builder.env('VAR').schema } });
+	return sourcedVerdict(schema, { env: { VAR: raw } });
+}
+
+/** Resolve one positional from the environment and report the verdict. */
+async function argEnvVerdict<C extends ArgConfig>(
+	builder: ArgBuilder<C>,
+	raw: string,
+): Promise<Verdict> {
+	const schema = createCommandSchema({
+		name: 'subject',
+		args: [{ name: 'x', schema: builder.env('VAR').schema }],
+	});
+	return sourcedVerdict(schema, { env: { VAR: raw } });
+}
+
+/** Resolve one flag from a config value of any shape and report the verdict. */
+async function flagConfigVerdict<C extends FlagConfig>(
+	builder: FlagBuilder<C>,
+	raw: unknown,
+): Promise<Verdict> {
+	const schema = createCommandSchema({ name: 'subject', flags: { x: builder.config('p').schema } });
+	return sourcedVerdict(schema, { config: { p: raw } });
+}
+
+/** Resolve one positional from a config value of any shape and report the verdict. */
+async function argConfigVerdict<C extends ArgConfig>(
+	builder: ArgBuilder<C>,
+	raw: unknown,
+): Promise<Verdict> {
+	const schema = createCommandSchema({
+		name: 'subject',
+		args: [{ name: 'x', schema: builder.config('p').schema }],
+	});
+	return sourcedVerdict(schema, { config: { p: raw } });
+}
+
+describe('an environment value fails the same way on both surfaces', () => {
+	const cases: ReadonlyArray<
+		readonly [string, () => FlagBuilder<FlagConfig>, () => ArgBuilder<ArgConfig>, string]
+	> = [
+		['a number', () => flag.number(), () => arg.number(), 'nope'],
+		['a boolean', () => flag.boolean(), () => arg.boolean(), 'nope'],
+		['an enum', () => flag.enum(['us', 'eu']), () => arg.enum(['us', 'eu']), 'mars'],
+		['a length bound', () => flag.string().minLength(9), () => arg.string().minLength(9), 'short'],
+		[
+			'a pattern',
+			() => flag.string().pattern(/^ghp_/),
+			() => arg.string().pattern(/^ghp_/),
+			'nope',
+		],
+		['a numeric bound', () => flag.number().min(1000), () => arg.number().min(1000), '5'],
+		['an integer', () => flag.number().int(), () => arg.number().int(), '1.5'],
+		['a url', () => flag.url(), () => arg.url(), 'nope'],
+		[
+			'a url protocol',
+			() => flag.url({ protocols: ['https'] }),
+			() => arg.url({ protocols: ['https'] }),
+			'http://example.com',
+		],
+		['a date', () => flag.date(), () => arg.date(), 'nope'],
+		['a duration', () => flag.duration(), () => arg.duration(), 'nope'],
+		['a size', () => flag.bytes(), () => arg.bytes(), 'nope'],
+		[
+			'a thrown message holding colons',
+			() =>
+				flag.custom(() => {
+					throw new Error('bad input: really bad');
+				}),
+			() =>
+				arg.custom(() => {
+					throw new Error('bad input: really bad');
+				}),
+			'anything',
+		],
+	];
+
+	for (const [label, flagBuilder, argBuilder, raw] of cases) {
+		it(`rejects ${label} with the same code and reason`, async () => {
+			const forFlag = await flagEnvVerdict(flagBuilder(), raw);
+			const forArg = await argEnvVerdict(argBuilder(), raw);
+
+			expect(forFlag.accepted).toBe(false);
+			expect(forArg.code).toBe(forFlag.code);
+			expect(forArg.reason).toBe(forFlag.reason);
+		});
+	}
+
+	it('rejects a config value no string codec can read with the same reason', async () => {
+		const forFlag = await flagConfigVerdict(flag.string(), {});
+		const forArg = await argConfigVerdict(arg.string(), {});
+
+		expect(forArg.code).toBe(forFlag.code);
+		expect(forArg.reason).toBe(forFlag.reason);
+		expect(forFlag.reason).toBe('Invalid string value from config p for <subject>');
+	});
+});
+
+// === a collection given the wrong shape
+
+describe('a config value of the wrong shape fails the same way on both surfaces', () => {
+	it('names the array a list wanted', async () => {
+		const forFlag = await flagConfigVerdict(flag.array(flag.string()), 5);
+		const forArg = await argConfigVerdict(arg.string().variadic(), 5);
+
+		expect(forArg.code).toBe(forFlag.code);
+		expect(forArg.reason).toBe(forFlag.reason);
+		expect(forFlag.reason).toBe('Invalid array value from config p for <subject>');
+	});
+
+	it('names the object a key-value input wanted', async () => {
+		const forFlag = await flagConfigVerdict(flag.keyValue(), 5);
+		const forArg = await argConfigVerdict(arg.keyValue(), 5);
+
+		expect(forArg.code).toBe(forFlag.code);
+		expect(forArg.reason).toBe(forFlag.reason);
+		expect(forFlag.reason).toBe('Invalid object value from config p for <subject>');
+	});
+
+	it('names the array a list wanted when the config value is an object', async () => {
+		const forFlag = await flagConfigVerdict(flag.array(flag.string()), { a: 1 });
+		const forArg = await argConfigVerdict(arg.string().variadic(), { a: 1 });
+
+		expect(forArg.reason).toBe(forFlag.reason);
+		expect(forFlag.reason).toBe('Invalid array value from config p for <subject>');
+	});
+
+	it('carries the same expected detail on both surfaces', async () => {
+		const flagSchema = createCommandSchema({
+			name: 'subject',
+			flags: { x: flag.keyValue().config('p').schema },
+		});
+		const argSchema = createCommandSchema({
+			name: 'subject',
+			args: [{ name: 'x', schema: arg.keyValue().config('p').schema }],
+		});
+		const options = { config: { p: 5 } };
+
+		const forFlag = await resolve(flagSchema, parse(flagSchema, []), options).catch(
+			(thrown: unknown) => thrown,
+		);
+		const forArg = await resolve(argSchema, parse(argSchema, []), options).catch(
+			(thrown: unknown) => thrown,
+		);
+
+		expect(isValidationError(forFlag) && forFlag.details).toEqual({
+			flag: 'x',
+			source: 'config',
+			configPath: 'p',
+			expected: 'object',
+		});
+		expect(isValidationError(forArg) && forArg.details).toEqual({
+			arg: 'x',
+			source: 'config',
+			configPath: 'p',
+			expected: 'object',
+		});
+	});
+});
+
+// === prompt kinds follow the cardinality, not the kind alone
+
+describe('an input that collects several values takes the same prompt on both surfaces', () => {
+	/** Resolve one input from a prompt answer and report the verdict. */
+	async function promptVerdict(
+		schema: CommandSchema,
+		answer: unknown,
+	): Promise<Verdict & { readonly resolved: unknown }> {
+		let resolved: unknown;
+		const prompter = { promptOne: () => Promise.resolve({ answered: true, value: answer }) };
+		const error = await resolve(schema, parse(schema, []), { prompter }).then(
+			(result) => {
+				resolved = result.flags.x ?? result.args.x;
+				return undefined;
+			},
+			(thrown: unknown) => (isValidationError(thrown) ? thrown : undefined),
+		);
+		return {
+			accepted: error === undefined,
+			code: error?.code,
+			reason: withoutReference(error?.message),
+			value: undefined,
+			resolved,
+		};
+	}
+
+	/** A command carrying one list flag with the given prompt config. */
+	function flagWith(prompt: PromptConfig): CommandSchema {
+		return createCommandSchema({
+			name: 'subject',
+			flags: {
+				x: createFlagSchema('array', { elementSchema: flag.string().schema, prompt }),
+			},
+		});
+	}
+
+	/** A command carrying one variadic positional with the given prompt config. */
+	function argWith(prompt: PromptConfig): CommandSchema {
+		return createCommandSchema({
+			name: 'subject',
+			args: [{ name: 'x', schema: createArgSchema('string', { variadic: true, prompt }) }],
+		});
+	}
+
+	it('takes a multiselect answer on both surfaces', async () => {
+		const prompt: PromptConfig = {
+			kind: 'multiselect',
+			message: 'Pick',
+			choices: [{ value: 'a' }, { value: 'b' }],
+		};
+		const forFlag = await promptVerdict(flagWith(prompt), ['a', 'b']);
+		const forArg = await promptVerdict(argWith(prompt), ['a', 'b']);
+
+		expect(forFlag.accepted).toBe(true);
+		expect(forArg.accepted).toBe(true);
+		expect(forArg.resolved).toEqual(forFlag.resolved);
+		expect(forArg.resolved).toEqual(['a', 'b']);
+	});
+
+	for (const kind of ['input', 'select', 'confirm'] as const) {
+		it(`rejects a ${kind} prompt with the same code and reason`, async () => {
+			const prompt: PromptConfig = { kind, message: 'Pick' };
+			const forFlag = await promptVerdict(flagWith(prompt), 'a');
+			const forArg = await promptVerdict(argWith(prompt), 'a');
+
+			expect(forFlag.accepted).toBe(false);
+			expect(forArg.code).toBe(forFlag.code);
+			expect(forArg.code).toBe('CONSTRAINT_VIOLATED');
+			expect(forFlag.reason).toBe(
+				`Prompt kind '${kind}' is not compatible with array <subject>. Use 'multiselect' instead`,
+			);
+			expect(forArg.reason).toBe(
+				`Prompt kind '${kind}' is not compatible with variadic string <subject>. Use 'multiselect' instead`,
+			);
+		});
+	}
+
+	it('rejects prompts on key-value definitions at both factory boundaries', () => {
+		const prompt: PromptConfig = { kind: 'input', message: 'Pick' };
+
+		expect(() => createFlagSchema('keyValue', { prompt })).toThrow(
+			"Flag schema field 'prompt' is not available on kind 'keyValue'",
+		);
+		expect(() => createArgSchema('keyValue', { prompt })).toThrow(
+			"Arg schema field 'prompt' is not available on kind 'keyValue'",
+		);
 	});
 });
 

--- a/src/core/schema/flag-element-eligibility.test.ts
+++ b/src/core/schema/flag-element-eligibility.test.ts
@@ -9,7 +9,7 @@
  * @module dreamcli/core/schema/flag-element-eligibility.test
  */
 
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it, test } from 'vitest';
 import { parse } from '#internals/core/parse/index.ts';
 import { command } from './command.ts';
 import { flag, type InferFlag } from './flag.ts';
@@ -42,38 +42,112 @@ describe('flag.array() element eligibility', () => {
 		);
 	});
 
-	it('rejects builders carrying flag-level settings elements would ignore', () => {
-		// @ts-expect-error — element aliases are never read
-		flag.array(flag.string().alias('s'));
-		// @ts-expect-error — element env bindings are never read
-		flag.array(flag.string().env('TAGS'));
-		// @ts-expect-error — element config paths are never read
-		flag.array(flag.string().config('deploy.tags'));
-		// @ts-expect-error — element defaults are never read (default the array)
-		flag.array(flag.string().default('x'));
-		// @ts-expect-error — element requiredness is never read (require the array)
-		flag.array(flag.string().required());
-		// @ts-expect-error — element descriptions are never read (describe the array)
-		flag.array(flag.string().describe('a tag'));
-		// @ts-expect-error — element prompts are never read
-		flag.array(flag.string().prompt({ kind: 'input', message: '?' }));
-		// @ts-expect-error — element deprecation is never read
-		flag.array(flag.string().deprecated('use --new'));
-		// @ts-expect-error — element propagation is never read
-		flag.array(flag.string().propagate());
-		// @ts-expect-error — element negation is never read
-		flag.array(flag.boolean().negatable());
-		// @ts-expect-error — element duplicate policy is never read
-		flag.array(flag.string().duplicates('error'));
+	test.each([
+		[
+			'aliases',
+			() => {
+				// @ts-expect-error — element aliases are never read
+				flag.array(flag.string().alias('s'));
+			},
+		],
+		[
+			'environment bindings',
+			() => {
+				// @ts-expect-error — element env bindings are never read
+				flag.array(flag.string().env('TAGS'));
+			},
+		],
+		[
+			'config paths',
+			() => {
+				// @ts-expect-error — element config paths are never read
+				flag.array(flag.string().config('deploy.tags'));
+			},
+		],
+		[
+			'defaults',
+			() => {
+				// @ts-expect-error — element defaults are never read (default the array)
+				flag.array(flag.string().default('x'));
+			},
+		],
+		[
+			'requiredness',
+			() => {
+				// @ts-expect-error — element requiredness is never read (require the array)
+				flag.array(flag.string().required());
+			},
+		],
+		[
+			'descriptions',
+			() => {
+				// @ts-expect-error — element descriptions are never read (describe the array)
+				flag.array(flag.string().describe('a tag'));
+			},
+		],
+		[
+			'prompts',
+			() => {
+				// @ts-expect-error — element prompts are never read
+				flag.array(flag.string().prompt({ kind: 'input', message: '?' }));
+			},
+		],
+		[
+			'deprecation',
+			() => {
+				// @ts-expect-error — element deprecation is never read
+				flag.array(flag.string().deprecated('use --new'));
+			},
+		],
+		[
+			'propagation',
+			() => {
+				// @ts-expect-error — element propagation is never read
+				flag.array(flag.string().propagate());
+			},
+		],
+		[
+			'negation',
+			() => {
+				// @ts-expect-error — element negation is never read
+				flag.array(flag.boolean().negatable());
+			},
+		],
+		[
+			'duplicate policies',
+			() => {
+				// @ts-expect-error — element duplicate policy is never read
+				flag.array(flag.string().duplicates('error'));
+			},
+		],
+	])('rejects builders carrying %s', (_field, build) => {
+		expect(build).toThrow(/Flag element schema field/);
 	});
 
-	it('rejects kinds that are not element-meaningful', () => {
-		// @ts-expect-error — nested arrays are unsupported
-		flag.array(flag.array(flag.string()));
-		// @ts-expect-error — count accumulates occurrences, not values
-		flag.array(flag.count());
-		// @ts-expect-error — keyValue accumulates into a record, not an array
-		flag.array(flag.keyValue());
+	test.each([
+		[
+			'array',
+			() => {
+				// @ts-expect-error — nested arrays are unsupported
+				flag.array(flag.array(flag.string()));
+			},
+		],
+		[
+			'count',
+			() => {
+				// @ts-expect-error — count accumulates occurrences, not values
+				flag.array(flag.count());
+			},
+		],
+		[
+			'keyValue',
+			() => {
+				// @ts-expect-error — keyValue accumulates into a record, not an array
+				flag.array(flag.keyValue());
+			},
+		],
+	])('rejects %s elements', (_kind, build) => {
+		expect(build).toThrow(/Flag element schema kind/);
 	});
 
 	it('flag-level modifiers still chain freely on the array itself', () => {

--- a/src/core/schema/flag.test.ts
+++ b/src/core/schema/flag.test.ts
@@ -88,14 +88,13 @@ describe('flag.number() chained constraint methods', () => {
 		expect(base.schema.numberConstraints).toEqual({ min: 0 });
 	});
 
-	it('constraint methods are number-kind only at compile time', () => {
+	it('constraint methods are number-kind only, at compile time and construction time', () => {
 		// @ts-expect-error — .min() is not available on string flags
-		flag.string().min(0);
+		expect(() => flag.string().min(0)).toThrow(/requires kind 'number'/);
 		// @ts-expect-error — .int() is not available on boolean flags
-		flag.boolean().int();
+		expect(() => flag.boolean().int()).toThrow(/requires kind 'number'/);
 		// @ts-expect-error — .finite() is not available on enum flags
-		flag.enum(['a', 'b']).finite();
-		expect(true).toBe(true);
+		expect(() => flag.enum(['a', 'b']).finite()).toThrow(/requires kind 'number'/);
 	});
 });
 

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -16,6 +16,7 @@ import {
 	DUPLICATE_KEYS,
 	defaultViolationError,
 	flagCardinality,
+	indefiniteArticle,
 	isCollection,
 	normalizeSplitOptions,
 	normalizeSplitPolicy,
@@ -860,9 +861,13 @@ const KIND_SPECIFIC_FLAG_FIELDS: readonly (readonly [
  *
  * @param kind - Declared kind of the definition.
  * @param fields - Definition fields excluding the kind discriminator.
- * @throws {CLIError} With code `'INVALID_SCHEMA'` on a kind mismatch.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` on an unknown kind or a kind
+ *   mismatch.
+ * @internal
  */
 function assertValidFlagDefinition(kind: FlagKind, fields: FlagDefinitionFields): void {
+	assertKnownFlagKind(kind);
+
 	for (const [field, requiredKinds] of KIND_SPECIFIC_FLAG_FIELDS) {
 		if (requiredKinds.includes(kind)) continue;
 		if (fields[field] === undefined) continue;
@@ -920,6 +925,27 @@ function assertValidFlagDefinition(kind: FlagKind, fields: FlagDefinitionFields)
 	if (fields.stdin !== undefined) {
 		assertStdinCapableKind(kind);
 	}
+}
+
+/**
+ * Reject a discriminator outside {@link FLAG_KINDS}.
+ *
+ * The types admit only a declared kind, so this catches an untyped JavaScript
+ * caller before an unknown discriminator reaches an exhaustive `switch` that
+ * has no arm for it.
+ *
+ * @param kind - Declared kind of the definition.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` on an unknown kind.
+ * @internal
+ */
+function assertKnownFlagKind(kind: FlagKind): void {
+	if (FLAG_KINDS.includes(kind)) return;
+
+	throw new CLIError(`Unknown flag kind '${String(kind)}'`, {
+		code: 'INVALID_SCHEMA',
+		details: { kind, allowed: [...FLAG_KINDS] },
+		suggest: `Use one of: ${FLAG_KINDS.join(', ')}`,
+	});
 }
 
 /**
@@ -1055,9 +1081,7 @@ function assertValidFlagDefault(name: string | undefined, schema: FlagSchema): v
 	);
 	if (violation === undefined) return;
 	throw defaultViolationError(
-		name === undefined
-			? `${schema.kind === 'enum' || schema.kind === 'array' ? 'an' : 'a'} ${schema.kind} flag`
-			: `flag --${name}`,
+		name === undefined ? `${indefiniteArticle(schema.kind)} ${schema.kind} flag` : `flag --${name}`,
 		{ kind: schema.kind, ...(name === undefined ? {} : { flag: name }) },
 		violation,
 	);
@@ -1629,6 +1653,8 @@ class FlagBuilder<C extends FlagConfig> {
 	 *
 	 * @param value - Separator string (e.g. `','`).
 	 * @returns The builder (for chaining).
+	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on a flag that carries a
+	 *   single value.
 	 *
 	 * @example
 	 * ```ts
@@ -1641,7 +1667,7 @@ class FlagBuilder<C extends FlagConfig> {
 		value: string,
 	): FlagBuilder<C> {
 		normalizeSplitPolicy('cli', value);
-		return new FlagBuilder({ ...this.schema, separator: value });
+		return nextFlag({ ...this.schema, separator: value });
 	}
 
 	/**
@@ -1660,7 +1686,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * @param options - Per-source split settings.
 	 * @returns The builder (for chaining).
 	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on a format the source does
-	 *   not accept, or an empty delimiter.
+	 *   not accept, an empty delimiter, or a flag that carries a single value.
 	 *
 	 * @example
 	 * ```ts
@@ -1674,7 +1700,7 @@ class FlagBuilder<C extends FlagConfig> {
 		options: SplitOptions,
 	): FlagBuilder<C> {
 		const normalized = normalizeSplitOptions(options, this.schema.split);
-		return new FlagBuilder({
+		return nextFlag({
 			...this.schema,
 			...(normalized.setsSeparator ? { separator: normalized.separator } : {}),
 			split: normalized.split,
@@ -1690,19 +1716,21 @@ class FlagBuilder<C extends FlagConfig> {
 	 *
 	 * @param policy - `'last'` (default), `'first'`, or `'error'`.
 	 * @returns The builder (for chaining).
+	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on a flag that is not
+	 *   `keyValue`.
 	 *
 	 * @example
 	 * ```ts
 	 * flag.keyValue().duplicateKeys('error').env('VARS')
 	 * // $ VARS='A=1,A=2' mycli run
-	 * // #   → Duplicate key 'A' from env VARS for flag --env  (CONSTRAINT_VIOLATED)
+	 * // #   → Duplicate key '<redacted>' from env VARS for flag --env  (CONSTRAINT_VIOLATED)
 	 * ```
 	 */
 	duplicateKeys(
 		this: FlagBuilder<C & { readonly flagKind: 'keyValue' }>,
 		policy: DuplicateKeys,
 	): FlagBuilder<C> {
-		return new FlagBuilder({ ...this.schema, duplicateKeys: policy });
+		return nextFlag({ ...this.schema, duplicateKeys: policy });
 	}
 
 	/**
@@ -1737,6 +1765,8 @@ class FlagBuilder<C extends FlagConfig> {
 	 * @param value - Whether to deduplicate.
 	 * @defaultValue `true`
 	 * @returns The builder (for chaining).
+	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on a flag that is not
+	 *   `array`.
 	 *
 	 * @example
 	 * ```ts
@@ -1745,7 +1775,7 @@ class FlagBuilder<C extends FlagConfig> {
 	 * ```
 	 */
 	unique(this: FlagBuilder<C & { readonly flagKind: 'array' }>, value = true): FlagBuilder<C> {
-		return new FlagBuilder({ ...this.schema, unique: value });
+		return nextFlag({ ...this.schema, unique: value });
 	}
 
 	// -- Boolean modifiers -----------------------------------------------------
@@ -1762,6 +1792,8 @@ class FlagBuilder<C extends FlagConfig> {
 	 * @param options - Optional custom spelling (`alias`, without `--`) and
 	 *   `hidden` to keep the negated spelling parseable but unadvertised.
 	 * @returns The builder (for chaining).
+	 * @throws {CLIError} With code `'INVALID_SCHEMA'` on a flag that is not
+	 *   `boolean`.
 	 *
 	 * @example
 	 * ```ts
@@ -1774,7 +1806,7 @@ class FlagBuilder<C extends FlagConfig> {
 		this: FlagBuilder<C & { readonly flagKind: 'boolean' }>,
 		options?: { alias?: string; hidden?: boolean },
 	): FlagBuilder<WithoutElementEligibility<C>> {
-		return new FlagBuilder({
+		return nextFlag({
 			...this.schema,
 			negation: { alias: options?.alias, hidden: options?.hidden ?? false },
 		});
@@ -1806,21 +1838,30 @@ class FlagBuilder<C extends FlagConfig> {
 		>,
 		policy: DuplicatePolicy,
 	): FlagBuilder<WithoutElementEligibility<C>> {
-		return new FlagBuilder({ ...this.schema, duplicates: policy });
+		return nextFlag({ ...this.schema, duplicates: policy });
 	}
 }
 
 /**
- * Continue a builder chain, rejecting a default the change just invalidated.
+ * Continue a builder chain, rejecting a schema the change just invalidated.
+ *
+ * The `this` constraint on each modifier states to the compiler which kinds
+ * carry the field it sets; this states the same rule to a caller who reaches
+ * the builder from JavaScript, with the error {@link createFlagSchema} already
+ * gives, so what a builder produces is always a definition the framework can
+ * read back.
  *
  * A constraint added after `.default()` still governs the default, so the
  * verdict is the same whichever order the chain was written in.
  *
  * @param schema - The schema the modifier produced.
  * @returns A builder over that schema.
- * @throws {CLIError} With code `'INVALID_DEFAULT'` when the default no longer holds.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` when the field does not belong
+ *   on the flag, or `'INVALID_DEFAULT'` when the default no longer holds.
+ * @internal
  */
 function nextFlag<C extends FlagConfig>(schema: FlagSchema): FlagBuilder<C> {
+	assertValidFlagDefinition(schema.kind, schema);
 	assertValidFlagDefault(undefined, schema);
 	return new FlagBuilder(schema);
 }
@@ -2260,6 +2301,7 @@ const flag: FlagFactory = {
 		readonly flagKind: 'array';
 		readonly elementEligible: false;
 	}> {
+		assertFlagElementBuilder('array', element);
 		return new FlagBuilder(createFlagSchema('array', { elementSchema: element.schema }));
 	},
 
@@ -2356,6 +2398,7 @@ const flag: FlagFactory = {
 		readonly flagKind: 'keyValue';
 		readonly elementEligible: false;
 	}> {
+		if (element !== undefined) assertFlagElementBuilder('keyValue', element);
 		return new FlagBuilder(
 			createFlagSchema('keyValue', {
 				valueHint: 'key=value',
@@ -2364,6 +2407,28 @@ const flag: FlagFactory = {
 		);
 	},
 };
+
+/**
+ * Reject a collection factory handed something other than a flag builder.
+ *
+ * The types demand one, so this catches an untyped JavaScript caller before the
+ * factory reads `.schema` off a value that has none.
+ *
+ * @param factory - Name of the factory being called.
+ * @param element - What the caller passed as the element.
+ * @throws {CLIError} With code `'INVALID_SCHEMA'` when it is not a
+ *   {@link FlagBuilder}.
+ * @internal
+ */
+function assertFlagElementBuilder(factory: 'array' | 'keyValue', element: unknown): void {
+	if (element instanceof FlagBuilder) return;
+
+	throw new CLIError(`flag.${factory}() requires an element builder`, {
+		code: 'INVALID_SCHEMA',
+		details: { factory, field: 'element', received: typeof element },
+		suggest: `Pass an element builder, as in flag.${factory}(flag.string())`,
+	});
+}
 
 // --- Exports
 

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -772,8 +772,8 @@ function isNormalizedFlagSchema(element: FlagDefinition | FlagSchema): element i
 	return NORMALIZED_FLAG_SCHEMA_KEYS.every((key) => key in element);
 }
 
-/** Reject flag-level fields on a collection element's value schema. */
-function assertValidFlagElementSchema(schema: FlagSchema): void {
+/** Reject flag-level fields on a collection factory's element builder. */
+function assertEligibleFlagElementBuilder(schema: FlagSchema): void {
 	if (COLLECTION_FLAG_KINDS.includes(schema.kind) || schema.kind === 'count') {
 		throw new CLIError(`Flag element schema kind '${schema.kind}' is not supported`, {
 			code: 'INVALID_SCHEMA',
@@ -783,8 +783,8 @@ function assertValidFlagElementSchema(schema: FlagSchema): void {
 	}
 
 	const defaults: readonly (readonly [keyof FlagSchema, unknown])[] = [
-		['presence', 'optional'],
-		['defaultValue', undefined],
+		['presence', schema.kind === 'boolean' ? 'defaulted' : 'optional'],
+		['defaultValue', schema.kind === 'boolean' ? false : undefined],
 		['stdin', undefined],
 		['envVar', undefined],
 		['configPath', undefined],
@@ -832,15 +832,12 @@ function assertValidFlagElementSchema(schema: FlagSchema): void {
 function normalizeFlagElementSchema(element: FlagDefinition | FlagSchema): FlagSchema {
 	if (isNormalizedFlagSchema(element)) {
 		assertValidFlagDefinition(element.kind, element);
-		assertValidFlagElementSchema(element);
 		return element;
 	}
 
 	const { kind, ...fields } = element;
 	assertValidFlagDefinition(kind, fields);
-	const schema = buildFlagSchema(kind, normalizeFlagDefinitionFields(fields));
-	assertValidFlagElementSchema(schema);
-	return schema;
+	return buildFlagSchema(kind, normalizeFlagDefinitionFields(fields));
 }
 
 /**
@@ -2474,7 +2471,7 @@ const flag: FlagFactory = {
  */
 function assertFlagElementBuilder(factory: 'array' | 'keyValue', element: unknown): void {
 	if (element instanceof FlagBuilder) {
-		assertValidFlagElementSchema(element.schema);
+		assertEligibleFlagElementBuilder(element.schema);
 		return;
 	}
 

--- a/src/core/schema/flag.ts
+++ b/src/core/schema/flag.ts
@@ -772,6 +772,52 @@ function isNormalizedFlagSchema(element: FlagDefinition | FlagSchema): element i
 	return NORMALIZED_FLAG_SCHEMA_KEYS.every((key) => key in element);
 }
 
+/** Reject flag-level fields on a collection element's value schema. */
+function assertValidFlagElementSchema(schema: FlagSchema): void {
+	if (COLLECTION_FLAG_KINDS.includes(schema.kind) || schema.kind === 'count') {
+		throw new CLIError(`Flag element schema kind '${schema.kind}' is not supported`, {
+			code: 'INVALID_SCHEMA',
+			details: { kind: schema.kind, field: 'kind' },
+			suggest: 'Use a scalar value kind for the collection element',
+		});
+	}
+
+	const defaults: readonly (readonly [keyof FlagSchema, unknown])[] = [
+		['presence', 'optional'],
+		['defaultValue', undefined],
+		['stdin', undefined],
+		['envVar', undefined],
+		['configPath', undefined],
+		['description', undefined],
+		['elementSchema', undefined],
+		['separator', undefined],
+		['split', undefined],
+		['duplicateKeys', 'last'],
+		['unique', false],
+		['prompt', undefined],
+		['aggregateStandard', undefined],
+		['deprecated', undefined],
+		['propagate', false],
+		['negation', undefined],
+		['duplicates', 'last'],
+	];
+	for (const [field, allowed] of defaults) {
+		if (schema[field] === allowed) continue;
+		throw new CLIError(`Flag element schema field '${String(field)}' is not supported`, {
+			code: 'INVALID_SCHEMA',
+			details: { kind: schema.kind, field },
+			suggest: `Drop '${String(field)}' from the collection element`,
+		});
+	}
+	if (schema.aliases.length !== 0) {
+		throw new CLIError("Flag element schema field 'aliases' is not supported", {
+			code: 'INVALID_SCHEMA',
+			details: { kind: schema.kind, field: 'aliases' },
+			suggest: "Drop 'aliases' from the collection element",
+		});
+	}
+}
+
 /**
  * Normalise an array flag's element input into a built {@link FlagSchema}.
  *
@@ -784,11 +830,17 @@ function isNormalizedFlagSchema(element: FlagDefinition | FlagSchema): element i
  *   different {@link FlagKind}.
  */
 function normalizeFlagElementSchema(element: FlagDefinition | FlagSchema): FlagSchema {
-	if (isNormalizedFlagSchema(element)) return element;
+	if (isNormalizedFlagSchema(element)) {
+		assertValidFlagDefinition(element.kind, element);
+		assertValidFlagElementSchema(element);
+		return element;
+	}
 
 	const { kind, ...fields } = element;
 	assertValidFlagDefinition(kind, fields);
-	return buildFlagSchema(kind, normalizeFlagDefinitionFields(fields));
+	const schema = buildFlagSchema(kind, normalizeFlagDefinitionFields(fields));
+	assertValidFlagElementSchema(schema);
+	return schema;
 }
 
 /**
@@ -2421,7 +2473,10 @@ const flag: FlagFactory = {
  * @internal
  */
 function assertFlagElementBuilder(factory: 'array' | 'keyValue', element: unknown): void {
-	if (element instanceof FlagBuilder) return;
+	if (element instanceof FlagBuilder) {
+		assertValidFlagElementSchema(element.schema);
+		return;
+	}
 
 	throw new CLIError(`flag.${factory}() requires an element builder`, {
 		code: 'INVALID_SCHEMA',

--- a/src/core/schema/index.ts
+++ b/src/core/schema/index.ts
@@ -39,7 +39,9 @@ export type {
 	PromptConfigByArgKind,
 	ResolvedArgValue,
 	StringArgDefinition,
+	StringArgElementConfig,
 	WithArgPresence,
+	WithoutArgElementEligibility,
 	WithVariadic,
 } from './arg.ts';
 export { ARG_KINDS, ARG_PRESENCES, ArgBuilder, arg, createArgSchema } from './arg.ts';
@@ -115,6 +117,7 @@ export type {
 	StringElementConfig,
 	StringFlagDefinition,
 	UrlFlagOptions,
+	WithoutElementEligibility,
 	WithPresence,
 } from './flag.ts';
 export {

--- a/src/core/schema/input-modifier-guards.test.ts
+++ b/src/core/schema/input-modifier-guards.test.ts
@@ -8,8 +8,8 @@
 
 import { describe, expect, it } from 'vitest';
 import { CLIError } from '#internals/core/errors/index.ts';
-import { arg, createArgSchema } from './arg.ts';
-import { createFlagSchema, flag } from './flag.ts';
+import { ARG_KINDS, arg, createArgSchema } from './arg.ts';
+import { createFlagSchema, FLAG_KINDS, flag } from './flag.ts';
 
 // --- helpers
 
@@ -154,5 +154,207 @@ describe('.stdin() on a count flag', () => {
 		expect(flag.string().stdin().schema.stdin?.when).toBe('dash-or-missing');
 		expect(flag.array(flag.string()).stdin().schema.stdin?.when).toBe('dash-or-missing');
 		expect(flag.keyValue().stdin().schema.stdin?.when).toBe('dash-or-missing');
+	});
+});
+
+describe('.duplicates() on a collection flag', () => {
+	it('is refused by the builder at run time', () => {
+		// @ts-expect-error .duplicates() is not available on an array flag
+		const error = schemaError(() => flag.array(flag.string()).duplicates('first'));
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toBe("Flag schema field 'duplicates' is not supported on kind 'array'");
+	});
+});
+
+// === an unknown kind discriminator
+
+describe('createFlagSchema() rejects a kind outside FLAG_KINDS', () => {
+	it('names the allowed kinds on the two-argument path', () => {
+		// @ts-expect-error 'nope' is not a FlagKind
+		const error = schemaError(() => createFlagSchema('nope'));
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toBe("Unknown flag kind 'nope'");
+		expect(error.details).toEqual({ kind: 'nope', allowed: [...FLAG_KINDS] });
+		expect(error.suggest).toBe(`Use one of: ${FLAG_KINDS.join(', ')}`);
+	});
+
+	it('rejects the same kind on the definition path', () => {
+		// @ts-expect-error 'nope' is not a FlagKind
+		const error = schemaError(() => createFlagSchema({ kind: 'nope' }));
+		expect(error.message).toBe("Unknown flag kind 'nope'");
+	});
+
+	it('rejects an unknown kind nested in an element schema', () => {
+		const error = schemaError(() =>
+			// @ts-expect-error 'nope' is not a FlagKind
+			createFlagSchema({ kind: 'array', elementSchema: { kind: 'nope' } }),
+		);
+		expect(error.message).toBe("Unknown flag kind 'nope'");
+	});
+
+	it('accepts every declared kind', () => {
+		for (const kind of FLAG_KINDS) {
+			const schema =
+				kind === 'enum'
+					? createFlagSchema(kind, { enumValues: ['value'] })
+					: createFlagSchema(kind);
+			expect(schema.kind).toBe(kind);
+		}
+	});
+});
+
+describe('createArgSchema() rejects a kind outside ARG_KINDS', () => {
+	it('refuses a flag-only kind the arg surface has no arm for', () => {
+		// @ts-expect-error 'count' is not an ArgKind
+		const error = schemaError(() => createArgSchema('count'));
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toBe("Unknown arg kind 'count'");
+		expect(error.details).toEqual({ kind: 'count', allowed: [...ARG_KINDS] });
+		expect(error.suggest).toBe(`Use one of: ${ARG_KINDS.join(', ')}`);
+	});
+
+	it('refuses the array kind, which the arg surface spells as variadic', () => {
+		// @ts-expect-error 'array' is not an ArgKind
+		expect(schemaError(() => createArgSchema('array')).message).toBe("Unknown arg kind 'array'");
+	});
+
+	it('rejects the same kind on the definition path', () => {
+		// @ts-expect-error 'count' is not an ArgKind
+		expect(schemaError(() => createArgSchema({ kind: 'count' })).message).toBe(
+			"Unknown arg kind 'count'",
+		);
+	});
+
+	it('rejects an unknown kind nested in an element schema', () => {
+		const error = schemaError(() =>
+			// @ts-expect-error 'nope' is not an ArgKind
+			createArgSchema({ kind: 'keyValue', elementSchema: { kind: 'nope' } }),
+		);
+		expect(error.message).toBe("Unknown arg kind 'nope'");
+	});
+
+	it('accepts every declared kind', () => {
+		for (const kind of ARG_KINDS) {
+			const schema =
+				kind === 'enum' ? createArgSchema(kind, { enumValues: ['value'] }) : createArgSchema(kind);
+			expect(schema.kind).toBe(kind);
+		}
+	});
+});
+
+// === a collection factory called without its element
+
+describe('flag.array() requires an element builder', () => {
+	it('reports a structured schema error when the element is missing', () => {
+		// @ts-expect-error the element is required
+		const error = schemaError(() => flag.array());
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toBe('flag.array() requires an element builder');
+		expect(error.details).toEqual({ factory: 'array', field: 'element', received: 'undefined' });
+		expect(error.suggest).toBe('Pass an element builder, as in flag.array(flag.string())');
+	});
+
+	it('reports the same error for a value that is not a builder', () => {
+		// @ts-expect-error a plain object is not a FlagBuilder
+		expect(schemaError(() => flag.array({})).details).toEqual({
+			factory: 'array',
+			field: 'element',
+			received: 'object',
+		});
+	});
+
+	it('builds normally with a real element builder', () => {
+		expect(flag.array(flag.number()).schema.elementSchema?.kind).toBe('number');
+	});
+});
+
+describe('the keyValue factories keep their element optional', () => {
+	it('builds without an element on both surfaces', () => {
+		expect(flag.keyValue().schema.elementSchema).toBeUndefined();
+		expect(arg.keyValue().schema.elementSchema).toBeUndefined();
+	});
+
+	it('rejects a supplied element that is not a builder', () => {
+		// @ts-expect-error null is not a FlagBuilder
+		expect(schemaError(() => flag.keyValue(null)).message).toBe(
+			'flag.keyValue() requires an element builder',
+		);
+		// @ts-expect-error a number is not an ArgBuilder
+		expect(schemaError(() => arg.keyValue(0)).message).toBe(
+			'arg.keyValue() requires an element builder',
+		);
+	});
+});
+
+// === what a builder produces is always a definition the framework reads back
+
+describe('a modifier called on a kind that does not carry its field', () => {
+	it('is rejected on the flag builder, with the error the definition path gives', () => {
+		// @ts-expect-error .separator() is not available on a string flag
+		expect(schemaError(() => flag.string().separator(',')).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .split() is not available on a number flag
+		expect(schemaError(() => flag.number().split({ env: ';' })).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .unique() is not available on a keyValue flag
+		expect(schemaError(() => flag.keyValue().unique()).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .duplicateKeys() is not available on an array flag
+		expect(schemaError(() => flag.array(flag.string()).duplicateKeys('first')).code).toBe(
+			'INVALID_SCHEMA',
+		);
+		// @ts-expect-error .negatable() is not available on a count flag
+		expect(schemaError(() => flag.count().negatable()).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .nonEmpty() is not available on an enum flag
+		expect(schemaError(() => flag.enum(['a', 'b']).nonEmpty()).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .min() is not available on a keyValue flag
+		expect(schemaError(() => flag.keyValue().min(1)).code).toBe('INVALID_SCHEMA');
+	});
+
+	it('is rejected on the arg builder, with the error the definition path gives', () => {
+		// @ts-expect-error .separator() is not available on a single-value arg
+		expect(schemaError(() => arg.boolean().separator(',')).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .unique() is not available on a keyValue arg
+		expect(schemaError(() => arg.keyValue().unique()).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .duplicateKeys() is not available on a variadic string arg
+		expect(schemaError(() => arg.string().variadic().duplicateKeys('first')).code).toBe(
+			'INVALID_SCHEMA',
+		);
+		// @ts-expect-error .pattern() is not available on a number arg
+		expect(schemaError(() => arg.number().pattern(/x/)).code).toBe('INVALID_SCHEMA');
+		// @ts-expect-error .finite() is not available on an enum arg
+		expect(schemaError(() => arg.enum(['a', 'b']).finite()).code).toBe('INVALID_SCHEMA');
+	});
+});
+
+describe('every legal modifier leaves a schema its own factory reads back', () => {
+	it('holds for the flag builder', () => {
+		const built = [
+			flag.string().nonEmpty().minLength(2).pattern(/^a/),
+			flag.number().int().min(1).max(9).finite(),
+			flag.boolean().negatable(),
+			flag.enum(['a', 'b']),
+			flag.count(),
+			flag.custom((raw: unknown) => String(raw)),
+			flag.array(flag.string()).separator(',').split({ env: ';', stdin: 'json' }).unique(),
+			flag.keyValue().separator(',').split({ env: ';' }).duplicateKeys('first'),
+			flag.path({ mustExist: true }),
+		];
+		for (const builder of built) {
+			expect(() => createFlagSchema(builder.schema.kind, builder.schema)).not.toThrow();
+		}
+	});
+
+	it('holds for the arg builder', () => {
+		const built = [
+			arg.string().nonEmpty().minLength(2).pattern(/^a/),
+			arg.number().int().min(1).max(9).finite(),
+			arg.boolean(),
+			arg.enum(['a', 'b']),
+			arg.custom((raw: string) => raw),
+			arg.string().variadic().separator(',').split({ env: ';', stdin: 'json' }).unique(),
+			arg.keyValue().separator(',').split({ env: ';' }).duplicateKeys('first'),
+			arg.path({ mustExist: true }),
+		];
+		for (const builder of built) {
+			expect(() => createArgSchema(builder.schema.kind, builder.schema)).not.toThrow();
+		}
 	});
 });

--- a/src/core/schema/input-modifier-guards.test.ts
+++ b/src/core/schema/input-modifier-guards.test.ts
@@ -266,6 +266,18 @@ describe('flag.array() requires an element builder', () => {
 	it('builds normally with a real element builder', () => {
 		expect(flag.array(flag.number()).schema.elementSchema?.kind).toBe('number');
 	});
+
+	it('rejects nested collection builders at run time', () => {
+		const error = schemaError(() => flag.array(flag.array(flag.string()) as never));
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toBe("Flag element schema kind 'array' is not supported");
+	});
+
+	it('rejects source-configured builders at run time', () => {
+		const error = schemaError(() => flag.array(flag.string().env('VALUE') as never));
+		expect(error.code).toBe('INVALID_SCHEMA');
+		expect(error.message).toBe("Flag element schema field 'envVar' is not supported");
+	});
 });
 
 describe('the keyValue factories keep their element optional', () => {

--- a/src/core/schema/prompt.test.ts
+++ b/src/core/schema/prompt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
+import { arg } from './arg.ts';
 import type {
 	AllowedPromptConfig,
 	ConfirmPromptConfig,
@@ -294,6 +295,13 @@ describe('FlagBuilder.prompt()', () => {
 		expect(f.schema.kind).toBe('array');
 		expect(f.schema.prompt?.kind).toBe('multiselect');
 		expectTypeOf<InferFlag<typeof f>>().toEqualTypeOf<string[]>();
+	});
+});
+
+describe('ArgBuilder.prompt()', () => {
+	it('rejects a multiselect prompt on a variadic key-value argument', () => {
+		const variables = arg.keyValue().variadic();
+		expectTypeOf<Parameters<typeof variables.prompt>[0]>().toBeNever();
 	});
 });
 

--- a/src/core/schema/provenance.test.ts
+++ b/src/core/schema/provenance.test.ts
@@ -21,4 +21,21 @@ describe('wasExplicit()', () => {
 			expect(wasExplicit(source)).toBe(expected);
 		});
 	}
+
+	// === L19 — the two readings of explicitness, side by side
+
+	it('parts with the typed-it derivation only on the sources that supplied bytes', () => {
+		const typedIt = (source: ResolutionProvenance | undefined): boolean => source?.stage === 'cli';
+
+		expect(table.map(([, source]) => [wasExplicit(source), typedIt(source)])).toEqual([
+			[true, true],
+			[true, true],
+			[true, false],
+			[true, false],
+			[true, false],
+			[true, false],
+			[false, false],
+			[false, false],
+		]);
+	});
 });

--- a/src/core/schema/string-constraints.test.ts
+++ b/src/core/schema/string-constraints.test.ts
@@ -344,16 +344,15 @@ describe('flag.string() chained constraint methods', () => {
 		expect(base.schema.stringConstraints).toEqual({ minLength: 2 });
 	});
 
-	it('constraint methods are string-kind only at compile time', () => {
+	it('constraint methods are string-kind only, at compile time and construction time', () => {
 		// @ts-expect-error — .nonEmpty() is not available on number flags
-		flag.number().nonEmpty();
+		expect(() => flag.number().nonEmpty()).toThrow(/requires kind 'string'/);
 		// @ts-expect-error — .minLength() is not available on number flags
-		flag.number().minLength(1);
+		expect(() => flag.number().minLength(1)).toThrow(/requires kind 'string'/);
 		// @ts-expect-error — .maxLength() is not available on boolean flags
-		flag.boolean().maxLength(2);
+		expect(() => flag.boolean().maxLength(2)).toThrow(/requires kind 'string'/);
 		// @ts-expect-error — .pattern() is not available on enum flags
-		flag.enum(['a', 'b']).pattern(/^a/);
-		expect(true).toBe(true);
+		expect(() => flag.enum(['a', 'b']).pattern(/^a/)).toThrow(/requires kind 'string'/);
 	});
 });
 

--- a/src/core/schema/value.test.ts
+++ b/src/core/schema/value.test.ts
@@ -179,6 +179,19 @@ describe('number codec', () => {
 		expect(rejected(numberValue(), {}, 'config')).toEqual({ kind: 'type', expected: 'number' });
 	});
 
+	it('rejects blank text from every input', () => {
+		for (const input of ['token', 'stdin', 'env', 'config', 'prompt'] as const) {
+			for (const raw of ['', ' ', '\t', '\n', '\r\n', '  \n ']) {
+				expect(rejected(numberValue(), raw, input)).toEqual({ kind: 'type', expected: 'number' });
+			}
+		}
+	});
+
+	it('keeps the surrounding whitespace of a real number readable', () => {
+		expect(decoded(numberValue(), ' 42 ', 'env')).toBe(42);
+		expect(decoded(numberValue(), '42\n', 'stdin')).toBe(42);
+	});
+
 	// --- constraints
 
 	it('rejects Infinity with no constraints declared', () => {

--- a/src/core/schema/value.ts
+++ b/src/core/schema/value.ts
@@ -181,14 +181,15 @@ const strictStringCodec: ValueCodec<string> = {
 	},
 };
 
-/** Reads a raw value as a number, rejecting `NaN` from every input. */
+/** Reads a raw value as a number, rejecting `NaN` and blank text from every input. */
 const numberCodec: ValueCodec<number> = {
 	name: 'number',
 	decode(raw) {
 		if (typeof raw === 'number') {
 			return Number.isNaN(raw) ? NUMBER_TYPE_FAILURE : { ok: true, value: raw };
 		}
-		if (typeof raw === 'string') {
+		// Number('') and Number(' ') are 0, which would read an empty pipe or env var as zero.
+		if (typeof raw === 'string' && raw.trim() !== '') {
 			const value = Number(raw);
 			if (!Number.isNaN(value)) return { ok: true, value };
 		}

--- a/src/core/testkit/sources-e2e.test.ts
+++ b/src/core/testkit/sources-e2e.test.ts
@@ -271,6 +271,106 @@ describe('sources beside the resolved values', () => {
 	});
 });
 
+// === L19 — the two explicitness readings on a real invocation
+
+describe('explicitness, both readings', () => {
+	/** Both answers for one invocation: the shipped predicate and the typed-it derivation. */
+	async function readings(
+		argv: readonly string[],
+		options?: RunOptions,
+	): Promise<{ readonly supplied: boolean; readonly typedIt: boolean }> {
+		let seen: { readonly supplied: boolean; readonly typedIt: boolean } | undefined;
+		const cmd = command('send')
+			.flag('body', flag.string().stdin().env('BODY').default('fallback'))
+			.action(({ sources }) => {
+				seen = {
+					supplied: wasExplicit(sources.flags.body),
+					typedIt: sources.flags.body?.stage === 'cli',
+				};
+			});
+
+		await runCommand(cmd, [...argv], options);
+		if (seen === undefined) throw new Error('the action never ran');
+		return seen;
+	}
+
+	it('agrees on a typed value', async () => {
+		expect(await readings(['--body', 'typed'])).toEqual({ supplied: true, typedIt: true });
+	});
+
+	it('agrees on an explicit dash, which keeps CLI precedence', async () => {
+		expect(await readings(['--body', '-'], { stdinData: 'piped' })).toEqual({
+			supplied: true,
+			typedIt: true,
+		});
+	});
+
+	it('parts on the stdin fallback, which supplied bytes nobody typed', async () => {
+		expect(await readings([], { stdinData: 'piped' })).toEqual({
+			supplied: true,
+			typedIt: false,
+		});
+	});
+
+	it('parts on an environment value', async () => {
+		expect(await readings([], { env: { BODY: 'from-env' } })).toEqual({
+			supplied: true,
+			typedIt: false,
+		});
+	});
+
+	it('agrees on the declared default', async () => {
+		expect(await readings([])).toEqual({ supplied: false, typedIt: false });
+	});
+});
+
+// === L19 — every handler position reads the same null-prototype record
+
+describe('a name no input declared', () => {
+	it('answers undefined inside middleware', async () => {
+		const seen: Record<string, unknown> = {};
+		const cmd = command('t')
+			.flag('region', flag.string().env('REGION'))
+			.middleware(
+				middleware(({ sources, next }) => {
+					const flags: Record<string, unknown> = sources.flags;
+					const args: Record<string, unknown> = sources.args;
+					seen.flag = flags.toString;
+					seen.arg = args.valueOf;
+					seen.constructor = flags.constructor;
+					seen.declared = flags.region;
+					return next({});
+				}),
+			)
+			.action(() => {});
+
+		await runCommand(cmd, [], { env: { REGION: 'eu' } });
+
+		expect(seen).toEqual({
+			flag: undefined,
+			arg: undefined,
+			constructor: undefined,
+			declared: { stage: 'env', envVar: 'REGION' },
+		});
+	});
+
+	it('answers undefined inside derive', async () => {
+		const seen: Record<string, unknown> = {};
+		const cmd = command('t')
+			.flag('region', flag.string())
+			.derive(({ sources }) => {
+				const flags: Record<string, unknown> = sources.flags;
+				seen.flag = flags.hasOwnProperty;
+				return {};
+			})
+			.action(() => {});
+
+		await runCommand(cmd, []);
+
+		expect(seen).toEqual({ flag: undefined });
+	});
+});
+
 describe('readFlags() provenance', () => {
 	it('hands the whole record to onSources', async () => {
 		const onSources = vi.fn();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
@@ -21,7 +22,12 @@ function hasJsDoc(node: ts.Node): boolean {
 	return ts.getJSDocCommentsAndTags(node).length > 0;
 }
 
-function collectPublicExportsWithoutJsDoc(): readonly string[] {
+interface TypeScriptProject {
+	readonly program: ts.Program;
+	readonly checker: ts.TypeChecker;
+}
+
+function createTypeScriptProject(): TypeScriptProject {
 	const configPath = ts.findConfigFile(
 		repoRoot,
 		(fileName) => ts.sys.fileExists(fileName),
@@ -49,28 +55,43 @@ function collectPublicExportsWithoutJsDoc(): readonly string[] {
 		rootNames: parsedConfig.fileNames,
 		options: parsedConfig.options,
 	});
-	const checker = program.getTypeChecker();
+	return { program, checker: program.getTypeChecker() };
+}
+
+const typescriptProject = createTypeScriptProject();
+
+function sourceFile(file: string): ts.SourceFile {
+	const found = typescriptProject.program.getSourceFile(path.join(repoRoot, file));
+	if (found === undefined) throw new Error(`Expected source file for ${file}`);
+	return found;
+}
+
+function moduleExports(file: string): readonly ts.Symbol[] {
+	const moduleSymbol = typescriptProject.checker.getSymbolAtLocation(sourceFile(file));
+	if (moduleSymbol === undefined) throw new Error(`Expected module symbol for ${file}`);
+	return typescriptProject.checker.getExportsOfModule(moduleSymbol);
+}
+
+function targetSymbol(symbol: ts.Symbol): ts.Symbol {
+	return symbol.flags & ts.SymbolFlags.Alias
+		? typescriptProject.checker.getAliasedSymbol(symbol)
+		: symbol;
+}
+
+function isInternalExport(symbol: ts.Symbol): boolean {
+	return (targetSymbol(symbol).getDeclarations() ?? []).some((declaration) =>
+		ts.getJSDocTags(getDocTarget(declaration)).some((tag) => tag.tagName.text === 'internal'),
+	);
+}
+
+function collectPublicExportsWithoutJsDoc(): readonly string[] {
+	const { checker } = typescriptProject;
 	const missing = new Set<string>();
 	const seen = new Set<string>();
 
 	for (const entryPoint of publicEntryPoints) {
-		const sourceFile = program.getSourceFile(path.join(repoRoot, entryPoint));
-
-		if (sourceFile === undefined) {
-			throw new Error(`Expected source file for ${entryPoint}`);
-		}
-
-		const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
-
-		if (moduleSymbol === undefined) {
-			throw new Error(`Expected module symbol for ${entryPoint}`);
-		}
-
-		for (const exportedSymbol of checker.getExportsOfModule(moduleSymbol)) {
-			const symbol =
-				exportedSymbol.flags & ts.SymbolFlags.Alias
-					? checker.getAliasedSymbol(exportedSymbol)
-					: exportedSymbol;
+		for (const exportedSymbol of moduleExports(entryPoint)) {
+			const symbol = targetSymbol(exportedSymbol);
 			const key = checker.getFullyQualifiedName(symbol);
 
 			if (seen.has(key)) {
@@ -123,7 +144,76 @@ describe('@kjanat/dreamcli', () => {
 	it('keeps public export JSDoc coverage complete', { timeout: 15_000 }, () => {
 		expect(collectPublicExportsWithoutJsDoc()).toEqual([]);
 	});
+
+	// A document leaves the process, so every fragment naming part of its shape
+	// is a type a consumer writes against. `stability.md` classifies them as one
+	// group, and one missing from the barrel is only visible at a consumer's
+	// import.
+	it('re-exports every version 1 fragment type from the barrel', () => {
+		const declared = new Set(
+			moduleExports('src/core/json-schema/index.ts')
+				.filter((symbol) => symbol.getName().endsWith('FragmentV1') && !isInternalExport(symbol))
+				.map((symbol) => symbol.getName()),
+		);
+		const reExported = new Set(moduleExports('src/index.ts').map((symbol) => symbol.getName()));
+
+		expect([...declared].filter((name) => !reExported.has(name))).toEqual([]);
+	});
+
+	// `stability.md` classifies the exports of the four entrypoints, so a type it
+	// classifies and no entrypoint exports is a promise a consumer cannot keep.
+	// Its own "Internal surface" section is where a name is declared unreachable,
+	// so everything above that heading is a claim about the public surface.
+	it('exports every type stability.md classifies as public', () => {
+		const read = (file: string): string => readFileSync(path.join(repoRoot, file), 'utf8');
+
+		const entrypoints = new Set(
+			['src/index.ts', 'src/runtime.ts', 'src/testkit.ts', 'src/version.ts'].flatMap((file) =>
+				moduleExports(file).map((symbol) => symbol.getName()),
+			),
+		);
+
+		const doc = read('docs/reference/stability.md');
+		const publicSection = doc.slice(0, doc.indexOf('## Internal surface'));
+		const cited = new Set(
+			[...publicSection.matchAll(/`([A-Z][A-Za-z0-9]*)`/g)].map((match) => match[1] ?? ''),
+		);
+
+		const declared = collectDeclaredTypeNames();
+		const unreachable = [...cited]
+			.filter((name) => declared.has(name) && !entrypoints.has(name))
+			.sort();
+
+		expect(unreachable).toEqual([]);
+	});
 });
+
+/** Every type, interface, and class name `src/` declares, outside test files. */
+function collectDeclaredTypeNames(): ReadonlySet<string> {
+	const names = new Set<string>();
+	const sourceRoot = path.join(repoRoot, 'src');
+
+	for (const file of typescriptProject.program.getSourceFiles()) {
+		if (!file.fileName.startsWith(sourceRoot) || file.fileName.includes('.test.')) continue;
+
+		const visit = (node: ts.Node): void => {
+			if (
+				(ts.isTypeAliasDeclaration(node) ||
+					ts.isInterfaceDeclaration(node) ||
+					ts.isClassDeclaration(node)) &&
+				node.name !== undefined
+			) {
+				const symbol = typescriptProject.checker.getSymbolAtLocation(node.name);
+				if (symbol !== undefined) names.add(symbol.getName());
+			}
+			ts.forEachChild(node, visit);
+		};
+
+		visit(file);
+	}
+
+	return names;
+}
 
 // === @kjanat/dreamcli/runtime
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,7 @@ export type {
 	StdinOptions,
 	StdinWhen,
 	StringArgDefinition,
+	StringArgElementConfig,
 	StringConstraints,
 	StringConstraintViolation,
 	StringElementConfig,
@@ -280,6 +281,8 @@ export type {
 	TableStream,
 	UrlFlagOptions,
 	WithArgPresence,
+	WithoutArgElementEligibility,
+	WithoutElementEligibility,
 	WithPresence,
 	WithVariadic,
 } from './core/schema/index.ts';

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -18,6 +18,9 @@
  */
 
 export type {
+	DenoNamespace,
+	GlobalForDetect,
+	NodeProcess,
 	Runtime,
 	RuntimeAdapter,
 	TerminalSize,

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -11,16 +11,16 @@ adapter factories, `ExitError`, detection. `createTestAdapter`/`TestAdapterOptio
 
 | File                 | Status      | Lines | Purpose                                                             |
 | -------------------- | ----------- | ----: | ------------------------------------------------------------------- |
-| `adapter.ts`         | **Active**  |   300 | `RuntimeAdapter` interface — process/env/IO abstraction             |
-| `auto.ts`            | **Active**  |   110 | `createAdapter()` — auto-detecting adapter factory                  |
-| `node.ts`            | **Active**  |   278 | `createNodeAdapter()` — Node.js impl (also used for Bun)            |
-| `deno.ts`            | **Active**  |   355 | `createDenoAdapter()` — Deno namespace implementation               |
-| `detect.ts`          | **Active**  |   102 | `detectRuntime()` — Bun/Deno/Node feature detection                 |
-| `paths.ts`           | `@internal` |    56 | XDG/platform path resolution utilities                              |
-| `support.ts`         | `@internal` |   119 | Runtime feature support detection                                   |
-| `test-helpers.ts`    | Test        |    40 | Test adapter helpers (Deno namespace mock, etc.)                    |
-| `node-builtins.d.ts` | Types       |    23 | `@internal` — ambient decls for `node:readline`, `node:fs/promises` |
-| `index.ts`           | Barrel      |    21 | Re-exports `RuntimeAdapter`, adapters, `ExitError`                  |
+| `adapter.ts`         | **Active**  |   398 | `RuntimeAdapter` interface — process/env/IO abstraction             |
+| `auto.ts`            | **Active**  |    87 | `createAdapter()` — auto-detecting adapter factory                  |
+| `node.ts`            | **Active**  |   373 | `createNodeAdapter()` — Node.js impl (also used for Bun)            |
+| `deno.ts`            | **Active**  |   446 | `createDenoAdapter()` — Deno namespace implementation               |
+| `detect.ts`          | **Active**  |   105 | `detectRuntime()` — Bun/Deno/Node feature detection                 |
+| `paths.ts`           | `@internal` |    64 | XDG/platform path resolution utilities                              |
+| `support.ts`         | `@internal` |    77 | Runtime feature support detection                                   |
+| `test-helpers.ts`    | Test        |    41 | Test adapter helpers (Deno namespace mock, etc.)                    |
+| `node-builtins.d.ts` | Types       |    27 | `@internal` — ambient decls for `node:readline`, `node:fs/promises` |
+| `index.ts`           | Barrel      |    20 | Re-exports `RuntimeAdapter`, adapters, `ExitError`                  |
 
 ## `RuntimeAdapter` INTERFACE
 
@@ -48,16 +48,16 @@ joinPath(...segments: string[]): string
 4. Wire auto-detection in `auto.ts`
 5. Re-export from `src/runtime.ts`
 
-## TEST FILES (5)
+## TEST FILES (6)
 
-| File              | Tests                                                     |
-| ----------------- | --------------------------------------------------------- |
-| `runtime.test.ts` | Node adapter, test adapter, `ExitError`, adapter contract |
-| `detect.test.ts`  | Runtime detection logic (globalThis feature probing)      |
-| `bun.test.ts`     | Bun adapter delegation                                    |
-| `deno.test.ts`    | Deno adapter (mock namespace, permission handling, stdin) |
-| `auto.test.ts`    | Auto-detecting adapter factory                            |
-| `support.test.ts` | Runtime feature support detection                         |
+| File                         | Tests                                                          |
+| ---------------------------- | -------------------------------------------------------------- |
+| `runtime.test.ts`            | Node adapter, test adapter, `ExitError`, adapter contract      |
+| `detect.test.ts`             | Runtime detection logic (globalThis feature probing)           |
+| `deno.test.ts`               | Deno adapter (mock namespace, permission handling, stdin)      |
+| `auto.test.ts`               | Auto-detecting adapter factory                                 |
+| `support.test.ts`            | Runtime feature support detection                              |
+| `adapter-resolution.test.ts` | One resolution driven through the Node, Bun, and Deno adapters |
 
 ## GOTCHAS
 

--- a/src/runtime/adapter-resolution.test.ts
+++ b/src/runtime/adapter-resolution.test.ts
@@ -1,0 +1,244 @@
+/**
+ * One resolution, driven through every host adapter.
+ *
+ * The adapter supplies argv, the environment, and the stdin buffer, so the same
+ * invocation must produce the same values and the same provenance on Node, Bun,
+ * and Deno.
+ *
+ * @module dreamcli/runtime/adapter-resolution.test
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { cli } from '#internals/core/cli/index.ts';
+import { arg } from '#internals/core/schema/arg.ts';
+import { command } from '#internals/core/schema/command.ts';
+import { flag } from '#internals/core/schema/flag.ts';
+import type { ResolutionProvenance } from '#internals/core/schema/provenance.ts';
+import type { RuntimeAdapter } from './adapter.ts';
+import { ExitError } from './adapter.ts';
+import { createAdapter } from './auto.ts';
+import type { DenoNamespace } from './deno.ts';
+import { createDenoAdapter } from './deno.ts';
+import type { NodeProcess } from './node.ts';
+import { createNodeAdapter } from './node.ts';
+
+// === adapters over injected host state
+
+/** What every adapter under test is handed. */
+interface HostState {
+	/** User arguments, without the binary and script entries. */
+	readonly args: readonly string[];
+	/** Environment variables the adapter reports. */
+	readonly env: Readonly<Record<string, string>>;
+	/** Bytes a pipe delivers, or `undefined` for a TTY with nothing piped. */
+	readonly stdin: string | undefined;
+}
+
+/** A Node process stub whose stdin yields the piped bytes in two chunks. */
+function nodeProcess(state: HostState, stdout: (text: string) => void): NodeProcess {
+	const encoder = new TextEncoder();
+	const piped = state.stdin;
+	return {
+		argv: ['node', 'cli.js', ...state.args],
+		env: state.env,
+		versions: { node: '22.22.2' },
+		cwd: () => '/',
+		platform: 'linux',
+		stdin: {
+			isTTY: piped === undefined,
+			async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+				if (piped === undefined) return;
+				const split = Math.ceil(piped.length / 2);
+				yield encoder.encode(piped.slice(0, split));
+				yield encoder.encode(piped.slice(split));
+			},
+		},
+		stdout: {
+			write: (data: string) => {
+				stdout(data);
+				return true;
+			},
+		},
+		stderr: { write: () => true },
+		exit: (code: number): never => {
+			throw new ExitError(code);
+		},
+	};
+}
+
+/** A Deno namespace stub with the same host state behind Deno's stream APIs. */
+function denoNamespace(state: HostState, stdout: (text: string) => void): DenoNamespace {
+	const encoder = new TextEncoder();
+	const decoder = new TextDecoder();
+	const piped = state.stdin;
+	let delivered = false;
+
+	return {
+		build: { os: 'linux' },
+		args: [...state.args],
+		env: {
+			get: (key: string) => state.env[key],
+			toObject: () => ({ ...state.env }),
+		},
+		cwd: () => '/',
+		stdout: {
+			writeSync: (data: Uint8Array) => {
+				stdout(decoder.decode(data));
+				return data.length;
+			},
+			isTerminal: () => false,
+		},
+		stderr: { writeSync: (data: Uint8Array) => data.length },
+		stdin: {
+			isTerminal: () => piped === undefined,
+			readable: {
+				getReader: () => ({
+					read: () => {
+						if (piped === undefined || delivered) {
+							return Promise.resolve({ done: true, value: new Uint8Array(0) });
+						}
+						delivered = true;
+						return Promise.resolve({ done: false, value: encoder.encode(piped) });
+					},
+					releaseLock: () => {},
+				}),
+			} as ReadableStream<Uint8Array>,
+		},
+		exit: (code: number): never => {
+			throw new ExitError(code);
+		},
+		readTextFile: () => Promise.reject(Object.assign(new Error('not found'), { name: 'NotFound' })),
+		stat: () => Promise.reject(Object.assign(new Error('not found'), { name: 'NotFound' })),
+		mkdir: () => Promise.resolve(),
+		version: { deno: '2.6.0' },
+	};
+}
+
+/** Build the adapter each host produces for the same state. */
+const HOSTS: ReadonlyArray<
+	readonly [string, (state: HostState, stdout: (text: string) => void) => RuntimeAdapter]
+> = [
+	['node', (state, stdout) => createNodeAdapter(nodeProcess(state, stdout))],
+	[
+		'bun',
+		(state, stdout) => {
+			// Bun exposes a Node-compatible `process`, so `createAdapter` builds the
+			// Node adapter from the global rather than from an argument.
+			vi.stubGlobal('process', nodeProcess(state, stdout));
+			return createAdapter({ Bun: { version: '1.3.12' }, process: { versions: { node: '22' } } });
+		},
+	],
+	['deno', (state, stdout) => createDenoAdapter(denoNamespace(state, stdout))],
+];
+
+// === the command every host runs
+
+/** What one invocation produced, as the action saw it. */
+interface Observed {
+	readonly body: string | undefined;
+	readonly region: string | undefined;
+	readonly target: string | undefined;
+	readonly bodySource: ResolutionProvenance | undefined;
+	readonly regionSource: ResolutionProvenance | undefined;
+	readonly targetSource: ResolutionProvenance | undefined;
+}
+
+/** Run one invocation through the adapter a host produced. */
+async function runThrough(
+	adapter: RuntimeAdapter,
+): Promise<{ readonly observed: Observed | undefined; readonly exitCode: number }> {
+	let observed: Observed | undefined;
+	const send = command('send')
+		.flag('region', flag.string().env('REGION').default('us'))
+		.arg('target', arg.string().optional())
+		.flag('body', flag.string().stdin())
+		.action(({ flags, args, sources }) => {
+			observed = {
+				body: flags.body,
+				region: flags.region,
+				target: args.target,
+				bodySource: sources.flags.body,
+				regionSource: sources.flags.region,
+				targetSource: sources.args.target,
+			};
+		});
+
+	let exitCode = 0;
+	try {
+		await cli('mycli').command(send).run({ adapter });
+	} catch (error) {
+		if (!(error instanceof ExitError)) throw error;
+		exitCode = error.code;
+	}
+	return { observed, exitCode };
+}
+
+/** Build and run one host adapter, always restoring any global process stub. */
+async function runHost(
+	build: (state: HostState, stdout: (text: string) => void) => RuntimeAdapter,
+	state: HostState,
+): Promise<{ readonly observed: Observed | undefined; readonly exitCode: number }> {
+	try {
+		return await runThrough(build(state, () => {}));
+	} finally {
+		vi.unstubAllGlobals();
+	}
+}
+
+describe('every host adapter drives the same resolution', () => {
+	for (const [host, build] of HOSTS) {
+		it(`reads argv, env, and the pipe on ${host}`, async () => {
+			const { observed, exitCode } = await runHost(build, {
+				args: ['send', 'prod'],
+				env: { REGION: 'eu' },
+				stdin: 'piped body\n',
+			});
+
+			expect(exitCode).toBe(0);
+			expect(observed).toEqual({
+				body: 'piped body\n',
+				region: 'eu',
+				target: 'prod',
+				bodySource: { stage: 'stdin', via: 'stdin', trigger: 'fallback' },
+				regionSource: { stage: 'env', envVar: 'REGION' },
+				targetSource: { stage: 'cli' },
+			});
+		});
+
+		it(`keeps a typed value ahead of the pipe on ${host}`, async () => {
+			const { observed } = await runHost(build, {
+				args: ['send', '--body', 'typed'],
+				env: {},
+				stdin: 'piped body\n',
+			});
+
+			expect(observed?.body).toBe('typed');
+			expect(observed?.bodySource).toEqual({ stage: 'cli' });
+			expect(observed?.regionSource).toEqual({ stage: 'default' });
+		});
+
+		it(`reads the pipe for an explicit dash on ${host}`, async () => {
+			const { observed } = await runHost(build, {
+				args: ['send', '--body', '-'],
+				env: {},
+				stdin: 'dashed\n',
+			});
+
+			expect(observed?.body).toBe('dashed\n');
+			expect(observed?.bodySource).toEqual({ stage: 'cli', via: 'stdin', trigger: 'dash' });
+		});
+
+		it(`falls back to the default with nothing piped on ${host}`, async () => {
+			const { observed } = await runHost(build, {
+				args: ['send'],
+				env: {},
+				stdin: undefined,
+			});
+
+			expect(observed?.body).toBeUndefined();
+			expect(observed?.bodySource).toBeUndefined();
+			expect(observed?.region).toBe('us');
+			expect(observed?.regionSource).toEqual({ stage: 'default' });
+		});
+	}
+});


### PR DESCRIPTION
Targets v4. Stacked on #117. Top of the stack. L19: the adversarial matrices and the program's review-to-fixpoint sweep.

The coverage audit maps every plan case to a named pin and fills the gaps (82 new tests, then more from the sweeps): run-time stdin conflicts across siblings, Object.prototype names in config paths and sources records, native config arrays bypassing split policies, Node/Bun/Deno adapters driving real resolutions, a 31-row readFlags parity matrix, definition-document round trips over a maximal schema, the caller-text redaction boundary pinned as deliberate, and both `wasExplicit` readings worked.

Six fresh-eyes sweep rounds over the whole L14-L19 diff found and fixed 25 defects, every one by execution and every fix mutation-verified. Highlights: serialization dropped defaults declared without the defaulted presence (an emit/rebuild changed behavior); an arg-side scrape truncated parse-function reasons at their last colon; `keyValue` arg prompts suggested kind `'undefined'`; help marked defaulted flags `[required]` (which are unreachable-required at runtime); `.standard()` on `flag.count()` never ran; variadic arg prompts read the scalar table, rejecting `multiselect` where the flag twin accepts it; and 91 of 125 builder modifier chains produced schemas their own factory refuses, closed by routing every modifier through the construction-time asserts (breaking for chains that built silently-invalid schemas).

Suite across the six layers: 3363 to 4007 tests. Every layer's gates ran raw and green per commit; the definition meta-schema artifact is emit-stable throughout.

Known items deliberately left for the tag decision, not silently dropped: V1 documents are runtime-readable but not type-assignable to definitions under exactOptionalPropertyTypes (a shipped decoder or laxer fragment types would close it); the arg surface's config-shape suggestion names CLI syntax for a config problem; `ErasedInputSources` is `@internal` on public members (a pre-existing pattern); `.middleware()` given a bare function fails at execution rather than build; booleans read `''` as false but reject whitespace off argv; positional enums complete nothing and render `<us|eu>` instead of their name in help (both pre-existing).

Closes #83. The TS2883 declaration-emit failure no longer reproduces on the stack (all three repro shapes verified on the issue, emit fully structural). The fix accumulated across the v4 builder layers rather than landing in one PR, so the closure rides the stack top, which is the union that fixed it.
