### PR TITLE
fix(help): wrap long positional choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Keep long positional choices readable in help** (https://github.com/kjanat/dreamcli/issues/125).\
+  Use the argument name when an inline enum list is too wide, show the accepted choices on wrapped lines in Arguments, and indent continued Usage lines. Short choice lists retain their inline form.
 - **Completion script headers name the program version** (https://github.com/kjanat/dreamcli/issues/131).\
   The first comment line of every generated script now reads `<name> v<version>` when the CLI declares a version, so an installed script records which release of the program it completes, alongside the existing DreamCLI build tag.
 

--- a/src/core/help/help.test.ts
+++ b/src/core/help/help.test.ts
@@ -4,12 +4,14 @@
  * @module dreamcli/core/help/help.test
  */
 
+import { createColors } from 'ansispeck';
 import { describe, expect, it } from 'vitest';
 
 import { arg, createArgSchema } from '#internals/core/schema/arg.ts';
 import { command } from '#internals/core/schema/command.ts';
 import { createFlagSchema, flag } from '#internals/core/schema/flag.ts';
 
+import { stripAnsi, visibleWidth } from './ansi.ts';
 import { formatHelp } from './index.ts';
 
 // --- Helpers
@@ -140,6 +142,75 @@ describe('formatHelp', () => {
 	// -----------------------------------------------------------------------
 
 	describe('arguments section', () => {
+		const resources = [
+			'summary',
+			'status',
+			'components',
+			'incidents',
+			'incidents/unresolved',
+			'scheduled-maintenances',
+			'scheduled-maintenances/active',
+			'scheduled-maintenances/upcoming',
+		] as const;
+
+		it.each([40, 80])('fits long positional choices into %i columns', (width) => {
+			const cmd = command('api').arg(
+				'resource',
+				arg.enum(resources).default('summary').describe('Status API resource to fetch'),
+			);
+			const help = formatHelp(cmd.schema, { width });
+			expect(help).toContain('Usage: api [resource]\n');
+			expect(help).toContain('Arguments:\n  [resource]  Status API resource');
+			expect(help).toContain('(default: summary)');
+			expect(help).toContain('\n    Choices: summary, status,');
+			for (const resource of resources) expect(help).toContain(resource);
+			for (const line of help.split('\n')) expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			expect(help.endsWith('\n')).toBe(true);
+		});
+
+		it.each([
+			{ builder: arg.enum(resources), token: '<resource>' },
+			{ builder: arg.enum(resources).optional(), token: '[resource]' },
+			{ builder: arg.enum(resources).variadic(), token: '<resource>...' },
+		])('preserves $token and choices without a description', ({ builder, token }) => {
+			const help = formatHelp(command('api').arg('resource', builder).schema);
+			expect(help).toContain(`Usage: api ${token}\n`);
+			expect(help).toContain(`Arguments:\n  ${token}\n    Choices:`);
+			for (const resource of resources) expect(help).toContain(resource);
+		});
+
+		it('keeps choices inline when the available width accommodates them', () => {
+			const help = formatHelp(command('api').arg('resource', arg.enum(resources)).schema, {
+				width: 400,
+			});
+			expect(help).toContain(`Usage: api <${resources.join('|')}>\n`);
+			expect(help).not.toContain('Choices:');
+		});
+
+		it('moves a long default below the argument instead of overflowing the description column', () => {
+			const cmd = command('api').arg(
+				'resource',
+				arg.enum(resources).default('scheduled-maintenances/upcoming'),
+			);
+			const help = formatHelp(cmd.schema, { width: 40 });
+			expect(help).toContain('Arguments:\n  [resource]\n    (default:');
+			expect(help).toContain('scheduled-maintenances/upcoming)');
+			for (const line of help.split('\n')) expect(visibleWidth(line)).toBeLessThanOrEqual(40);
+		});
+
+		it('measures styled choices and indents continued usage without losing arguments', () => {
+			const cmd = command('api')
+				.arg('environment', arg.string())
+				.arg('resource', arg.enum(resources).default('summary'));
+			const options = { width: 40, binName: 'status-client' };
+			const plain = formatHelp(cmd.schema, options);
+			const styled = formatHelp(cmd.schema, { ...options, colors: createColors(true) });
+			expect(plain).toContain('Usage: status-client api <environment>\n       [resource]\n');
+			expect(styled).not.toBe(plain);
+			expect(stripAnsi(styled)).toBe(plain);
+			for (const line of styled.split('\n')) expect(visibleWidth(line)).toBeLessThanOrEqual(40);
+		});
+
 		it('lists positional args with descriptions', () => {
 			const cmd = command('deploy')
 				.arg('target', arg.string().describe('Deploy target'))

--- a/src/core/help/index.ts
+++ b/src/core/help/index.ts
@@ -409,13 +409,15 @@ function buildFlagEntries(
  * Format a positional arg for the usage line.
  *
  * @param entry - The {@link CommandArgEntry} containing name and schema.
+ * @param maxWidth - Width available for inline choices before using the argument name.
  * @returns Bracketed arg token, e.g. `<file>` or `[output]...`.
  */
-function formatArgUsage(entry: CommandArgEntry): string {
+function formatArgUsage(entry: CommandArgEntry, maxWidth = Infinity): string {
 	const { name, schema } = entry;
-	const label =
+	let label =
 		schema.kind === 'enum' && schema.enumValues !== undefined ? schema.enumValues.join('|') : name;
 	const variadicSuffix = schema.variadic ? '...' : '';
+	if (visibleWidth(label) + 2 + variadicSuffix.length > maxWidth) label = name;
 	// A positional carrying a default resolves one whatever its presence says, so
 	// the usage line does not demand a token for it.
 	if (schema.presence === 'required' && schema.defaultValue === undefined) {
@@ -551,7 +553,7 @@ function formatHelp(schema: CommandSchema, options?: HelpOptions): string {
  *
  * @param schema - The {@link CommandSchema} to summarize.
  * @param opts - Resolved help options (bin name, default-help flag).
- * @returns Single-line usage string, e.g. `Usage: mycli deploy [flags] <env>`.
+ * @returns Usage string with indented continuation lines when needed.
  */
 function formatUsageLine(schema: CommandSchema, opts: ResolvedHelpOptions): string {
 	const { theme } = opts;
@@ -581,10 +583,10 @@ function formatUsageLine(schema: CommandSchema, opts: ResolvedHelpOptions): stri
 
 	// Positional args
 	for (const entry of schema.args) {
-		parts.push(theme.arg(formatArgUsage(entry)));
+		parts.push(theme.arg(formatArgUsage(entry, opts.width - 7)));
 	}
 
-	return parts.join(' ');
+	return `${parts[0]} ${wrapText(parts.slice(1).join(' '), opts.width, 7)}`;
 }
 
 /**
@@ -601,23 +603,40 @@ function formatArgsSection(args: readonly CommandArgEntry[], opts: ResolvedHelpO
 
 	// Compute max left width (visible columns — the left column may carry SGR escapes)
 	let maxLeft = 0;
-	const entries: Array<{ left: string; desc: string }> = [];
+	const entries: Array<{ left: string; desc: string; choices?: readonly string[] }> = [];
 	for (const entry of args) {
-		const left = `  ${theme.arg(formatArgUsage(entry))}`;
+		const token = formatArgUsage(entry, Math.floor(opts.width / 2) - 4);
+		const left = `  ${theme.arg(token)}`;
 		const desc = formatArgDescription(entry.schema, theme, opts.descriptionTheme);
-		entries.push({ left, desc });
+		entries.push({
+			left,
+			desc,
+			...(token !== formatArgUsage(entry) && entry.schema.enumValues !== undefined
+				? { choices: entry.schema.enumValues }
+				: {}),
+		});
 		const leftWidth = visibleWidth(left);
 		if (leftWidth > maxLeft) maxLeft = leftWidth;
 	}
 
 	const descCol = maxLeft + GAP;
-	for (const { left, desc } of entries) {
+	for (const { left, desc, choices } of entries) {
 		if (desc.length === 0) {
 			lines.push(left);
+		} else if (
+			descCol >= opts.width / 2 ||
+			desc.split(' ').some((word) => visibleWidth(word) > opts.width - descCol)
+		) {
+			lines.push(left, `    ${wrapText(desc, opts.width, 4)}`);
 		} else {
 			const padded = padEnd(left, descCol);
 			const wrapped = wrapText(desc, opts.width, descCol);
 			lines.push(`${padded}${wrapped}`);
+		}
+		if (choices !== undefined) {
+			lines.push(
+				`    ${wrapText(`Choices: ${choices.map((choice) => theme.arg(choice)).join(', ')}`, opts.width, 4)}`,
+			);
 		}
 	}
 


### PR DESCRIPTION
Long positional enum lists overflowed both Usage and Arguments: the reported example produced 154- and 165-column lines at a requested width of 80. Use a compact argument name when the inline choices are too wide, then show every accepted choice on wrapped lines in Arguments. Indent continued Usage lines and put long defaults below the argument when the description column cannot accommodate them. Short enums keep their inline form.

Regression coverage includes 40/80-column output, required/optional/variadic arguments, defaults, wide-terminal inline choices, and ANSI-aware wrapping. The packed package was also installed outside the repository and verified under Node and Bun.

Validation:

- `runner run -s schema:emit version:check ci smoke` passed, including 4,218 tests, source/dist typechecks, lint, dprint, docs build, package budgets, and all ten exact lazy-loading scenarios.
- `runner run -s check typecheck:gh test:gh` passed: all nine Deno entrypoints, the example workspace typecheck, and 21 example tests.
- Packed archive: 47 files, every export target present, no unexpected generated artifacts or dependencies; no generator drift in tracked files.

Closes #125.
