### PR TITLE
fix(completion): hide unroutable defaults

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -56,14 +56,14 @@
 	"plugins": [
 		"https://plugins.dprint.dev/kjanat/svg-v0.4.1.wasm",
 		"https://plugins.dprint.dev/kjanat/sortpackagejson-0.2.1.wasm",
-		"https://plugins.dprint.dev/biome-0.13.6.wasm",
-		"https://plugins.dprint.dev/markdown-0.22.1.wasm",
-		"https://plugins.dprint.dev/ruff-0.8.3.wasm",
-		"https://plugins.dprint.dev/json-0.23.0.wasm",
-		"https://plugins.dprint.dev/g-plane/malva-v0.16.0.wasm",
-		"https://plugins.dprint.dev/g-plane/markup_fmt-v0.27.3.wasm",
-		"https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
-		"https://plugins.dprint.dev/exec-0.7.3.json@a7898d5f1897e77bff474cec3d948c3ec3a7f455e32de2cc60c8adb9a5dd24aa",
-		"https://plugins.dprint.dev/prettier-0.72.0.json@6e7af2cb2182a5a11358d3adde9ae0ef3b94b7d2e5dcfdd252e3f7c3916541fe"
+		"npm:@dprint/biome@0.13.10",
+		"npm:@dprint/markdown@0.23.3",
+		"npm:@dprint/ruff@0.8.6",
+		"npm:@dprint/json@0.23.0",
+		"npm:dprint-plugin-malva@0.16.0",
+		"npm:dprint-plugin-markup@0.27.3",
+		"npm:dprint-plugin-yaml@0.6.0",
+		"npm:@dprint/exec@0.7.3/plugin.json@704701df449dd7e942a71144773778ac529d68c2e4657bfc236d393b898b9a67",
+		"npm:@dprint/prettier@0.70.0/plugin.json@97c0dccf54ed5b7343e7a3f6418e77bd80afcd2b74beed3a632689d47e392ddc"
 	]
 }

--- a/src/core/cli/cli-completion-contract.test.ts
+++ b/src/core/cli/cli-completion-contract.test.ts
@@ -175,7 +175,7 @@ describe('completion contract — shipped surface', () => {
 				const rootWords = extractBashRootWords(result.stdout.join(''));
 
 				expect(result.exitCode).toBe(0);
-				expect(rootWords).toEqual(['serve', 'status', '--help']);
+				expect(rootWords).toEqual(['status', '--help']);
 			});
 
 			it('surfaces default flags in surface mode', async () => {
@@ -204,7 +204,7 @@ describe('completion contract — shipped surface', () => {
 				const rootFunction = extractZshRootFunction(result.stdout.join(''), '_mycli');
 
 				expect(result.exitCode).toBe(0);
-				expect(rootFunction).toContain("'serve:Start the server'");
+				expect(rootFunction).not.toContain("'serve:Start the server'");
 				expect(rootFunction).toContain("'status:Show current status'");
 				expect(rootFunction).not.toContain("'(-p --port)'{-p,--port}'[Port]:value:'");
 			});
@@ -238,7 +238,7 @@ describe('completion contract — shipped surface', () => {
 				).join('\n');
 
 				expect(result.exitCode).toBe(0);
-				expect(rootLines).toContain('-a serve');
+				expect(rootLines).not.toContain('-a serve');
 				expect(rootLines).toContain('-a status');
 				expect(rootLines).not.toContain('-l port');
 			});

--- a/src/core/cli/cli-completion-contract.test.ts
+++ b/src/core/cli/cli-completion-contract.test.ts
@@ -204,7 +204,7 @@ describe('completion contract — shipped surface', () => {
 				const rootFunction = extractZshRootFunction(result.stdout.join(''), '_mycli');
 
 				expect(result.exitCode).toBe(0);
-				expect(rootFunction).not.toContain("'serve:Start the server'");
+				expect(rootFunction).not.toContain("'serve:Start the server'\n");
 				expect(rootFunction).toContain("'status:Show current status'");
 				expect(rootFunction).not.toContain("'(-p --port)'{-p,--port}'[Port]:value:'");
 			});
@@ -238,7 +238,7 @@ describe('completion contract — shipped surface', () => {
 				).join('\n');
 
 				expect(result.exitCode).toBe(0);
-				expect(rootLines).not.toContain('-a serve');
+				expect(rootLines).not.toContain("-a serve -d 'Start the server'\n");
 				expect(rootLines).toContain('-a status');
 				expect(rootLines).not.toContain('-l port');
 			});

--- a/src/core/cli/cli-completions.test.ts
+++ b/src/core/cli/cli-completions.test.ts
@@ -240,7 +240,7 @@ describe('.completions()', () => {
 				const rootFunction = extractZshRootFunction(result.stdout.join(''), '_mycli');
 
 				expect(rootFunction).toContain("'--help[Show help text]'");
-				expect(rootFunction).not.toContain("'serve:Start the server'");
+				expect(rootFunction).not.toContain("'serve:Start the server'\n");
 				expect(rootFunction).toContain("'status:Show current status'");
 				expect(rootFunction).not.toContain("'(-p --port)'{-p,--port}'[Port]:value:'");
 			});

--- a/src/core/cli/cli-completions.test.ts
+++ b/src/core/cli/cli-completions.test.ts
@@ -170,7 +170,7 @@ describe('.completions()', () => {
 				const result = await app.execute(['completions', 'bash']);
 				const rootWords = extractBashRootWords(result.stdout.join(''));
 
-				expect(rootWords).toEqual(['serve', 'status', '--help']);
+				expect(rootWords).toEqual(['status', '--help']);
 			});
 
 			it('surfaces default flags in surface mode', async () => {
@@ -192,7 +192,7 @@ describe('.completions()', () => {
 				const result = await app.execute(['completions', 'bash']);
 				const rootWords = extractBashRootWords(result.stdout.join(''));
 
-				expect(rootWords).toContain('serve');
+				expect(rootWords).not.toContain('serve');
 				expect(rootWords).toContain('--help');
 				expect(rootWords).toContain('--port');
 				expect(rootWords).toContain('-p');
@@ -240,7 +240,7 @@ describe('.completions()', () => {
 				const rootFunction = extractZshRootFunction(result.stdout.join(''), '_mycli');
 
 				expect(rootFunction).toContain("'--help[Show help text]'");
-				expect(rootFunction).toContain("'serve:Start the server'");
+				expect(rootFunction).not.toContain("'serve:Start the server'");
 				expect(rootFunction).toContain("'status:Show current status'");
 				expect(rootFunction).not.toContain("'(-p --port)'{-p,--port}'[Port]:value:'");
 			});

--- a/src/core/completion/completion.test.ts
+++ b/src/core/completion/completion.test.ts
@@ -182,8 +182,8 @@ describe('routed default completion policy', () => {
 	it('includes the routed default in zsh', () => {
 		const root = extractZshRootFunction(generateZshCompletion(schema), '_testcli');
 
-		expect(root).toContain("'serve:Start server'");
-		expect(root).toContain("'status:Show status'");
+		expect(root).toContain("'serve:Start server'\n");
+		expect(root).toContain("'status:Show status'\n");
 	});
 
 	it('includes the routed default in fish', () => {
@@ -193,15 +193,15 @@ describe('routed default completion policy', () => {
 			'',
 		).join('\n');
 
-		expect(root).toContain("-a serve -d 'Start server'");
-		expect(root).toContain("-a status -d 'Show status'");
+		expect(root).toContain("-a serve -d 'Start server'\n");
+		expect(root).toContain("-a status -d 'Show status'\n");
 	});
 
 	it('includes the routed default in PowerShell', () => {
 		const script = generatePowerShellCompletion(schema);
 
-		expect(script).toContain("CanonicalName = 'serve'");
-		expect(script).toContain("CanonicalName = 'status'");
+		expect(script).toContain("CanonicalName = 'serve'\n");
+		expect(script).toContain("CanonicalName = 'status'\n");
 	});
 });
 
@@ -1453,7 +1453,7 @@ describe('generateZshCompletion', () => {
 				expect(rootFunction).toContain("'--version[Show version]'");
 				expect(rootFunction).not.toContain("'--port[Port]:value:'");
 				expect(rootFunction).toContain("'1: :->subcmd'");
-				expect(rootFunction).not.toContain("'serve:serve'");
+				expect(rootFunction).not.toContain("'serve:serve'\n");
 				expect(rootFunction).toContain("'status:Status'");
 			});
 
@@ -2416,7 +2416,7 @@ describe('generateFishCompletion — script structure', () => {
 		expect(rootLines.join('\n')).toContain('-l port');
 		expect(rootLines.join('\n')).toContain('-s p');
 		expect(rootLines.join('\n')).toContain('-l verbose');
-		expect(rootLines.join('\n')).not.toContain('-a serve');
+		expect(rootLines.join('\n')).not.toContain("-a serve -d 'Start server'\n");
 	});
 
 	it('escapes enum values for fish completions', () => {
@@ -2582,7 +2582,7 @@ describe('generatePowerShellCompletion — script structure', () => {
 		expect(script).toMatch(
 			/'' = @\{[\s\S]*Forms = @\('--port', '-p'\)[\s\S]*Forms = @\('--verbose'\)/,
 		);
-		expect(script).not.toContain("CanonicalName = 'serve'");
+		expect(script).not.toContain("CanonicalName = 'serve'\n");
 	});
 
 	it('includes enum values in the generated flag metadata', () => {

--- a/src/core/completion/completion.test.ts
+++ b/src/core/completion/completion.test.ts
@@ -161,6 +161,50 @@ describe('CompletionOptions — type contract', () => {
 	});
 });
 
+describe('routed default completion policy', () => {
+	const serve = commandSchema({ name: 'serve', description: 'Start server' });
+	const status = commandSchema({ name: 'status', description: 'Show status' });
+	const schema = minimalSchema({
+		commands: [status],
+		defaultCommand: serve,
+		defaultCommandRouted: true,
+	});
+
+	it('includes the routed default in bash', () => {
+		expect(extractBashRootWords(generateBashCompletion(schema))).toEqual([
+			'serve',
+			'status',
+			'--help',
+			'--version',
+		]);
+	});
+
+	it('includes the routed default in zsh', () => {
+		const root = extractZshRootFunction(generateZshCompletion(schema), '_testcli');
+
+		expect(root).toContain("'serve:Start server'");
+		expect(root).toContain("'status:Show status'");
+	});
+
+	it('includes the routed default in fish', () => {
+		const root = extractFishCompletionLines(
+			generateFishCompletion(schema),
+			'__testcli_completions_path_is',
+			'',
+		).join('\n');
+
+		expect(root).toContain("-a serve -d 'Start server'");
+		expect(root).toContain("-a status -d 'Show status'");
+	});
+
+	it('includes the routed default in PowerShell', () => {
+		const script = generatePowerShellCompletion(schema);
+
+		expect(script).toContain("CanonicalName = 'serve'");
+		expect(script).toContain("CanonicalName = 'status'");
+	});
+});
+
 // === generateBashCompletion
 
 describe('generateBashCompletion', () => {
@@ -329,7 +373,7 @@ describe('generateBashCompletion', () => {
 
 				const rootWords = extractBashRootWords(generateBashCompletion(schema));
 
-				expect(rootWords).toEqual(['serve', 'status', '--help', '--version']);
+				expect(rootWords).toEqual(['status', '--help', '--version']);
 			});
 
 			it('surface default flags in surface mode', () => {
@@ -362,7 +406,7 @@ describe('generateBashCompletion', () => {
 					generateBashCompletion(schema, { rootMode: 'surface' }),
 				);
 
-				expect(rootWords).toContain('serve');
+				expect(rootWords).not.toContain('serve');
 				expect(rootWords).toContain('status');
 				expect(rootWords).toContain('--help');
 				expect(rootWords).toContain('--version');
@@ -388,7 +432,7 @@ describe('generateBashCompletion', () => {
 
 				const rootWords = extractBashRootWords(generateBashCompletion(schema));
 
-				expect(rootWords).toEqual(['serve', '--help', '--version', '--port', '-p']);
+				expect(rootWords).toEqual(['--help', '--version', '--port', '-p']);
 			});
 		});
 	});
@@ -1409,7 +1453,7 @@ describe('generateZshCompletion', () => {
 				expect(rootFunction).toContain("'--version[Show version]'");
 				expect(rootFunction).not.toContain("'--port[Port]:value:'");
 				expect(rootFunction).toContain("'1: :->subcmd'");
-				expect(rootFunction).toContain("'serve:serve'");
+				expect(rootFunction).not.toContain("'serve:serve'");
 				expect(rootFunction).toContain("'status:Status'");
 			});
 
@@ -2372,6 +2416,7 @@ describe('generateFishCompletion — script structure', () => {
 		expect(rootLines.join('\n')).toContain('-l port');
 		expect(rootLines.join('\n')).toContain('-s p');
 		expect(rootLines.join('\n')).toContain('-l verbose');
+		expect(rootLines.join('\n')).not.toContain('-a serve');
 	});
 
 	it('escapes enum values for fish completions', () => {
@@ -2537,6 +2582,7 @@ describe('generatePowerShellCompletion — script structure', () => {
 		expect(script).toMatch(
 			/'' = @\{[\s\S]*Forms = @\('--port', '-p'\)[\s\S]*Forms = @\('--verbose'\)/,
 		);
+		expect(script).not.toContain("CanonicalName = 'serve'");
 	});
 
 	it('includes enum values in the generated flag metadata', () => {

--- a/src/core/completion/shells/bash.ts
+++ b/src/core/completion/shells/bash.ts
@@ -179,7 +179,10 @@ function generateBashCompletion(schema: CLISchema, options?: CompletionOptions):
 		lines.push(`\t# Root-level completions: visible root surface`);
 		lines.push(`\tCOMPREPLY=($(compgen -W '${completionWords}' -- "$cur"))`);
 	} else {
-		const globalFlags = collectFlagWords(rootSurface.rootFlags);
+		const globalFlags = collectFlagWords({
+			...rootSurface.rootFlags,
+			...(rootSurface.includeDefaultFlags ? rootSurface.defaultFlags : {}),
+		});
 		lines.push(`\tCOMPREPLY=($(compgen -W '${globalFlags}' -- "$cur"))`);
 	}
 

--- a/src/core/completion/shells/shared.ts
+++ b/src/core/completion/shells/shared.ts
@@ -105,6 +105,7 @@ interface RootCompletionSurface {
 interface RootCompletionSchemaLike {
 	readonly commands: readonly CommandSchema[];
 	readonly defaultCommand: CommandSchema | undefined;
+	readonly defaultCommandRouted?: boolean | undefined;
 	readonly version: string | undefined;
 	/**
 	 * Built-in flag state. `help: 'off'` drops the synthetic root `--help` so a
@@ -136,19 +137,20 @@ function resolveRootCompletionSurface(
 			? rootSurface.hasVisibleDefault
 			: rootSurface.hasVisibleDefault && !rootSurface.hasVisibleSubcommands;
 
-	// Generated completion scripts keep treating the default command as part of
-	// the root surface (a walkable node carrying its own flags/args), regardless
-	// of whether it is registered under `commands` — since v0.3 `.default()` keeps
-	// it only in `defaultCommand`. Re-add it here so the per-shell generators,
-	// which build their dispatch machinery from this list, behave unchanged.
+	// A surface-only default is invoked at the root and is not a named route, so
+	// completion must not advertise its name as a subcommand. A routed default is
+	// re-added because `.default(cmd, { route: true })` keeps the command identity
+	// in `defaultCommand` rather than duplicating it in `commands`.
 	const defaultCommand = rootSurface.visibleDefaultCommand;
 	const alreadyListed =
 		defaultCommand !== undefined &&
 		rootSurface.visibleCommands.some((c) => c.name === defaultCommand.name);
 	const visibleCommands =
-		defaultCommand !== undefined && !alreadyListed
+		rootSurface.defaultRouted && defaultCommand !== undefined && !alreadyListed
 			? [defaultCommand, ...rootSurface.visibleCommands]
-			: rootSurface.visibleCommands;
+			: rootSurface.defaultRouted
+				? rootSurface.visibleCommands
+				: rootSurface.visibleSubcommands;
 
 	return {
 		visibleCommands,

--- a/src/core/completion/shells/zsh.ts
+++ b/src/core/completion/shells/zsh.ts
@@ -154,8 +154,11 @@ function generateZshCompletion(schema: CLISchema, options?: CompletionOptions): 
 		lines.push('\t\t\t;;');
 		lines.push('\tesac');
 	} else {
-		// --- No subcommands: just global flags ---
-		const globalFlags = buildZshFlagSpecsFromFlags(rootSurface.rootFlags);
+		// --- No subcommands: root and default-surface flags ---
+		const globalFlags = buildZshFlagSpecsFromFlags({
+			...rootSurface.rootFlags,
+			...(rootSurface.includeDefaultFlags ? rootSurface.defaultFlags : {}),
+		});
 		lines.push('\t_arguments \\');
 		for (let i = 0; i < globalFlags.length; i++) {
 			const trailing = i < globalFlags.length - 1 ? ' \\' : '';


### PR DESCRIPTION
## Summary

- stop advertising surface-only default commands as named routes
- preserve root-level flags for lone defaults and keep routed defaults completable
- move supported dprint plugins to their npm entry points

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test` (4,108 tests)
- generated `gh-mention-watch`-shaped Zsh completion contains `schema` and root flags without the unroutable `watch` command